### PR TITLE
v6.5.3 — fix walkMode preservation (root cause of visual FX bugs)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v6.5.2
+// Network+ AI Quiz — app.js  v6.5.3
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '6.5.2';
+const APP_VERSION = '6.5.3';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/features/topology-builder-v3.js
+++ b/features/topology-builder-v3.js
@@ -7007,6 +7007,7 @@
 
   function runStep(step, mode) {
     if (!step) return;
+    mode = mode || '2d';  // v6.5.3 defensive default — handles edge cases where state.walkMode is undefined
     clearEffects(mode);
     // Bug A fix (v6.5.2): track which flow step's pellets are currently in
     // flight so the SVG mutation observer can decide whether to re-spawn.
@@ -7893,11 +7894,22 @@
     // Bug B fix (v6.5.2): loadScenarioOnCanvas returns the new state — must
     // reassign `state = ...` (matches scenario-picker pattern at L4156) so
     // activeScenarioId syncs, then trigger a canvas re-render.
+    // v6.5.3 root-cause fix: loadScenarioOnCanvas constructs a fresh state
+    // object that does NOT include walkthrough-specific fields (walkMode,
+    // walkCardAnchor). Preserve and restore them across the reassignment,
+    // and re-render intent chip / minimap / mode bar to clear stale UI.
     if (state.activeScenarioId !== walk.scenarioId) {
       var scenario = TB_V3_SCENARIOS.find(function (s) { return s.id === walk.scenarioId; });
       if (scenario) {
+        var savedWalkMode = state.walkMode || '2d';
+        var savedWalkCardAnchor = state.walkCardAnchor;
         state = loadScenarioOnCanvas(state, scenario);
+        state.walkMode = savedWalkMode;
+        state.walkCardAnchor = savedWalkCardAnchor;
         if (typeof _renderCanvas === 'function') _renderCanvas();
+        if (typeof _renderIntentChip === 'function') _renderIntentChip();
+        if (typeof _renderMinimap === 'function') _renderMinimap();
+        if (typeof _renderModeBar === 'function') _renderModeBar();
       }
     }
     state.priorIntent = state.intent;

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.2</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.3</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v6.5.2 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v6.5.2';
+// Service Worker v6.5.3 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v6.5.3';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23637,23 +23637,23 @@ test('TB v3 walk: _clearWalkHighlight3D resets panX/panY via camera state', (fun
 
 // ── v6.5.2 hotfix tests ──
 
-test('v6.5.2: package.json version is 6.5.2', (function () {
+test('v6.5.3: package.json version is 6.5.3', (function () {
   var pkg = read('package.json');
-  return /"version":\s*"6\.5\.2"/.test(pkg);
+  return /"version":\s*"6\.5\.3"/.test(pkg);
 })());
 
-test('v6.5.2: sw.js CACHE_NAME is netplus-v6.5.2', (function () {
+test('v6.5.3: sw.js CACHE_NAME is netplus-v6.5.3', (function () {
   var sw = read('sw.js');
-  return /netplus-v6\.5\.2/.test(sw);
+  return /netplus-v6\.5\.3/.test(sw);
 })());
 
-test('v6.5.2: index.html version badge is v6.5.2', (function () {
-  return /version-badge[\s\S]*?v6\.5\.2/.test(html);
+test('v6.5.3: index.html version badge is v6.5.3', (function () {
+  return /version-badge[\s\S]*?v6\.5\.3/.test(html);
 })());
 
-test('v6.5.2: app.js APP_VERSION is 6.5.2', (function () {
+test('v6.5.3: app.js APP_VERSION is 6.5.3', (function () {
   var js = read('app.js');
-  return /APP_VERSION\s*=\s*['"]6\.5\.2['"]/.test(js);
+  return /APP_VERSION\s*=\s*['"]6\.5\.3['"]/.test(js);
 })());
 
 // Bug A: MutationObserver re-applies walk FX after canvas re-render
@@ -23772,6 +23772,20 @@ test('v6.5.2 drag: controls still clickable (.tb3-walk-card-controls cursor:poin
   var tbCss = read('features/topology-builder-v3.css');
   var m = tbCss.match(/\.tb3-walk-card-controls[\s\S]*?\{[\s\S]*?cursor:\s*pointer[\s\S]*?user-select:\s*auto[\s\S]*?\}/);
   return !!m;
+})());
+
+test('TB v3 walk: walkStart preserves walkMode across loadScenarioOnCanvas state reassign', (function () {
+  var m = tbV3JsForWalk.match(/function walkStart[\s\S]*?\n  \}/);
+  if (!m) return false;
+  var body = m[0];
+  return /savedWalkMode\s*=\s*state\.walkMode/.test(body)
+      && /state\.walkMode\s*=\s*savedWalkMode/.test(body);
+})());
+
+test('TB v3 walk: runStep defaults mode to 2d when undefined', (function () {
+  var m = tbV3JsForWalk.match(/function runStep[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /mode\s*=\s*mode\s*\|\|\s*['"]2d['"]/.test(m[0]);
 })());
 
 // ── Summary ──


### PR DESCRIPTION
## Root cause fix

Live Chrome DevTools inspection of v6.5.2 on prod revealed:

`state.walkMode` was **undefined** during step transitions. Cause: v6.5.2's `walkStart` does `state = loadScenarioOnCanvas(state, scenario);` — this reassigns `state` to a fresh object that doesn't include the walkthrough-specific runtime fields (`walkMode`, `walkCardAnchor`).

Then `runStep(step, state.walkMode)` passes `undefined` as `mode`. Inside `applyHighlight`:
```js
if (mode === '2d') { ... }
else if (mode === '3d') { ... }
```
Neither branch fires. No class added, no error. Silently broken.

This single bug explains ALL the v6.5.2 visual FX regressions: pulse not appearing, cable pulse not appearing, flow pellets not spawning.

## Fix

1. In `walkStart`, save `walkMode` + `walkCardAnchor` before `loadScenarioOnCanvas` reassign, restore after
2. Also re-call `_renderIntentChip`, `_renderMinimap`, `_renderModeBar` to refresh post-scenario-load UI (was stale)
3. Defensive: in `runStep`, default `mode = mode || '2d'` as belt-and-suspenders

## Test plan
- [ ] CI green
- [ ] Manual smoke: open prod → Walk pill → Hub-and-Spoke → "How branches reach HQ" → confirm router glows on step 2, packets animate on step 4