### PR TITLE
fix: Tech Debt Monitor SyntaxError from escaped backticks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,10 @@ jobs:
               });
               try {
                 const projectId = 'PVT_kwHOB0H7gM4BT-VD';
-                const result = await github.graphql(\`mutation { addProjectV2ItemById(input: { projectId: "\${projectId}", contentId: "\${issue.data.node_id}" }) { item { id } } }\`);
+                const result = await github.graphql(`mutation { addProjectV2ItemById(input: { projectId: "${projectId}", contentId: "${issue.data.node_id}" }) { item { id } } }`);
                 const itemId = result.addProjectV2ItemById.item.id;
-                await github.graphql(\`mutation { updateProjectV2ItemFieldValue(input: { projectId: "\${projectId}", itemId: "\${itemId}", fieldId: "PVTSSF_lAHOB0H7gM4BT-VDzhBQYqI", value: { singleSelectOptionId: "f0fdf4e6" } }) { projectV2Item { id } } }\`);
-                await github.graphql(\`mutation { updateProjectV2ItemFieldValue(input: { projectId: "\${projectId}", itemId: "\${itemId}", fieldId: "PVTSSF_lAHOB0H7gM4BT-VDzhBJlx0", value: { singleSelectOptionId: "630cbc97" } }) { projectV2Item { id } } }\`);
+                await github.graphql(`mutation { updateProjectV2ItemFieldValue(input: { projectId: "${projectId}", itemId: "${itemId}", fieldId: "PVTSSF_lAHOB0H7gM4BT-VDzhBQYqI", value: { singleSelectOptionId: "f0fdf4e6" } }) { projectV2Item { id } } }`);
+                await github.graphql(`mutation { updateProjectV2ItemFieldValue(input: { projectId: "${projectId}", itemId: "${itemId}", fieldId: "PVTSSF_lAHOB0H7gM4BT-VDzhBJlx0", value: { singleSelectOptionId: "630cbc97" } }) { projectV2Item { id } } }`);
               } catch (_) {}
             }
 


### PR DESCRIPTION
## Summary
- The `tech-debt` job in `ci.yml` used `\`` (escaped backticks) for JS template literals, which is a SyntaxError at parse time. The whole `github-script` block failed to compile, so no tech-debt issue could ever be filed when a breach was detected.
- Replaced the escaped backticks with literal backticks. YAML `|` blocks are literal — no escaping needed.

## Why now
- Latent since 8232c83. The block only runs when `tech-debt.js` exits non-zero, and main has had real pre-existing breaches (`app.js` > 5000 lines, `styles.css` > 900 lines, globals > 35) that have been silently failing the auto-issue creator instead of filing tickets.

## Test plan
- [x] Extracted the script and parsed it via `new Function()` locally — passes.
- [ ] Watch CI: `Tech Debt Monitor` job should now succeed (or, if a breach is still detected, should successfully file/comment on an issue instead of crashing with SyntaxError).