### PR TITLE
v6.5.7 — catalog contrast fix (use theme tokens)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v6.5.6
+// Network+ AI Quiz — app.js  v6.5.7
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '6.5.6';
+const APP_VERSION = '6.5.7';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/features/topology-builder-v3.css
+++ b/features/topology-builder-v3.css
@@ -3013,8 +3013,8 @@ html[data-theme="light"] #page-topology-builder-v3 {
 }
 .tb3-walk-catalog-header {
   font-size: 13px;
-  font-weight: 600;
-  color: var(--tb3-text-strong, #f5deb6);
+  font-weight: 700;
+  color: var(--tb3-text);
   margin-bottom: 4px;
 }
 .tb3-walk-catalog-domain-h {
@@ -3022,13 +3022,13 @@ html[data-theme="light"] #page-topology-builder-v3 {
   justify-content: space-between;
   align-items: center;
   padding: 6px 8px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--tb3-surface-2);
   border-left: 2px solid var(--tb3-bronze, #8b5a3c);
   border-radius: 4px;
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--tb3-text);
   font-weight: 600;
   margin-top: 8px;
 }
@@ -3046,21 +3046,21 @@ html[data-theme="light"] #page-topology-builder-v3 {
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
-  background: rgba(255, 255, 255, 0.025);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--tb3-surface);
+  border: 1px solid var(--tb3-border);
   border-radius: 5px;
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--tb3-text);
   cursor: pointer;
   transition: opacity 200ms ease, background 200ms ease;
 }
 .tb3-walk-scen-row:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--tb3-surface-2);
 }
 .tb3-walk-scen-title { flex: 1; }
 .tb3-walk-walks-pill {
   font-size: 9px;
-  color: rgba(201, 138, 54, 0.9);
+  color: var(--tb3-bronze, #c98a36);
   background: rgba(201, 138, 54, 0.10);
   border: 1px solid rgba(201, 138, 54, 0.3);
   padding: 2px 7px;
@@ -3072,14 +3072,14 @@ html[data-theme="light"] #page-topology-builder-v3 {
 .tb3-walk-scen-row.tb3-walk-scen-active {
   background: linear-gradient(180deg, rgba(201, 138, 54, 0.18), rgba(201, 138, 54, 0.06)) !important;
   border-color: rgba(201, 138, 54, 0.55) !important;
-  color: #f5deb6 !important;
+  color: var(--tb3-text) !important;
 }
 .tb3-walk-dimmed {
-  opacity: 0.3;
+  opacity: 0.5;
   pointer-events: none;
 }
 .tb3-walk-catalog-domain-h.tb3-walk-dimmed {
-  border-left-color: rgba(255, 255, 255, 0.1);
+  border-left-color: var(--tb3-border-soft);
 }
 .tb3-walk-nest {
   margin-left: 14px;
@@ -3099,7 +3099,7 @@ html[data-theme="light"] #page-topology-builder-v3 {
   border-radius: 4px;
   background: linear-gradient(180deg, rgba(201, 138, 54, 0.14), rgba(201, 138, 54, 0.05));
   border: 1px solid rgba(201, 138, 54, 0.35);
-  color: #f5deb6;
+  color: var(--tb3-text);
   font-size: 10px;
   cursor: pointer;
   transition: background 200ms ease;
@@ -3119,13 +3119,13 @@ html[data-theme="light"] #page-topology-builder-v3 {
   border: 1px solid rgba(201, 138, 54, 0.45);
   flex-shrink: 0;
 }
-.tb3-walk-row-title { flex: 1; }
+.tb3-walk-row-title { flex: 1; color: var(--tb3-text); }
 .tb3-walk-row-meta {
   font-size: 9px;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--tb3-text-dim);
 }
 .tb3-walk-row.tb3-walk-row-running .tb3-walk-row-meta {
-  color: rgba(240, 199, 137, 0.95);
+  color: var(--tb3-bronze, #f0c789);
 }
 
 /* ── Walkthrough completion ledger (Task 14) ───────────────────── */
@@ -3156,12 +3156,12 @@ html[data-theme="light"] #page-topology-builder-v3 {
 .tb3-walk-badge-blank {
   width: 14px; height: 14px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--tb3-surface-2);
+  border: 1px solid var(--tb3-border-soft);
   flex-shrink: 0;
 }
 .tb3-walk-row.tb3-walk-row-done .tb3-walk-row-title {
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--tb3-text-mid);
 }
 .tb3-walk-walks-pill-complete {
   color: rgba(93, 161, 75, 0.95) !important;
@@ -3250,7 +3250,7 @@ html[data-theme="light"] #page-topology-builder-v3 {
   font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(201, 138, 54, 0.9);
+  color: var(--tb3-bronze, #c98a36);
   font-weight: 600;
 }
 .tb3-walk-card-kind {

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.6</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:rgba(124,111,247,.12);border:1px solid rgba(124,111,247,.3);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v6.5.7</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "6.5.6",
+  "version": "6.5.7",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v6.5.6 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v6.5.6';
+// Service Worker v6.5.7 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v6.5.7';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23637,23 +23637,34 @@ test('TB v3 walk: _clearWalkHighlight3D resets panX/panY via camera state', (fun
 
 // ── v6.5.2 hotfix tests ──
 
-test('v6.5.6: package.json version is 6.5.6', (function () {
+test('v6.5.7: package.json version is 6.5.7', (function () {
   var pkg = read('package.json');
-  return /"version":\s*"6\.5\.6"/.test(pkg);
+  return /"version":\s*"6\.5\.7"/.test(pkg);
 })());
 
-test('v6.5.6: sw.js CACHE_NAME is netplus-v6.5.6', (function () {
+test('v6.5.7: sw.js CACHE_NAME is netplus-v6.5.7', (function () {
   var sw = read('sw.js');
-  return /netplus-v6\.5\.6/.test(sw);
+  return /netplus-v6\.5\.7/.test(sw);
 })());
 
-test('v6.5.6: index.html version badge is v6.5.6', (function () {
-  return /version-badge[\s\S]*?v6\.5\.6/.test(html);
+test('v6.5.7: index.html version badge is v6.5.7', (function () {
+  return /version-badge[\s\S]*?v6\.5\.7/.test(html);
 })());
 
-test('v6.5.6: app.js APP_VERSION is 6.5.6', (function () {
+test('v6.5.7: app.js APP_VERSION is 6.5.7', (function () {
   var js = read('app.js');
-  return /APP_VERSION\s*=\s*['"]6\.5\.6['"]/.test(js);
+  return /APP_VERSION\s*=\s*['"]6\.5\.7['"]/.test(js);
+})());
+
+test('TB v3 walk: catalog text uses theme tokens, not hardcoded white rgba', (function () {
+  var css = read('features/topology-builder-v3.css');
+  // Catalog rules (not card) — extract those specifically
+  var rules = css.match(/\.tb3-walk-(scen-row|catalog-header|catalog-domain|row|nest)[^{]*\{[^}]*\}/g) || [];
+  for (var i = 0; i < rules.length; i++) {
+    // No hardcoded white text in catalog rules
+    if (/color:\s*rgba\(255,\s*255,\s*255/.test(rules[i])) return false;
+  }
+  return rules.length > 0; // ensure we actually found rules
 })());
 
 test('TB v3 walk: catalog panel uses absolute positioning (slides over canvas, not grid item)', (function () {


### PR DESCRIPTION
User report: 'can't even read the damn thing.' Catalog used hardcoded rgba(255,255,255,*) text — invisible on TB v3's light theme. Fixed by switching all catalog-list color/bg/border to var(--tb3-*) tokens. Card-internal rules unchanged (card has its own dark gradient bg).