### PR TITLE
v6.5.4 — fix MutationObserver infinite loop on flow steps

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v6.5.3
+// Network+ AI Quiz — app.js  v6.5.4
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '6.5.3';
+const APP_VERSION = '6.5.4';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/features/topology-builder-v3.js
+++ b/features/topology-builder-v3.js
@@ -7009,9 +7009,8 @@
     if (!step) return;
     mode = mode || '2d';  // v6.5.3 defensive default — handles edge cases where state.walkMode is undefined
     clearEffects(mode);
-    // Bug A fix (v6.5.2): track which flow step's pellets are currently in
-    // flight so the SVG mutation observer can decide whether to re-spawn.
-    state.walkActiveFlowStepId = (step.type === 'flow') ? step.id : null;
+    // v6.5.4: walkActiveFlowStepId removed — observer no longer re-spawns
+    // flow pellets (was an infinite-loop source). Pellets are one-shot per step.
     _fadeCardThroughStepChange(function () {
       renderStepCard(step);
       switch (step.type) {
@@ -7863,20 +7862,11 @@
       if (state.walkMode !== '2d') return;
       if (step.type === 'highlight' && step.target) {
         applyHighlight(step.target, '2d');
-      } else if (step.type === 'flow' && step.flow) {
-        // Pellets live inside the SVG too — the rewrite wipes them. Re-spawn
-        // only if we're still on this flow step (idempotent: clearEffects strips
-        // any leftover pellets before _animateFlow2D spawns fresh ones).
-        if (state.walkActiveFlowStepId === step.id) {
-          // Strip stale pellets/arrows that the rewrite may have orphaned in
-          // sibling DOM (none expected, but defensive), then respawn.
-          var stale = document.querySelectorAll('.tb3-walk-pellet, .tb3-walk-flow-arrow');
-          for (var s = 0; s < stale.length; s++) {
-            stale[s].parentNode && stale[s].parentNode.removeChild(stale[s]);
-          }
-          _animateFlow2D(step.flow);
-        }
       }
+      // v6.5.4: Flow pellets are one-shot per step — they live in the SVG too
+      // but auto-clean in ~2.6s. Re-spawning them in the observer creates an
+      // infinite loop because each pellet IS a childList change. Pellets get
+      // one chance per step from runStep. Highlights remain protected above.
     });
     _walkSvgObserver.observe(svg, { childList: true, subtree: false });
   }
@@ -7954,7 +7944,6 @@
     state.activeWalkthroughId = null;
     state.walkStepIdx = 0;
     state.walkCardAnchor = null;
-    state.walkActiveFlowStepId = null;
     _saveStateImmediate();
     renderWalkCatalog();
   }

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.3</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.4</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "6.5.3",
+  "version": "6.5.4",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v6.5.3 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v6.5.3';
+// Service Worker v6.5.4 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v6.5.4';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23637,23 +23637,23 @@ test('TB v3 walk: _clearWalkHighlight3D resets panX/panY via camera state', (fun
 
 // ── v6.5.2 hotfix tests ──
 
-test('v6.5.3: package.json version is 6.5.3', (function () {
+test('v6.5.4: package.json version is 6.5.4', (function () {
   var pkg = read('package.json');
-  return /"version":\s*"6\.5\.3"/.test(pkg);
+  return /"version":\s*"6\.5\.4"/.test(pkg);
 })());
 
-test('v6.5.3: sw.js CACHE_NAME is netplus-v6.5.3', (function () {
+test('v6.5.4: sw.js CACHE_NAME is netplus-v6.5.4', (function () {
   var sw = read('sw.js');
-  return /netplus-v6\.5\.3/.test(sw);
+  return /netplus-v6\.5\.4/.test(sw);
 })());
 
-test('v6.5.3: index.html version badge is v6.5.3', (function () {
-  return /version-badge[\s\S]*?v6\.5\.3/.test(html);
+test('v6.5.4: index.html version badge is v6.5.4', (function () {
+  return /version-badge[\s\S]*?v6\.5\.4/.test(html);
 })());
 
-test('v6.5.3: app.js APP_VERSION is 6.5.3', (function () {
+test('v6.5.4: app.js APP_VERSION is 6.5.4', (function () {
   var js = read('app.js');
-  return /APP_VERSION\s*=\s*['"]6\.5\.3['"]/.test(js);
+  return /APP_VERSION\s*=\s*['"]6\.5\.4['"]/.test(js);
 })());
 
 // Bug A: MutationObserver re-applies walk FX after canvas re-render
@@ -23683,18 +23683,18 @@ test('v6.5.2 Bug A: observer re-applies applyHighlight for current step', (funct
   return /applyHighlight\(step\.target/.test(m[0]);
 })());
 
-test('v6.5.2 Bug A: runStep tracks walkActiveFlowStepId for flow steps only', (function () {
-  var m = tbV3JsForWalk.match(/function runStep\(step,\s*mode\)[\s\S]*?\n  \}/);
-  if (!m) return false;
-  return /walkActiveFlowStepId/.test(m[0])
-      && /step\.type\s*===?\s*['"]flow['"]/.test(m[0]);
+test('v6.5.4 Bug A: walkActiveFlowStepId no longer assigned (removed from code paths)', (function () {
+  // v6.5.4: state.walkActiveFlowStepId no longer written or read — assignment patterns gone
+  // (a doc-comment may still mention the name; assertion targets actual usage)
+  return !/state\.walkActiveFlowStepId\s*=/.test(tbV3JsForWalk)
+      && !/walkActiveFlowStepId\s*===?/.test(tbV3JsForWalk);
 })());
 
-test('v6.5.2 Bug A: observer respawns pellets for current flow step', (function () {
+test('v6.5.4 Bug A: observer does NOT respawn flow pellets (infinite-loop fix)', (function () {
+  // v6.5.4: removed flow pellet re-spawn from observer — each pellet was a childList change → infinite loop
   var m = tbV3JsForWalk.match(/function _startWalkEffectObserver[\s\S]*?\n  \}/);
   if (!m) return false;
-  return /walkActiveFlowStepId/.test(m[0])
-      && /_animateFlow2D\(step\.flow\)/.test(m[0]);
+  return !/_animateFlow2D\(step\.flow\)/.test(m[0]);
 })());
 
 // Bug B: walkStart reassigns state from loadScenarioOnCanvas + re-renders


### PR DESCRIPTION
## Bug

v6.5.2's _startWalkEffectObserver re-spawns flow pellets on SVG childList change. Each pellet IS a childList change → observer fires again → infinite loop. Live-confirmed on v6.5.3 prod: flow steps hang the browser; pellets never visible.

## Fix

Remove the flow re-spawn branch from the observer. Pellets are short-lived (~2.6s) one-shot effects — if canvas re-renders wipe them, they're gone, but preferable to a browser hang. Highlights remain protected (observer still re-applies highlight pulse).

Also removes state.walkActiveFlowStepId (no longer used).

## Test plan
- [ ] CI green
- [ ] Manual smoke: flow step on Home Network walk should briefly show pellets, NOT hang browser