### PR TITLE
v6.5.1 hotfix — walkthrough catalog mount fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v6.5.0
+// Network+ AI Quiz — app.js  v6.5.1
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '6.5.0';
+const APP_VERSION = '6.5.1';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/features/topology-builder-v3.js
+++ b/features/topology-builder-v3.js
@@ -7607,8 +7607,8 @@
     anchorStepCardToViewportCenter();
   }
   function renderWalkCatalog() {
-    var workspace = document.querySelector('.tb3-workspace');
-    if (!workspace) return;
+    var body = document.getElementById('tb3-body');
+    if (!body) return;
 
     // Get or create the panel
     var panel = document.querySelector('.tb3-rail-panel[data-mode="walk-catalog"]');
@@ -7616,7 +7616,7 @@
       panel = document.createElement('aside');
       panel.className = 'tb3-rail-panel';
       panel.dataset.mode = 'walk-catalog';
-      workspace.appendChild(panel);
+      body.appendChild(panel);
     }
 
     // Group scenarios by primary exam domain (first objectiveRef)

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.1</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v6.5.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v6.5.0';
+// Service Worker v6.5.1 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v6.5.1';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -22950,6 +22950,14 @@ test('TB v3 walk: domainsForRefs maps objectiveRefs to exam-domain names', (func
     && eq(fn(['9.9']), ['Other']);
 })());
 
+test('TB v3 walk: renderWalkCatalog mounts panel to #tb3-body (not .tb3-workspace)', (function () {
+  var m = tbV3JsForWalk.match(/function renderWalkCatalog\([\s\S]*?\n  \}/);
+  if (!m) return false;
+  var body = m[0];
+  return /getElementById\(['"]tb3-body['"]\)/.test(body)
+      && !/querySelector\(['"]\.tb3-workspace['"]\)/.test(body);
+})());
+
 test('TB v3 walk: walkthroughs file exists and exports array', (function () {
   const walkJs = read('features/topology-builder-v3-walkthroughs.js');
   return /var TB_V3_WALKTHROUGHS = \[/.test(walkJs);


### PR DESCRIPTION
## Hotfix

Bug: clicking the new Walk mode pill in v6.5.0 had no visible effect — the catalog panel was never appended to the DOM because `renderWalkCatalog` referenced a non-existent selector `.tb3-workspace` (the real mount point is `#tb3-body`, matching the other rail panels' pattern).

Fix: change the mount selector from `.tb3-workspace` to `#tb3-body` (one-line change).

Plus: one UAT regression test guarding against re-introducing `.tb3-workspace`.

## Test plan

- [ ] CI green
- [ ] Manual smoke: open prod → Network+ → Topology Builder V3 → click Walk pill → catalog appears in the right rail with 4 scenarios + 5 walkthroughs grouped by domain