### PR TITLE
ci: grant pull-requests:write to Deploy Preview + Lighthouse Audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,10 @@ jobs:
     needs: test
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -234,6 +238,10 @@ jobs:
     needs: test
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
Both Deploy Preview and Lighthouse Audit workflows produce correct artifacts but fail their final step trying to POST results as PR comments. Root cause: missing pull-requests:write + issues:write on the GITHUB_TOKEN. This bit PR #351. Fix mirrors PR #52 pattern for Tech Debt Monitor. Minimal job-level permissions block additions only.