### PR TITLE
v6.5.6 — catalog panel absolute positioning (fix grid collapse)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v6.5.5
+// Network+ AI Quiz — app.js  v6.5.6
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '6.5.5';
+const APP_VERSION = '6.5.6';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/features/topology-builder-v3.css
+++ b/features/topology-builder-v3.css
@@ -3007,9 +3007,8 @@ html[data-theme="light"] #page-topology-builder-v3 {
 }
 
 /* ── Walkthrough catalog (Phase 8) ─────────────────────────────── */
+/* Inner layout — main positioning rules are in the visibility block below */
 .tb3-rail-panel[data-mode="walk-catalog"] {
-  padding: 14px;
-  flex-direction: column;
   gap: 6px;
 }
 .tb3-walk-catalog-header {
@@ -3387,14 +3386,29 @@ html[data-theme="light"] #page-topology-builder-v3 {
   color: rgba(255, 255, 255, 0.45);
 }
 
-/* ── Walk catalog visibility (Follow-up #2) ───────────────────── */
-.tb3-rail-panel[data-mode="walk-catalog"] {
+/* ── Walkthrough catalog panel (Phase 8) — absolute, slides over canvas ── */
+#page-topology-builder-v3 .tb3-rail-panel[data-mode="walk-catalog"] {
   display: none;
-  position: relative;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 360px;
+  height: 100%;
+  background: var(--tb3-surface);
+  border-left: 1px solid var(--tb3-border);
+  z-index: 6;
+  flex-direction: column;
+  padding: 18px 18px 12px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform 240ms var(--tb3-ease-out);
 }
-#tb3-body.walk-catalog-open .tb3-rail-panel[data-mode="walk-catalog"] {
+#page-topology-builder-v3 .tb3-body.walk-catalog-open .tb3-rail-panel[data-mode="walk-catalog"] {
   display: flex;
+  transform: translateX(0);
 }
+#page-topology-builder-v3 .tb3-body.walk-catalog-open .tb3-rrail { display: none; }
 .tb3-walk-catalog-close {
   position: absolute;
   top: 10px;

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.5</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.6</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "6.5.5",
+  "version": "6.5.6",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v6.5.5 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v6.5.5';
+// Service Worker v6.5.6 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v6.5.6';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23637,23 +23637,31 @@ test('TB v3 walk: _clearWalkHighlight3D resets panX/panY via camera state', (fun
 
 // ── v6.5.2 hotfix tests ──
 
-test('v6.5.5: package.json version is 6.5.5', (function () {
+test('v6.5.6: package.json version is 6.5.6', (function () {
   var pkg = read('package.json');
-  return /"version":\s*"6\.5\.5"/.test(pkg);
+  return /"version":\s*"6\.5\.6"/.test(pkg);
 })());
 
-test('v6.5.5: sw.js CACHE_NAME is netplus-v6.5.5', (function () {
+test('v6.5.6: sw.js CACHE_NAME is netplus-v6.5.6', (function () {
   var sw = read('sw.js');
-  return /netplus-v6\.5\.5/.test(sw);
+  return /netplus-v6\.5\.6/.test(sw);
 })());
 
-test('v6.5.5: index.html version badge is v6.5.5', (function () {
-  return /version-badge[\s\S]*?v6\.5\.5/.test(html);
+test('v6.5.6: index.html version badge is v6.5.6', (function () {
+  return /version-badge[\s\S]*?v6\.5\.6/.test(html);
 })());
 
-test('v6.5.5: app.js APP_VERSION is 6.5.5', (function () {
+test('v6.5.6: app.js APP_VERSION is 6.5.6', (function () {
   var js = read('app.js');
-  return /APP_VERSION\s*=\s*['"]6\.5\.5['"]/.test(js);
+  return /APP_VERSION\s*=\s*['"]6\.5\.6['"]/.test(js);
+})());
+
+test('TB v3 walk: catalog panel uses absolute positioning (slides over canvas, not grid item)', (function () {
+  var css = read('features/topology-builder-v3.css');
+  var m = css.match(/#page-topology-builder-v3\s+\.tb3-rail-panel\[data-mode=["']walk-catalog["']\]\s*\{[\s\S]*?\n\}/);
+  if (!m) return false;
+  return /position:\s*absolute/.test(m[0])
+      && /transform:\s*translateX\(100%\)/.test(m[0]);
 })());
 
 test('TB v3 walk: walkStart resets viewport to scenario startingState (or {0,0,1})', (function () {


### PR DESCRIPTION
## Bug

v6.5.1 catalog panel CSS made it a regular flex/grid item in tb3-body (which uses CSS Grid). Without explicit grid-area, it landed in the wrong cell and squashed the canvas to 138px tall — user couldn't see anything when clicking the Walk pill.

## Fix

Match the existing rail-panel pattern (Trace/Picker/Inspector):
- position: absolute (out of grid flow)
- Slides in from right via transform translateX(100%) -> translateX(0)
- 360px wide, full height, z-index 6
- Hides .tb3-rrail when open (matches trace)

Diagnosed live on prod: catalog took 200px from grid; canvas-wrap collapsed to 138px tall.

## Test plan
- [ ] CI green
- [ ] Manual: click Walk pill -> catalog slides in from right; canvas stays full-size; step card visible