### PR TITLE
fix(tb-v3-walk): v6.5.5 — reset viewport on walkStart so scenario fits canvas

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v6.5.3
+// Network+ AI Quiz — app.js  v6.5.5
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '6.5.3';
+const APP_VERSION = '6.5.5';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/features/topology-builder-v3.js
+++ b/features/topology-builder-v3.js
@@ -7912,6 +7912,24 @@
         if (typeof _renderModeBar === 'function') _renderModeBar();
       }
     }
+    // v6.5.5 fix: ALWAYS reset viewport on walkStart so the scenario fits the
+    // canvas, regardless of whether scenarios switched. Without this, the
+    // user's prior zoom/pan (e.g., 268% zoom) is still applied to the new
+    // scenario's devices — rendering them off-screen and making the
+    // walkthrough visually unusable. Use the scenario's startingState.viewport
+    // when defined; otherwise fall back to {0,0,1}.
+    var walkScenario = TB_V3_SCENARIOS.find(function (s) { return s.id === walk.scenarioId; });
+    if (walkScenario && walkScenario.startingState && walkScenario.startingState.viewport) {
+      state.viewport = {
+        x: walkScenario.startingState.viewport.x || 0,
+        y: walkScenario.startingState.viewport.y || 0,
+        zoom: walkScenario.startingState.viewport.zoom || 1,
+      };
+    } else {
+      state.viewport = { x: 0, y: 0, zoom: 1 };
+    }
+    if (typeof _renderCanvas === 'function') _renderCanvas();
+    if (typeof _renderMinimap === 'function') _renderMinimap();
     state.priorIntent = state.intent;
     state.intent = 'walk';
     state.activeWalkthroughId = walkthroughId;

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.3</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.5</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "6.5.3",
+  "version": "6.5.5",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v6.5.3 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v6.5.3';
+// Service Worker v6.5.5 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v6.5.5';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23637,23 +23637,29 @@ test('TB v3 walk: _clearWalkHighlight3D resets panX/panY via camera state', (fun
 
 // ── v6.5.2 hotfix tests ──
 
-test('v6.5.3: package.json version is 6.5.3', (function () {
+test('v6.5.5: package.json version is 6.5.5', (function () {
   var pkg = read('package.json');
-  return /"version":\s*"6\.5\.3"/.test(pkg);
+  return /"version":\s*"6\.5\.5"/.test(pkg);
 })());
 
-test('v6.5.3: sw.js CACHE_NAME is netplus-v6.5.3', (function () {
+test('v6.5.5: sw.js CACHE_NAME is netplus-v6.5.5', (function () {
   var sw = read('sw.js');
-  return /netplus-v6\.5\.3/.test(sw);
+  return /netplus-v6\.5\.5/.test(sw);
 })());
 
-test('v6.5.3: index.html version badge is v6.5.3', (function () {
-  return /version-badge[\s\S]*?v6\.5\.3/.test(html);
+test('v6.5.5: index.html version badge is v6.5.5', (function () {
+  return /version-badge[\s\S]*?v6\.5\.5/.test(html);
 })());
 
-test('v6.5.3: app.js APP_VERSION is 6.5.3', (function () {
+test('v6.5.5: app.js APP_VERSION is 6.5.5', (function () {
   var js = read('app.js');
-  return /APP_VERSION\s*=\s*['"]6\.5\.3['"]/.test(js);
+  return /APP_VERSION\s*=\s*['"]6\.5\.5['"]/.test(js);
+})());
+
+test('TB v3 walk: walkStart resets viewport when loading scenario', (function () {
+  var m = tbV3JsForWalk.match(/function walkStart[\s\S]*?\n  \}/);
+  if (!m) return false;
+  return /state\.viewport\s*=/.test(m[0]) || /_fitCanvasToContent|_fitToView/.test(m[0]);
 })());
 
 // Bug A: MutationObserver re-applies walk FX after canvas re-render


### PR DESCRIPTION
## Summary
- **Bug**: When `walkStart` loaded a walkthrough whose scenario was already active, `state.viewport` (canvas zoom + pan) was never reset. The user's prior zoom (e.g., 268%) and pan offset persisted, rendering the new topology off-screen — user report: "can't see anything", tiny devices clustered top-right.
- **Fix**: ALWAYS reset `state.viewport` at the start of `walkStart`, regardless of scenario match. Uses `scenario.startingState.viewport` when defined; falls back to `{x:0,y:0,zoom:1}`. Triggers `_renderCanvas` + `_renderMinimap` so the new viewport takes effect immediately.
- **Version bump**: 6.5.3 → 6.5.5 (skipping 6.5.4 per plan target tag) across `package.json`, `sw.js`, `index.html`, `app.js`, UAT pins.

## Test plan
- [x] UAT suite passes: 6943/6943
- [x] New UAT test added: `TB v3 walk: walkStart resets viewport when loading scenario` (PASS)
- [ ] Manual: open a walkthrough → confirm devices are centered and visible regardless of prior zoom/pan
- [ ] Manual: confirm user can still drag/zoom mid-walk

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)