### PR TITLE
fix: grant Tech Debt Monitor issues:write permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
     name: Tech Debt Monitor
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Follow-up to #51. The SyntaxError fix lets the script compile, but now `github.rest.issues.create()` fails with `403 Resource not accessible by integration` because `GITHUB_TOKEN` does not have `issues: write`.
- Added an explicit `permissions:` block on the `tech-debt` job (`contents: read`, `issues: write`).

## Test plan
- [ ] On merge to main, `Tech Debt Monitor` should fully succeed and either create a new `[Tech Debt] Threshold breach` issue or comment on the existing one for the current breaches (`app.js > 5000`, `styles.css > 900`, globals > 35).