### PR TITLE
security(phase3): rate-limit + tighten CORS on notify-me waitlist endpoint

### DIFF
--- a/landing/api/notify.js
+++ b/landing/api/notify.js
@@ -24,10 +24,28 @@
 //                                   for the builder to see
 //   - SUPABASE_URL                — (optional) override; defaults to certanvil project
 //   - SUPABASE_PUBLISHABLE_KEY    — (optional) override; defaults to certanvil pub key
+//   - SUPABASE_SERVICE_ROLE_KEY   — (optional) service-role key for the per-IP-hash
+//                                   rate-limit RPC. If absent, the rate limit is
+//                                   skipped (fail-OPEN) and signups continue —
+//                                   so this ships safely BEFORE the env var is set.
 //
-// Migration to apply BEFORE this code is useful:
+// CORS (Security Phase 3 · M3b): the real signup is a same-origin POST from the
+// certanvil.com landing page (script.js → fetch('/api/notify')), so CORS is only
+// relevant to cross-origin callers. We allowlist the certanvil.com origins and
+// echo the matching Origin back — no more `Access-Control-Allow-Origin: *`, which
+// let any site on the web spam-insert waitlist rows.
+//
+// Rate limiting (Security Phase 3 · M3a): per-IP-hash, 10 POSTs / 1h rolling
+// window, enforced via a Supabase SECURITY DEFINER RPC. Fails OPEN on any infra
+// error (missing key / RPC down / throw) so a Supabase blip never blocks a real
+// signup — the abuse it stops (bulk row spam) is lower-stakes than losing a lead.
+//
+// Migrations to apply BEFORE this code is useful:
 //   supabase/migrations/20260509_notify_signups.sql
-//   (creates the table + RLS policy that lets anon insert)
+//     (creates the table + RLS policy that lets anon insert)
+//   supabase/migrations/20260529_phase3_notify_rate_limit.sql
+//     (creates notify_rate_limit + notify_rl_check_and_increment RPC — deploy
+//      this migration together with this code change)
 //
 // Reading the signups (admin-only):
 //   Open Supabase SQL editor → run:
@@ -37,27 +55,26 @@
 export const config = { runtime: 'edge' };
 
 export default async function handler(req) {
-  // CORS — same origin only is fine, but allow OPTIONS preflight
+  // CORS (M3b) — allowlist the certanvil.com origins; echo the matching Origin.
+  // The real signup is same-origin, so this never blocks legit traffic; it just
+  // stops cross-origin sites from POSTing waitlist rows. OPTIONS preflight gets
+  // the same headers (no ACAO when the Origin isn't allowed → browser blocks it).
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       status: 204,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-      },
+      headers: corsHeaders(req),
     });
   }
 
   if (req.method !== 'POST') {
-    return json({ error: 'Method not allowed' }, 405);
+    return json({ error: 'Method not allowed' }, 405, req);
   }
 
   let body;
   try {
     body = await req.json();
   } catch (e) {
-    return json({ error: 'Invalid JSON body' }, 400);
+    return json({ error: 'Invalid JSON body' }, 400, req);
   }
 
   const email = (body && body.email || '').trim().toLowerCase();
@@ -66,15 +83,32 @@ export default async function handler(req) {
 
   // ── Validate ────────────────────────────────────────────────────────────
   if (!email || !email.includes('@') || email.length > 254) {
-    return json({ error: 'Invalid email' }, 400);
+    return json({ error: 'Invalid email' }, 400, req);
   }
   if (!cert || cert.length > 100) {
-    return json({ error: 'Cert label required' }, 400);
+    return json({ error: 'Cert label required' }, 400, req);
   }
 
   // Honeypot — basic anti-bot. If body includes 'website' field, bail.
+  // Kept BEFORE the rate limit so a tripped bot doesn't spend a real IP's
+  // rate-limit budget (and we still "pretend success" with no side effects).
   if (body.website) {
-    return json({ ok: true }, 200); // pretend success, log nothing
+    return json({ ok: true }, 200, req); // pretend success, log nothing
+  }
+
+  // ── Rate limit (M3a) — per-IP-hash, 10 / 1h, fail-OPEN ───────────────────
+  // Gates row spam from a single IP. Fails OPEN: a missing service-role key or
+  // any RPC error lets the signup through (a Supabase blip must never cost a
+  // real lead). Only an explicit allowed:false from the RPC returns 429.
+  const rl = await checkNotifyRateLimit(req);
+  if (rl.limited) {
+    return json({
+      error: 'rate-limited',
+      message: 'Too many signups from your network · please try again shortly',
+      hourlyLimit: rl.hourlyLimit,
+      currentCount: rl.currentCount,
+      resetsAt: rl.resetsAt,
+    }, 429, req);
   }
 
   // Log the signup (always, even when email service is unconfigured) —
@@ -190,19 +224,116 @@ export default async function handler(req) {
     // tweak the modal copy when persisted_to_supabase: true vs false). Default
     // copy still works for both.
     persisted_to_supabase: persistedToSupabase,
-  }, 200);
+  }, 200, req);
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-function json(payload, status) {
+// CORS allowlist (M3b). The notify form is served from certanvil.com (apex) —
+// www is included defensively in case a visitor lands there. Per-cert subdomains
+// (networkplus.certanvil.com, …) live in separate Vercel projects and never call
+// this endpoint, so they're intentionally NOT here.
+const ALLOWED_ORIGINS = new Set([
+  'https://certanvil.com',
+  'https://www.certanvil.com',
+]);
+
+function corsHeaders(req) {
+  const headers = {
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin',
+  };
+  const origin = req && req.headers && req.headers.get('origin');
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+  }
+  return headers;
+}
+
+function json(payload, status, req) {
   return new Response(JSON.stringify(payload), {
     status: status || 200,
     headers: {
+      ...corsHeaders(req),
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
     },
   });
+}
+
+// ── Rate limit (M3a) ───────────────────────────────────────────────────────
+// Per-IP-hash, 10 POSTs / 1h, via the notify_rl_check_and_increment SECURITY
+// DEFINER RPC (service-role key). FAIL-OPEN on every infra error path: a missing
+// key, a non-2xx RPC response, an empty body, or a thrown fetch all return
+// { limited: false } so the signup proceeds. Only an explicit allowed:false from
+// the RPC returns { limited: true } → 429.
+async function checkNotifyRateLimit(req) {
+  const PASS = { limited: false };
+  const supabaseUrl = process.env.SUPABASE_URL || 'https://appmuaqwuethndvalarl.supabase.co';
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  // No service-role key configured → skip the limit (graceful pre-config; same
+  // soft-degrade philosophy as the rest of this endpoint).
+  if (!supabaseUrl || !serviceKey) {
+    console.warn('[certanvil-notify] SUPABASE_SERVICE_ROLE_KEY missing · rate limit skipped (fail-open)');
+    return PASS;
+  }
+  try {
+    const ipHash = await hashIp(extractIp(req));
+    const resp = await fetch(supabaseUrl + '/rest/v1/rpc/notify_rl_check_and_increment', {
+      method: 'POST',
+      headers: {
+        'apikey': serviceKey,
+        'Authorization': 'Bearer ' + serviceKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ p_ip_hash: ipHash }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.error('[certanvil-notify] Rate-limit RPC failed (fail-open):', resp.status, text);
+      return PASS; // fail-OPEN
+    }
+    const data = await resp.json();
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) {
+      console.error('[certanvil-notify] Rate-limit RPC returned empty (fail-open)');
+      return PASS; // fail-OPEN
+    }
+    if (row.allowed === false) {
+      return {
+        limited: true,
+        hourlyLimit: row.hourly_limit,
+        currentCount: row.current_count,
+        resetsAt: row.resets_at,
+      };
+    }
+    return PASS;
+  } catch (e) {
+    console.error('[certanvil-notify] Rate-limit RPC threw (fail-open):', e && (e.message || String(e)));
+    return PASS; // fail-OPEN
+  }
+}
+
+function extractIp(req) {
+  // Vercel forwards client IP via x-forwarded-for · x-real-ip · cf-connecting-ip
+  return (
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    req.headers.get('cf-connecting-ip') ||
+    '0.0.0.0'
+  );
+}
+
+async function hashIp(ip) {
+  // SHA-256 truncated to first 16 hex chars · raw IP never stored. Distinct salt
+  // from the diagnostic endpoints so the same IP's hashes don't correlate across
+  // tables.
+  const enc = new TextEncoder().encode(ip + '::certanvil-notify-salt-v1');
+  const buf = await crypto.subtle.digest('SHA-256', enc);
+  return Array.from(new Uint8Array(buf))
+    .slice(0, 8)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
 }
 
 function buildUserHtml(cert) {

--- a/supabase/migrations/20260529_phase3_notify_rate_limit.sql
+++ b/supabase/migrations/20260529_phase3_notify_rate_limit.sql
@@ -1,0 +1,188 @@
+-- ══════════════════════════════════════════════════════════════════════════
+-- Security Phase 3 · notify-me waitlist rate limit (v5.x · 2026-05-29)
+-- ══════════════════════════════════════════════════════════════════════════
+-- Closes M3(a) from SECURITY-AUDIT-2026-05-29.md.
+--
+--   M3 · landing/api/notify.js (the "Notify me" waitlist endpoint) had open
+--        CORS `*` AND no rate limit, so anyone could spam-insert notify_signups
+--        rows from any origin. This migration backs the per-IP-hash rate limit;
+--        the CORS tightening + the RPC call ship in the SAME PR (landing/api/
+--        notify.js). Migration and code MUST deploy together — the endpoint
+--        fails OPEN (allows the signup) if this RPC is missing, so applying the
+--        migration first is safe, and shipping the code first just means the
+--        limit isn't enforced until the RPC exists.
+--
+-- Pattern: mirrors diagnostic_signup_rate_limit + diag_signup_check_and_increment
+-- (20260511_diagnostic_pending.sql) — the closest analog (single p_ip_hash arg,
+-- short rolling window). Cap chosen at 10/hour/IP-hash (vs diag_signup's 5/hour):
+-- notify is LESS sensitive than the magic-link endpoint (no email is sent unless
+-- Resend is configured — it's just a waitlist row), and the multi-cert tile UX
+-- legitimately produces a handful of POSTs in one browsing session. 10/hour
+-- leaves genuine enthusiasts unblocked while capping a single IP-hash to ~240
+-- rows/day. The unique (email, cert) constraint already forces a spammer to vary
+-- the email per row, so the per-IP-hash cap is the binding spam ceiling.
+--
+-- IP hashes are SHA-256 truncated to 16 hex chars · raw IP never stored. Rows
+-- auto-age via the cleanup helper below.
+--
+-- How to apply: Supabase Dashboard → SQL Editor → paste → Run. Idempotent
+-- (IF NOT EXISTS / OR REPLACE / DROP-then-CREATE). Run once per environment.
+-- ══════════════════════════════════════════════════════════════════════════
+
+-- Preflight guards — fail loud if a prerequisite migration hasn't been applied.
+do $$
+begin
+  if not exists (select 1 from pg_class where relname = 'notify_signups') then
+    raise exception 'notify_signups not found — apply 20260509_notify_signups.sql first.';
+  end if;
+  if not exists (select 1 from pg_proc where proname = 'is_admin') then
+    raise exception 'is_admin() not found — apply 20260506_phase_c_prime.sql first.';
+  end if;
+end$$;
+
+-- ── 1. notify_rate_limit table ────────────────────────────────────────────
+-- Separate counter from D.3's diagnostic_rate_limit and D.5's
+-- diagnostic_signup_rate_limit. Gates anonymous /api/notify POSTs per IP-hash.
+create table if not exists notify_rate_limit (
+  ip_hash      text primary key,
+  call_count   int not null default 0,
+  first_at     timestamptz not null default now(),
+  last_at      timestamptz not null default now(),
+  blocked_at   timestamptz                            -- set when an IP trips the per-window cap
+);
+
+create index if not exists idx_notify_rl_last_at
+  on notify_rate_limit (last_at);
+
+comment on table notify_rate_limit is
+  'Notify-me waitlist (/api/notify) rate limiting · per-IP-hash · 10 calls / 1h rolling window. IP hash is SHA-256 truncated to 16 chars · raw IP never stored. Security Phase 3 (M3).';
+
+-- ── 2. RLS · service-role-only writes; admin can read for monitoring ───────
+alter table notify_rate_limit enable row level security;
+
+drop policy if exists "notify_rl_admin_select" on notify_rate_limit;
+create policy "notify_rl_admin_select" on notify_rate_limit
+  for select using (public.is_admin());
+
+-- No insert/update/delete policies for clients — the serverless endpoint calls
+-- the SECURITY DEFINER RPC below (via the service-role key), bypassing RLS.
+
+-- ── 3. notify_rl_check_and_increment(ip_hash) ─────────────────────────────
+-- Atomic check + upsert. 10 notify-me POSTs per IP-hash per 1h rolling window.
+-- Mirrors diag_signup_check_and_increment (same shape + locking) with a higher
+-- cap (see header rationale). Returns (allowed, current_count, hourly_limit,
+-- resets_at) so the endpoint can surface them in the 429 body.
+create or replace function notify_rl_check_and_increment(
+  p_ip_hash text
+)
+returns table(
+  allowed boolean,
+  current_count int,
+  hourly_limit int,
+  resets_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_count int;
+  v_first_at timestamptz;
+  v_limit constant int := 10;
+  v_window constant interval := interval '1 hour';
+begin
+  -- Lock the row for the duration of the check + update
+  select call_count, first_at
+    into v_count, v_first_at
+    from notify_rate_limit
+    where ip_hash = p_ip_hash
+    for update;
+
+  -- Fresh IP (or row never seen): insert + allow
+  if v_count is null then
+    insert into notify_rate_limit (ip_hash, call_count, first_at, last_at)
+      values (p_ip_hash, 1, now(), now());
+    return query select true, 1, v_limit, now() + v_window;
+    return;
+  end if;
+
+  -- Window expired · reset counter
+  if (now() - v_first_at) > v_window then
+    update notify_rate_limit
+      set call_count = 1, first_at = now(), last_at = now(), blocked_at = null
+      where ip_hash = p_ip_hash;
+    return query select true, 1, v_limit, now() + v_window;
+    return;
+  end if;
+
+  -- Within window · cap exceeded
+  if (v_count + 1) > v_limit then
+    update notify_rate_limit
+      set last_at = now(), blocked_at = coalesce(blocked_at, now())
+      where ip_hash = p_ip_hash;
+    return query select false, v_count, v_limit, v_first_at + v_window;
+    return;
+  end if;
+
+  -- Within window + under cap · increment
+  update notify_rate_limit
+    set call_count = call_count + 1, last_at = now()
+    where ip_hash = p_ip_hash;
+  return query select true, v_count + 1, v_limit, v_first_at + v_window;
+end;
+$$;
+
+comment on function notify_rl_check_and_increment is
+  'Atomic check + increment for the notify-me waitlist rate limit. 10/hour/IP-hash. Returns (allowed, current_count, hourly_limit, resets_at). Service-role only — clients should never call this directly. Security Phase 3 (M3).';
+
+-- ── 4. Cleanup helper · purges rows older than 7 days ──────────────────────
+-- Can be wired to pg_cron later. For now, runnable manually:
+--   select notify_rl_purge_old();
+create or replace function notify_rl_purge_old()
+returns int
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_deleted int;
+begin
+  delete from notify_rate_limit
+    where last_at < (now() - interval '7 days');
+  get diagnostics v_deleted = row_count;
+  return v_deleted;
+end;
+$$;
+
+comment on function notify_rl_purge_old is
+  'Deletes notify_rate_limit rows whose last_at is more than 7 days old. Safe to run via cron.';
+
+-- ══════════════════════════════════════════════════════════════════════════
+-- Verify (run manually as the relevant role)
+-- ══════════════════════════════════════════════════════════════════════════
+-- select notify_rl_check_and_increment('test-hash-001');
+--   → (true, 1, 10, now() + 1h)
+-- repeat 10× quickly:
+--   → after 10th call: (true, 10, 10, ...) → 11th: (false, 10, 10, ...)
+-- select * from notify_rate_limit limit 1;   -- as admin → 1 row; as anon → []
+-- select notify_rl_purge_old();              -- as admin → returns 0 fresh
+
+-- ══════════════════════════════════════════════════════════════════════════
+-- ROLLBACK  (backout plan — change-management discipline · v5.x Phase 3)
+-- ══════════════════════════════════════════════════════════════════════════
+-- Forward-only in prod. This block is the documented MANUAL reversal, tested on
+-- a throwaway run before merge. To revert, run the following in Supabase
+-- Dashboard → SQL Editor (production), in this order. NOTE: only roll this back
+-- together with reverting landing/api/notify.js to the no-rate-limit version —
+-- the endpoint fails OPEN, so dropping the RPC alone just disables enforcement
+-- (signups still succeed), but leaving the endpoint calling a missing RPC means
+-- every POST logs a fail-open warning.
+--
+--   drop function if exists notify_rl_purge_old();
+--   drop function if exists notify_rl_check_and_increment(text);
+--   drop policy if exists "notify_rl_admin_select" on notify_rate_limit;
+--   drop table if exists notify_rate_limit;
+--
+-- No data migration needed — notify_rate_limit holds only ephemeral counters
+-- (no signup data; that lives in notify_signups and is untouched here).
+-- ══════════════════════════════════════════════════════════════════════════

--- a/supabase/migrations/20260529_phase3_notify_rate_limit.sql
+++ b/supabase/migrations/20260529_phase3_notify_rate_limit.sql
@@ -25,12 +25,14 @@
 -- IP hashes are SHA-256 truncated to 16 hex chars · raw IP never stored. Rows
 -- auto-age via the cleanup helper below.
 --
--- How to apply: Supabase Dashboard → SQL Editor → paste → Run. Idempotent
--- (IF NOT EXISTS / OR REPLACE / DROP-then-CREATE). Run once per environment.
+-- How to apply: Supabase Dashboard → SQL Editor → paste WHOLE file → Run.
+-- Idempotent (IF NOT EXISTS / OR REPLACE / DROP-then-CREATE). Run once per env.
+-- NOTE: uses uniquely-named dollar-quote tags ($pf$ / $rl$ / $purge$) instead of
+-- bare $$ so a partial/truncated paste fails loudly rather than mis-pairing.
 -- ══════════════════════════════════════════════════════════════════════════
 
 -- Preflight guards — fail loud if a prerequisite migration hasn't been applied.
-do $$
+do $pf$
 begin
   if not exists (select 1 from pg_class where relname = 'notify_signups') then
     raise exception 'notify_signups not found — apply 20260509_notify_signups.sql first.';
@@ -38,7 +40,8 @@ begin
   if not exists (select 1 from pg_proc where proname = 'is_admin') then
     raise exception 'is_admin() not found — apply 20260506_phase_c_prime.sql first.';
   end if;
-end$$;
+end
+$pf$;
 
 -- ── 1. notify_rate_limit table ────────────────────────────────────────────
 -- Separate counter from D.3's diagnostic_rate_limit and D.5's
@@ -84,7 +87,7 @@ returns table(
 language plpgsql
 security definer
 set search_path = public
-as $$
+as $rl$
 declare
   v_count int;
   v_first_at timestamptz;
@@ -129,8 +132,8 @@ begin
     set call_count = call_count + 1, last_at = now()
     where ip_hash = p_ip_hash;
   return query select true, v_count + 1, v_limit, v_first_at + v_window;
-end;
-$$;
+end
+$rl$;
 
 comment on function notify_rl_check_and_increment is
   'Atomic check + increment for the notify-me waitlist rate limit. 10/hour/IP-hash. Returns (allowed, current_count, hourly_limit, resets_at). Service-role only — clients should never call this directly. Security Phase 3 (M3).';
@@ -143,7 +146,7 @@ returns int
 language plpgsql
 security definer
 set search_path = public
-as $$
+as $purge$
 declare
   v_deleted int;
 begin
@@ -151,8 +154,8 @@ begin
     where last_at < (now() - interval '7 days');
   get diagnostics v_deleted = row_count;
   return v_deleted;
-end;
-$$;
+end
+$purge$;
 
 comment on function notify_rl_purge_old is
   'Deletes notify_rate_limit rows whose last_at is more than 7 days old. Safe to run via cron.';
@@ -160,7 +163,7 @@ comment on function notify_rl_purge_old is
 -- ══════════════════════════════════════════════════════════════════════════
 -- Verify (run manually as the relevant role)
 -- ══════════════════════════════════════════════════════════════════════════
--- select notify_rl_check_and_increment('test-hash-001');
+-- select notify_rl_check_and_increment('test-hash-001'::text);
 --   → (true, 1, 10, now() + 1h)
 -- repeat 10× quickly:
 --   → after 10th call: (true, 10, 10, ...) → 11th: (false, 10, 10, ...)
@@ -171,12 +174,12 @@ comment on function notify_rl_purge_old is
 -- ROLLBACK  (backout plan — change-management discipline · v5.x Phase 3)
 -- ══════════════════════════════════════════════════════════════════════════
 -- Forward-only in prod. This block is the documented MANUAL reversal, tested on
--- a throwaway run before merge. To revert, run the following in Supabase
--- Dashboard → SQL Editor (production), in this order. NOTE: only roll this back
--- together with reverting landing/api/notify.js to the no-rate-limit version —
--- the endpoint fails OPEN, so dropping the RPC alone just disables enforcement
--- (signups still succeed), but leaving the endpoint calling a missing RPC means
--- every POST logs a fail-open warning.
+-- live before merge. To revert, run the following in Supabase Dashboard → SQL
+-- Editor (production), in this order. NOTE: only roll this back together with
+-- reverting landing/api/notify.js to the no-rate-limit version — the endpoint
+-- fails OPEN, so dropping the RPC alone just disables enforcement (signups still
+-- succeed), but leaving the endpoint calling a missing RPC means every POST logs
+-- a fail-open warning.
 --
 --   drop function if exists notify_rl_purge_old();
 --   drop function if exists notify_rl_check_and_increment(text);

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -24900,6 +24900,86 @@ console.log('\n\x1b[1m── Security Phase 2 — DB QUICK WINS ──\x1b[0m');
     && /'email_mismatch'/.test(p2));
 })();
 
+// ══════════════════════════════════════════════════════════════════════════
+// Security Phase 3 · notify-me rate limit + CORS (20260529_phase3_notify_rate_limit.sql
+// + landing/api/notify.js). M3a per-IP-hash rate limit (fail-OPEN) · M3b CORS
+// tightened from `*` to the certanvil.com allowlist. See SECURITY-AUDIT-2026-05-29.md.
+// ══════════════════════════════════════════════════════════════════════════
+console.log('\n\x1b[1m── Security Phase 3 — NOTIFY RATE LIMIT + CORS ──\x1b[0m');
+(function () {
+  const p3Path = path.join(ROOT, 'supabase/migrations/20260529_phase3_notify_rate_limit.sql');
+  const p3 = fs.existsSync(p3Path) ? fs.readFileSync(p3Path, 'utf8') : '';
+  const notify = fs.existsSync(path.join(ROOT, 'landing/api/notify.js'))
+    ? fs.readFileSync(path.join(ROOT, 'landing/api/notify.js'), 'utf8') : '';
+
+  // — file + gated-lane convention —
+  test('Sec-P3 migration: 20260529_phase3_notify_rate_limit.sql exists',
+    p3.length > 1000);
+  test('Sec-P3 migration: carries a -- ROLLBACK block (gated-lane discipline, dated >= 2026-05-12)',
+    /-- ROLLBACK/.test(p3));
+  test('Sec-P3 migration: preflight guard requires notify_signups + is_admin()',
+    /notify_signups not found/.test(p3) && /is_admin\(\) not found/.test(p3));
+
+  // — M3a: rate-limit table + RPC (mirrors diag_signup pattern) —
+  test('Sec-P3 M3a: creates notify_rate_limit table (ip_hash PK + counters)',
+    /create\s+table\s+if\s+not\s+exists\s+notify_rate_limit/i.test(p3)
+    && /ip_hash\s+text\s+primary key/i.test(p3)
+    && /call_count\s+int/i.test(p3)
+    && /first_at\s+timestamptz/i.test(p3)
+    && /last_at\s+timestamptz/i.test(p3));
+  test('Sec-P3 M3a: creates notify_rl_check_and_increment RPC',
+    /create\s+or\s+replace\s+function\s+notify_rl_check_and_increment/i.test(p3));
+  test('Sec-P3 M3a: RPC is SECURITY DEFINER with pinned search_path (atomic RL check)',
+    /notify_rl_check_and_increment[\s\S]{0,800}security\s+definer/i.test(p3)
+    && /notify_rl_check_and_increment[\s\S]{0,900}set\s+search_path\s*=\s*public/i.test(p3));
+  test('Sec-P3 M3a: RPC enforces 10-call / 1h window',
+    /v_limit\s+constant\s+int\s*:=\s*10/.test(p3)
+    && /interval\s+'1 hour'/.test(p3));
+  test('Sec-P3 M3a: RLS admin-only select on rate-limit table (clients have no read/write)',
+    /alter\s+table\s+notify_rate_limit\s+enable\s+row\s+level\s+security/i.test(p3)
+    && /notify_rl_admin_select[\s\S]{0,200}is_admin\(\)/i.test(p3));
+  test('Sec-P3 M3a: migration includes purge helper (notify_rl_purge_old)',
+    /create\s+or\s+replace\s+function\s+notify_rl_purge_old/i.test(p3));
+
+  // — M3a: endpoint wiring —
+  test('Sec-P3 M3a: notify.js calls the rate-limit RPC',
+    /\/rest\/v1\/rpc\/notify_rl_check_and_increment/.test(notify));
+  test('Sec-P3 M3a: notify.js hashes client IP (SHA-256, raw IP never stored, distinct salt)',
+    /crypto\.subtle\.digest\(\s*['"]SHA-256['"]/.test(notify)
+    && /certanvil-notify-salt-v1/.test(notify));
+  test('Sec-P3 M3a: notify.js uses the service-role key for the RL RPC',
+    /SUPABASE_SERVICE_ROLE_KEY/.test(notify));
+  test('Sec-P3 M3a: rate limit FAILS OPEN on infra error (missing key / RPC fail / throw)',
+    /rate limit skipped \(fail-open\)/i.test(notify)
+    && /fail-open\)/i.test(notify)
+    && /threw \(fail-open\)/i.test(notify));
+  test('Sec-P3 M3a: notify.js returns 429 only on explicit allowed:false',
+    /row\.allowed\s*===\s*false/.test(notify)
+    && /\}\s*,\s*429\s*,\s*req\s*\)/.test(notify));
+  test('Sec-P3 M3a: rate-limit check sits AFTER the honeypot (bots do not spend RL budget)',
+    /body\.website[\s\S]{0,700}checkNotifyRateLimit\(req\)/.test(notify));
+
+  // — M3b: CORS tightened from `*` to the certanvil.com allowlist —
+  test('Sec-P3 M3b: no Access-Control-Allow-Origin: * anywhere in notify.js',
+    !/Access-Control-Allow-Origin['"]?\s*:\s*['"]\*['"]/.test(notify));
+  test('Sec-P3 M3b: ALLOWED_ORIGINS allowlist contains the certanvil.com origins',
+    /ALLOWED_ORIGINS\s*=\s*new\s+Set\(/.test(notify)
+    && /https:\/\/certanvil\.com/.test(notify)
+    && /https:\/\/www\.certanvil\.com/.test(notify));
+  test('Sec-P3 M3b: corsHeaders echoes an allowlisted Origin + sets Vary: Origin',
+    /ALLOWED_ORIGINS\.has\(origin\)/.test(notify)
+    && /['"]Vary['"]\s*:\s*['"]Origin['"]/.test(notify));
+  test('Sec-P3 M3b: OPTIONS preflight + json() both route through corsHeaders(req)',
+    /headers:\s*corsHeaders\(req\)/.test(notify)
+    && /\.\.\.corsHeaders\(req\)/.test(notify));
+
+  // — graceful-degrade preserved (M3 must not break the existing soft-fail flow) —
+  test('Sec-P3 graceful: notify.js still soft-fails the Supabase insert (try/catch preserved)',
+    /try\s*\{[\s\S]{0,2000}\/rest\/v1\/notify_signups[\s\S]{0,2000}\}\s*catch\s*\(/.test(notify));
+  test('Sec-P3 graceful: notify.js still returns persisted_to_supabase flag (UX contract intact)',
+    /persisted_to_supabase:\s*persistedToSupabase/.test(notify));
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;


### PR DESCRIPTION
## Security Phase 3 — endpoint hardening / spam protection

Closes **M3** from `SECURITY-AUDIT-2026-05-29.md`. `landing/api/notify.js` (the "Notify me" waitlist endpoint) had open CORS `*` **and** no rate limit, so anyone could spam-insert `notify_signups` rows from any origin.

Phases 0–2 untouched (Phase 1 = PR #399 pending apply; Phase 2 = merged PR #400). This PR is **gated-lane** (adds `supabase/migrations/*`).

### M3a — per-IP-hash rate limit (fail-OPEN)
- **New migration** `supabase/migrations/20260529_phase3_notify_rate_limit.sql`, mirroring the `diag_signup` pattern:
  - `notify_rate_limit` table (`ip_hash` PK + counters), admin-only RLS, no client write policies.
  - `notify_rl_check_and_increment(p_ip_hash)` — `SECURITY DEFINER`, `set search_path = public`, **10 POSTs / 1h** rolling window.
  - `notify_rl_purge_old()` 7-day cleanup helper.
  - Preflight guards (`notify_signups` + `is_admin()`), idempotent, **tested `-- ROLLBACK:` block** (dated ≥ 2026-05-12).
- **`notify.js`** calls the RPC via the **service-role key** after validation + honeypot, before the insert/email. **Fails OPEN** on every infra error (missing key / non-2xx / empty body / throw) — a Supabase blip never blocks a real lead. Only an explicit `allowed:false` → **429** (with `resetsAt`/`hourlyLimit`/`currentCount`). IP is SHA-256→16-hex hashed with a notify-specific salt; raw IP never stored.

**Cap rationale (10/h, vs `diag_signup`'s 5/h):** notify is less sensitive (no email sent unless Resend is configured — just a waitlist row), and the multi-cert tile UX legitimately produces several POSTs per session. 10/h keeps enthusiasts unblocked while capping a single IP-hash to ~240 rows/day; `unique(email,cert)` already forces a spammer to vary the email per row.

### M3b — CORS tightened from `*` to an allowlist
- Allowlist `https://certanvil.com` + `https://www.certanvil.com`, echo the matching `Origin`, add `Vary: Origin`. Both the OPTIONS preflight and `json()` now route through `corsHeaders(req)`. The real form is same-origin (`script.js → fetch('/api/notify')`), so legit signups are unaffected; cross-origin row-spam is blocked.

### M8 — skipped (documented)
The only **hardcoded** (non-env) key is `landing/lib/supabase.js:29`, a **static client file with no build step** — `process.env` can't be injected at runtime without introducing build tooling (scope balloon, explicitly out of scope per the brief). Every place env vars *can* work at runtime already follows the pattern: `notify.js` uses `process.env.SUPABASE_PUBLISHABLE_KEY || '<public default>'` (already M8's target state), and `share-fetch.js`/`share-redirect.js` are env-backed. So M8 is effectively satisfied where feasible.

## Deploy steps (founder — migration + code deploy TOGETHER)
1. Supabase Dashboard → SQL Editor → paste & run `20260529_phase3_notify_rate_limit.sql` (idempotent; safe to paste-and-run on live).
2. Landing Vercel project → add env var **`SUPABASE_SERVICE_ROLE_KEY`** (Production + Preview). *(Until set, the rate limit fails OPEN — signups work, limit simply isn't enforced.)*
3. Merge → Vercel redeploys the landing project.

Rollback: documented manual block at the bottom of the migration (drop fns + policy + table; no signup data touched).

## Verification
- `node tests/uat.js` → **+21 Phase 3 guards, all green**; suite at **2668 fails (≤ 2700 MVP baseline; zero net-new)**.
- `node --check` clean on `notify.js` + `uat.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)