### PR TITLE
v6.5.2 — fix FX wipe + anchor + walkStart state + draggable card

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v6.5.1
+// Network+ AI Quiz — app.js  v6.5.2
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '6.5.1';
+const APP_VERSION = '6.5.2';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/features/topology-builder-v3.css
+++ b/features/topology-builder-v3.css
@@ -3194,6 +3194,17 @@ html[data-theme="light"] #page-topology-builder-v3 {
     left 300ms cubic-bezier(0.2, 0.8, 0.2, 1),
     top 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
   font-family: inherit;
+  /* v6.5.2: drag-to-move support */
+  cursor: grab;
+  user-select: none;
+}
+/* v6.5.2: keep controls and resume link clickable / selectable while card is draggable */
+.tb3-walk-card-controls,
+.tb3-walk-card-controls *,
+.tb3-walk-card-exit-x,
+.tb3-walk-card-resume-link {
+  cursor: pointer;
+  user-select: auto;
 }
 .tb3-walk-card.tb3-walk-card-in-popup {
   z-index: 8;

--- a/features/topology-builder-v3.js
+++ b/features/topology-builder-v3.js
@@ -7008,6 +7008,9 @@
   function runStep(step, mode) {
     if (!step) return;
     clearEffects(mode);
+    // Bug A fix (v6.5.2): track which flow step's pellets are currently in
+    // flight so the SVG mutation observer can decide whether to re-spawn.
+    state.walkActiveFlowStepId = (step.type === 'flow') ? step.id : null;
     _fadeCardThroughStepChange(function () {
       renderStepCard(step);
       switch (step.type) {
@@ -7113,7 +7116,58 @@
     if (nextBtn) nextBtn.onclick = walkNext;
     var backBtn = card.querySelector('[data-walk-back]');
     if (backBtn && idx > 0) backBtn.onclick = walkBack;
+
+    // v6.5.2: drag-to-move step card around the canvas
+    _makeCardDraggable(card);
   }                                                              // Task 15
+
+  // v6.5.2: drag step card. Mousedown anywhere on the card (except controls)
+  // starts a drag; mousemove updates left/top; mouseup ends it. Document-level
+  // mousemove/mouseup listeners are bound once per session.
+  var _tb3WalkCardDragState = null;
+  function _makeCardDraggable(card) {
+    if (!card) return;
+    card.style.cursor = 'grab';
+    card.onmousedown = function (e) {
+      // Don't drag from buttons / interactive controls — they own clicks.
+      if (e.target.closest('[data-walk-next], [data-walk-back], [data-walk-exit], [data-walk-replay], [data-walk-catalog], [data-walk-sibling], .tb3-walk-card-resume-link, .tb3-walk-card-controls')) return;
+      var host = card.parentElement;
+      if (!host) return;
+      var hostRect = host.getBoundingClientRect();
+      var cardRect = card.getBoundingClientRect();
+      _tb3WalkCardDragState = {
+        card: card,
+        startX: e.clientX,
+        startY: e.clientY,
+        startLeft: cardRect.left - hostRect.left,
+        startTop:  cardRect.top  - hostRect.top,
+      };
+      card.style.cursor = 'grabbing';
+      card.style.transition = 'none';
+      e.preventDefault();
+    };
+  }
+  if (typeof document !== 'undefined' && !window._tb3WalkDragBound) {
+    document.addEventListener('mousemove', function (e) {
+      var ds = _tb3WalkCardDragState;
+      if (!ds) return;
+      var dx = e.clientX - ds.startX;
+      var dy = e.clientY - ds.startY;
+      ds.card.style.left = (ds.startLeft + dx) + 'px';
+      ds.card.style.top  = (ds.startTop  + dy) + 'px';
+    });
+    document.addEventListener('mouseup', function () {
+      var ds = _tb3WalkCardDragState;
+      if (!ds) return;
+      ds.card.style.cursor = 'grab';
+      // Restore tween-style position transition for the next step's anchor move
+      ds.card.style.transition = '';
+      // Mark anchor as user-customised so future anchor-recompute can skip
+      state.walkCardAnchor = { custom: true };
+      _tb3WalkCardDragState = null;
+    });
+    window._tb3WalkDragBound = true;
+  }                                                              // v6.5.2 drag
   function anchorStepCardToViewportCenter() {
     var card = document.querySelector('.tb3-walk-card');
     if (!card) return;
@@ -7179,11 +7233,13 @@
     var sides = ['above-right', 'below-right', 'above-left', 'below-left', 'top-center'];
     for (var i = 0; i < sides.length; i++) {
       var pos = _computeAnchorPosition(sides[i], devCenter, cardRect);
+      // Bug C fix (v6.5.2): buffer was 4 → 0 so card can sit flush with host
+      // edge on narrower viewports (was falling through to top-center too often).
       if (
-        pos.left >= 4 &&
-        pos.top >= 4 &&
-        pos.left + cardRect.width <= hostSize.width - 4 &&
-        pos.top + cardRect.height <= hostSize.height - 4
+        pos.left >= 0 &&
+        pos.top >= 0 &&
+        pos.left + cardRect.width <= hostSize.width &&
+        pos.top + cardRect.height <= hostSize.height
       ) {
         return sides[i];
       }
@@ -7192,7 +7248,10 @@
   }
 
   function _computeAnchorPosition(side, devCenter, cardRect) {
-    var margin = 24;
+    // Bug C fix (v6.5.2): margin was 24 → 12 so the card-to-device gap doesn't
+    // push the card off-screen on smaller hosts (260px card + 24px margin + 83/2
+    // device half-width often exceeded the wrap width).
+    var margin = 12;
     switch (side) {
       case 'above-right':
         return {
@@ -7782,19 +7841,71 @@
     card.appendChild(link);
   }                                                    // Task 15
 
+  // Bug A fix (v6.5.2): TB v3 _renderCanvas rewrites svg.innerHTML on every render,
+  // which wipes the runtime-added .tb3-walk-pulse / .tb3-walk-cable-pulse classes
+  // and any in-flight pellet sprites. A MutationObserver on #tb3-canvas-svg
+  // detects the childList rewrite and re-applies the current step's effects.
+  var _walkSvgObserver = null;
+
+  function _startWalkEffectObserver() {
+    if (_walkSvgObserver) return;
+    var svg = document.getElementById('tb3-canvas-svg');
+    if (!svg || typeof MutationObserver === 'undefined') return;
+    _walkSvgObserver = new MutationObserver(function () {
+      if (!state.activeWalkthroughId) return;
+      var walkList = (typeof TB_V3_WALKTHROUGHS !== 'undefined' ? TB_V3_WALKTHROUGHS : []);
+      var walk = walkList.find(function (w) { return w.id === state.activeWalkthroughId; });
+      if (!walk) return;
+      var step = walk.steps[state.walkStepIdx];
+      if (!step) return;
+      // 2D-mode only — 3D popup uses its own SVG outside #tb3-canvas-svg.
+      if (state.walkMode !== '2d') return;
+      if (step.type === 'highlight' && step.target) {
+        applyHighlight(step.target, '2d');
+      } else if (step.type === 'flow' && step.flow) {
+        // Pellets live inside the SVG too — the rewrite wipes them. Re-spawn
+        // only if we're still on this flow step (idempotent: clearEffects strips
+        // any leftover pellets before _animateFlow2D spawns fresh ones).
+        if (state.walkActiveFlowStepId === step.id) {
+          // Strip stale pellets/arrows that the rewrite may have orphaned in
+          // sibling DOM (none expected, but defensive), then respawn.
+          var stale = document.querySelectorAll('.tb3-walk-pellet, .tb3-walk-flow-arrow');
+          for (var s = 0; s < stale.length; s++) {
+            stale[s].parentNode && stale[s].parentNode.removeChild(stale[s]);
+          }
+          _animateFlow2D(step.flow);
+        }
+      }
+    });
+    _walkSvgObserver.observe(svg, { childList: true, subtree: false });
+  }
+
+  function _stopWalkEffectObserver() {
+    if (_walkSvgObserver) {
+      _walkSvgObserver.disconnect();
+      _walkSvgObserver = null;
+    }
+  }
+
   function walkStart(walkthroughId) {
     var walk = TB_V3_WALKTHROUGHS.find(function (w) { return w.id === walkthroughId; });
     if (!walk) { console.warn('[walk] unknown walkthroughId', walkthroughId); return; }
-    // If the active scenario doesn't match, load it
+    // Bug B fix (v6.5.2): loadScenarioOnCanvas returns the new state — must
+    // reassign `state = ...` (matches scenario-picker pattern at L4156) so
+    // activeScenarioId syncs, then trigger a canvas re-render.
     if (state.activeScenarioId !== walk.scenarioId) {
       var scenario = TB_V3_SCENARIOS.find(function (s) { return s.id === walk.scenarioId; });
-      if (scenario) loadScenarioOnCanvas(state, scenario);
+      if (scenario) {
+        state = loadScenarioOnCanvas(state, scenario);
+        if (typeof _renderCanvas === 'function') _renderCanvas();
+      }
     }
     state.priorIntent = state.intent;
     state.intent = 'walk';
     state.activeWalkthroughId = walkthroughId;
     state.walkStepIdx = 0;
     _saveStateImmediate();
+    _startWalkEffectObserver();   // Bug A fix (v6.5.2)
     if (walk.steps && walk.steps.length > 0) runStep(walk.steps[0], state.walkMode);
     renderWalkCatalog();
   }
@@ -7824,12 +7935,14 @@
 
   function walkExit() {
     if (!state.activeWalkthroughId) return;
+    _stopWalkEffectObserver();   // Bug A fix (v6.5.2)
     clearEffects(state.walkMode);
     hideStepCard();
     state.intent = state.priorIntent || 'free-build';
     state.activeWalkthroughId = null;
     state.walkStepIdx = 0;
     state.walkCardAnchor = null;
+    state.walkActiveFlowStepId = null;
     _saveStateImmediate();
     renderWalkCatalog();
   }

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.1</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.2</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v6.5.1 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v6.5.1';
+// Service Worker v6.5.2 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v6.5.2';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23635,6 +23635,145 @@ test('TB v3 walk: _clearWalkHighlight3D resets panX/panY via camera state', (fun
   return /panX\s*=\s*0/.test(m[0]) && /_apply3DCamera/.test(m[0]);
 })());
 
+// ── v6.5.2 hotfix tests ──
+
+test('v6.5.2: package.json version is 6.5.2', (function () {
+  var pkg = read('package.json');
+  return /"version":\s*"6\.5\.2"/.test(pkg);
+})());
+
+test('v6.5.2: sw.js CACHE_NAME is netplus-v6.5.2', (function () {
+  var sw = read('sw.js');
+  return /netplus-v6\.5\.2/.test(sw);
+})());
+
+test('v6.5.2: index.html version badge is v6.5.2', (function () {
+  return /version-badge[\s\S]*?v6\.5\.2/.test(html);
+})());
+
+test('v6.5.2: app.js APP_VERSION is 6.5.2', (function () {
+  var js = read('app.js');
+  return /APP_VERSION\s*=\s*['"]6\.5\.2['"]/.test(js);
+})());
+
+// Bug A: MutationObserver re-applies walk FX after canvas re-render
+test('v6.5.2 Bug A: _startWalkEffectObserver defined and uses MutationObserver on #tb3-canvas-svg', (function () {
+  var m = tbV3JsForWalk.match(/function _startWalkEffectObserver[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /MutationObserver/.test(m[0])
+      && /tb3-canvas-svg/.test(m[0])
+      && /childList/.test(m[0]);
+})());
+
+test('v6.5.2 Bug A: walkStart calls _startWalkEffectObserver', (function () {
+  var m = tbV3JsForWalk.match(/function walkStart\([\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /_startWalkEffectObserver\(\)/.test(m[0]);
+})());
+
+test('v6.5.2 Bug A: walkExit calls _stopWalkEffectObserver', (function () {
+  var m = tbV3JsForWalk.match(/function walkExit\([\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /_stopWalkEffectObserver\(\)/.test(m[0]);
+})());
+
+test('v6.5.2 Bug A: observer re-applies applyHighlight for current step', (function () {
+  var m = tbV3JsForWalk.match(/function _startWalkEffectObserver[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /applyHighlight\(step\.target/.test(m[0]);
+})());
+
+test('v6.5.2 Bug A: runStep tracks walkActiveFlowStepId for flow steps only', (function () {
+  var m = tbV3JsForWalk.match(/function runStep\(step,\s*mode\)[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /walkActiveFlowStepId/.test(m[0])
+      && /step\.type\s*===?\s*['"]flow['"]/.test(m[0]);
+})());
+
+test('v6.5.2 Bug A: observer respawns pellets for current flow step', (function () {
+  var m = tbV3JsForWalk.match(/function _startWalkEffectObserver[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /walkActiveFlowStepId/.test(m[0])
+      && /_animateFlow2D\(step\.flow\)/.test(m[0]);
+})());
+
+// Bug B: walkStart reassigns state from loadScenarioOnCanvas + re-renders
+test('v6.5.2 Bug B: walkStart reassigns state = loadScenarioOnCanvas(...)', (function () {
+  var m = tbV3JsForWalk.match(/function walkStart\([\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /state\s*=\s*loadScenarioOnCanvas\(state,\s*scenario\)/.test(m[0]);
+})());
+
+test('v6.5.2 Bug B: walkStart calls _renderCanvas after loading a scenario', (function () {
+  var m = tbV3JsForWalk.match(/function walkStart\([\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /_renderCanvas\(\)/.test(m[0]);
+})());
+
+// Bug C: anchor positioning uses smaller margin + zero buffer
+test('v6.5.2 Bug C: _computeAnchorPosition margin reduced to 12', (function () {
+  var m = tbV3JsForWalk.match(/function _computeAnchorPosition[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /var\s+margin\s*=\s*12\b/.test(m[0]);
+})());
+
+test('v6.5.2 Bug C: _pickAnchorSide buffer reduced from 4 to 0', (function () {
+  var m = tbV3JsForWalk.match(/function _pickAnchorSide[\s\S]*?\n  \}/);
+  if (!m) return false;
+  var body = m[0];
+  return /pos\.left\s*>=\s*0\b/.test(body)
+      && /pos\.top\s*>=\s*0\b/.test(body)
+      && !/hostSize\.width\s*-\s*4/.test(body)
+      && !/hostSize\.height\s*-\s*4/.test(body);
+})());
+
+// Draggable step card
+test('v6.5.2 drag: _makeCardDraggable function defined', (function () {
+  return /function _makeCardDraggable\(card\)/.test(tbV3JsForWalk);
+})());
+
+test('v6.5.2 drag: renderStepCard calls _makeCardDraggable', (function () {
+  var m = tbV3JsForWalk.match(/function renderStepCard\(step\)[\s\S]*?_makeCardDraggable\(card\)/);
+  return !!m;
+})());
+
+test('v6.5.2 drag: mousedown handler skips control-region targets', (function () {
+  var m = tbV3JsForWalk.match(/function _makeCardDraggable[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /data-walk-next/.test(m[0])
+      && /data-walk-back/.test(m[0])
+      && /data-walk-exit/.test(m[0])
+      && /tb3-walk-card-controls/.test(m[0]);
+})());
+
+test('v6.5.2 drag: document-level mousemove + mouseup listeners bound once via _tb3WalkDragBound guard', (function () {
+  return /window\._tb3WalkDragBound/.test(tbV3JsForWalk)
+      && /document\.addEventListener\(['"]mousemove['"]/.test(tbV3JsForWalk)
+      && /document\.addEventListener\(['"]mouseup['"]/.test(tbV3JsForWalk);
+})());
+
+test('v6.5.2 drag: drag updates card.style.left/top live', (function () {
+  return /ds\.startLeft\s*\+\s*dx/.test(tbV3JsForWalk)
+      && /ds\.startTop\s*\+\s*dy/.test(tbV3JsForWalk);
+})());
+
+test('v6.5.2 drag: mouseup marks anchor as custom so next step skips re-anchor reset', (function () {
+  return /walkCardAnchor\s*=\s*\{\s*custom:\s*true\s*\}/.test(tbV3JsForWalk);
+})());
+
+test('v6.5.2 drag: .tb3-walk-card CSS has cursor:grab + user-select:none', (function () {
+  var tbCss = read('features/topology-builder-v3.css');
+  var m = tbCss.match(/\.tb3-walk-card\s*\{[\s\S]*?\}/);
+  if (!m) return false;
+  return /cursor:\s*grab/.test(m[0]) && /user-select:\s*none/.test(m[0]);
+})());
+
+test('v6.5.2 drag: controls still clickable (.tb3-walk-card-controls cursor:pointer + user-select:auto)', (function () {
+  var tbCss = read('features/topology-builder-v3.css');
+  var m = tbCss.match(/\.tb3-walk-card-controls[\s\S]*?\{[\s\S]*?cursor:\s*pointer[\s\S]*?user-select:\s*auto[\s\S]*?\}/);
+  return !!m;
+})());
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;


### PR DESCRIPTION
## Summary
Hotfix on top of v6.5.1 addressing 4 prod-smoke-test bugs, plus a new drag-to-move affordance for the walkthrough step card.

- **Bug A — visual FX wipe.** TB v3 `_renderCanvas` rebuilds `#tb3-canvas-svg` via `svg.innerHTML`, wiping `.tb3-walk-pulse` / `.tb3-walk-cable-pulse` classes and in-flight pellet sprites. Added a `MutationObserver` (started in `walkStart`, stopped in `walkExit`) that re-applies the current step's highlight; flow pellets re-spawn gated on a new `state.walkActiveFlowStepId`.
- **Bug B — walkStart state desync.** `walkStart` discarded the return value of `loadScenarioOnCanvas`, so `state.activeScenarioId` never updated and the canvas didn't re-render. Now matches the scenario-picker pattern at L4156 (`state = loadScenarioOnCanvas(...); _renderCanvas();`).
- **Bug C — anchor falling back to top-center.** Side picker rejected all 4 device-side positions on narrower viewports because 24px margin + 4px edge buffer exceeded available width. Margin 24→12, buffer 4→0.
- **Bug D — catalog row `.click()` no-op.** Event-dispatch quirk; real user clicks (MouseEvent) work fine. Per spec, documented as a known limitation, no fix shipped.
- **New feature — draggable step card.** Mousedown on card (except controls) starts a drag; document-level mousemove/mouseup bound once via `window._tb3WalkDragBound`. Mouseup marks `walkCardAnchor.custom = true` so next step doesn't fight the user's placement. CSS adds `cursor:grab` + `user-select:none` to `.tb3-walk-card`, with controls overriding back to pointer/auto.

UAT: **6940/6940 PASS** (baseline 6918, +22 new tests for these fixes).

## Test plan
- [x] `node tests/uat.js` → 6940/6940 PASS
- [ ] Live smoke: open a TB v3 walkthrough, advance steps, confirm pulse class persists across renders
- [ ] Live smoke: start a flow step, confirm pellets re-spawn if canvas re-renders
- [ ] Live smoke: switch active walkthrough → confirm new scenario loads on canvas
- [ ] Live smoke: drag step card around canvas; confirm anchor sticks until next walkthrough start
- [ ] Live smoke: small viewport → confirm card anchors to a device side rather than top-center

🤖 Generated with [Claude Code](https://claude.com/claude-code)