### PR TITLE
security(phase5): RBAC formalization + admin audit log + M5 ADR

### DIFF
--- a/docs/decisions/ADR-001-m5-supabase-session-cookies.md
+++ b/docs/decisions/ADR-001-m5-supabase-session-cookies.md
@@ -1,0 +1,68 @@
+# ADR-001 — Supabase session tokens in non-HttpOnly cookies (audit M5)
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Decider:** Founder
+- **Audit ref:** `SECURITY-AUDIT-2026-05-29.md` → M5
+- **Affected code:** `lib/supabase.js:79`, `landing/lib/supabase.js:79`
+
+## Context
+
+CertAnvil is a **thick client + Supabase** app: the browser talks directly to
+Supabase using the public anon key plus the signed-in user's JWT. The Supabase
+JS SDK manages the session (access + refresh tokens) and attaches the bearer
+token to every request it makes from the browser.
+
+To share one session across `networkplus.certanvil.com`, `certanvil.com`, and the
+other per-cert subdomains (Pattern A), the session is persisted via a
+cookie-backed storage adapter on `Domain=.certanvil.com`. Those cookies are
+**not** `HttpOnly` — they cannot be, because the client-side SDK has to read the
+token out of storage to attach it to outbound requests.
+
+**The risk (M5):** because the token store is JS-readable, **any** successful XSS
+on any `*.certanvil.com` page can exfiltrate the session → full account takeover
+across every subdomain. This is *inherent* to the client-direct Supabase model,
+not a coding mistake in our adapter.
+
+## Decision
+
+**Accept the non-HttpOnly token storage as an inherent property of the chosen
+architecture.** Do **not** build a server-side/BFF session layer at this time.
+
+The risk is mitigated by attacking its precondition — XSS — in depth, which is
+what the Phase 4 ship already delivered:
+
+- **Primary:** always-on `escHtml` / `escapeHtml` discipline on every innerHTML
+  sink (escape-then-highlight order is a hard rule — see CLAUDE.md gotchas).
+- **Backstop:** vendored DOMPurify (M6, v7.8.3) over the untrusted sinks (AI
+  output + cross-user/remote admin rows), failing open to the escape layer.
+- **Defence-in-depth (deferred):** CSP `'unsafe-inline'` removal (M7) would add a
+  browser-level backstop, but is high-effort and lower-ROI than M6; tracked
+  separately, not a precondition of this decision.
+
+## Alternatives considered
+
+| Option | Why not (now) |
+|---|---|
+| **BFF / server-side session with HttpOnly cookies** | Correct end-state for a multi-tenant SaaS holding many users' PII, but it is a **multi-week architectural rewrite**: stand up a session service, proxy every Supabase call through it, and re-do auth on both the cert app and the landing project. Unjustified for a **currently single-user, pre-pivot** app whose data-at-risk is one person's quiz progress. |
+| **`@supabase/ssr` cookie chunking** | Improves cookie handling but the access token is still JS-reachable for the browser SDK — does not remove the M5 class of risk. Cosmetic for this threat. |
+| **Drop cross-subdomain session sharing** | Would let cookies be tighter-scoped but breaks the Pattern-A single-sign-on UX across cert subdomains. Not worth it. |
+
+## Consequences
+
+- **Accepted:** a single XSS anywhere on `*.certanvil.com` = account takeover.
+  This is why XSS prevention (escHtml + DOMPurify) is treated as a P0-class
+  invariant in this codebase, and why M7 remains on the roadmap as additional
+  depth.
+- **Bounded blast radius today:** single-user app; the account at risk is the
+  founder's own. No third-party PII is exposed by a takeover.
+- M5 is now **closed as a documented, accepted decision** rather than an open
+  audit finding.
+
+## Revisit trigger (when this decision flips)
+
+Re-open and implement the BFF / HttpOnly-session option **when** the app crosses
+into **paid multi-tenant SaaS holding other users' PII at scale** — i.e. the
+moment a session-takeover would compromise *someone else's* data, not just the
+operator's. At that point the weeks-of-rewrite cost is justified by the changed
+threat model. Until that trigger fires, this ADR stands.

--- a/docs/decisions/ADR-002-rbac-admin-surface.md
+++ b/docs/decisions/ADR-002-rbac-admin-surface.md
@@ -1,0 +1,80 @@
+# ADR-002 — RBAC admin surface + what "formalization" means here (audit Phase 5)
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Decider:** Founder
+- **Audit ref:** `SECURITY-AUDIT-2026-05-29.md` → Phase 5 (RBAC formalization + audit logs), L4
+- **Companion migration:** `supabase/migrations/20260531_phase5_admin_audit_log.sql`
+
+## Context
+
+The audit's Phase-5 line item was "RBAC formalization + audit logs." RBAC itself
+already exists from **Phase C′** (`20260506_phase_c_prime.sql`):
+
+- `profiles.role TEXT NOT NULL DEFAULT 'user'`, constrained `CHECK (role IN ('user','admin'))`.
+- `is_admin()` — `SECURITY DEFINER STABLE`, reads the caller's `profiles.role`.
+- Admin promotion is a **deliberate manual SQL action** only — there is no
+  "promote to admin" UI, by design.
+
+"Formalization" needed a concrete definition so it didn't become speculative
+over-engineering.
+
+## Decision
+
+Formalization here means **two things, and explicitly excludes a third:**
+
+1. **Audit logging (the substantive deliverable)** — an append-only
+   `admin_audit_log` table + `SECURITY DEFINER` triggers recording every
+   privilege-/entitlement-sensitive mutation. Built in the companion migration.
+2. **Documenting the admin surface (this ADR)** — a single place that states
+   which tables grant admin read-all, how, and what an admin can do.
+3. **NOT a role-system expansion.** We deliberately do **not** introduce a
+   role enum type or additional roles (`support`, `readonly`, `billing`, …).
+   The app currently has **one admin** (the founder). Extra roles would be
+   complexity with no consumer; revisit only when a real second role appears.
+
+## The admin surface (policy audit)
+
+Admin authority flows entirely through `is_admin()`. The admin-readable tables —
+each via an `... OR public.is_admin()` SELECT policy:
+
+| Table | Admin grant | Source |
+|---|---|---|
+| `profiles` | SELECT all rows | `20260506_phase_c_prime.sql` |
+| `quiz_history` | SELECT all rows | `20260506_phase_c_prime.sql` |
+| `cert_entitlements` | SELECT all rows | `20260506_phase_c_prime.sql` |
+| `ai_proxy_rate_limit` | SELECT (admin-only) | `20260529_ai_proxy_rate_limit.sql` |
+| `notify_rate_limit` | SELECT (admin-only) | `20260529_phase3_notify_rate_limit.sql` |
+| `admin_audit_log` | SELECT (admin-only) | `20260531_phase5_admin_audit_log.sql` (this phase) |
+
+Service-role-only tables (no admin client policy, written by webhooks/RPCs):
+`subscriptions`, `stripe_events`, `diagnostic_share` (read via token-scoped
+DEFINER fn).
+
+**Privilege-escalation guard (verified):** `profiles` UPDATE is restricted to
+`auth.uid() = id`, so an admin cannot edit *another* user's `role` via a direct
+PostgREST UPDATE — role changes for other users would go through a service-role
+path. The new `trg_audit_profiles_role` trigger now records any role change
+regardless of who makes it.
+
+**Known accepted behaviour (L4):** admin = blanket Pro bypass
+(`20260509_phase_e_admin_bypass.sql`). By design — noted so that any *future*
+admin grant is understood to also confer unlimited paid features. With one
+admin today this is a non-issue; it is a thing to weigh before granting admin
+to anyone else.
+
+## Consequences
+
+- The admin surface is now documented in one place; future tables that need
+  admin read-all should add an `OR public.is_admin()` SELECT policy and a row to
+  the table above.
+- Sensitive mutations are now forensically traceable (`admin_audit_log`).
+- No new role machinery to maintain. The `CHECK (role IN ('user','admin'))`
+  constraint remains the single source of truth for valid roles.
+
+## Revisit trigger
+
+Introduce a real role enum / additional roles **only when** a concrete second
+role is required (e.g. a support agent who can read but not mutate, or a
+billing-only operator). At that point: migrate `role` to an enum or a dedicated
+`roles`/`user_roles` table, and split `is_admin()` into capability checks.

--- a/supabase/migrations/20260531_phase5_admin_audit_log.sql
+++ b/supabase/migrations/20260531_phase5_admin_audit_log.sql
@@ -1,0 +1,167 @@
+-- ══════════════════════════════════════════════════════════════════════════
+-- Security Phase 5 · RBAC formalization + admin audit log (2026-05-31)
+-- ══════════════════════════════════════════════════════════════════════════
+-- Maturity layer on top of the existing RBAC (Phase C′: profiles.role +
+-- is_admin()). This migration adds an APPEND-ONLY forensic trail for the three
+-- privilege-/entitlement-sensitive mutations in the schema:
+--
+--   1. profiles.role        changes  → who became/stopped being admin, and when
+--   2. subscriptions        writes    → tier/status changes (Stripe webhook is
+--                                       the only legit writer; log them all)
+--   3. cert_entitlements    writes    → per-cert access grants / revokes
+--
+-- Design:
+--   • One SECURITY DEFINER trigger fn (admin_audit_record) writes every row, so
+--     the insert bypasses RLS and ALWAYS lands — even for service-role writes.
+--   • actor_id = auth.uid() at write time. NULL actor = service-role / system
+--     (e.g. the Stripe webhook, which carries no end-user JWT).
+--   • admin_audit_log is RLS-locked to admin-SELECT only, with NO insert/update/
+--     delete policy for any client → immutable + append-only from outside.
+--   • profiles fires ONLY on an actual role change (high-volume metadata writes
+--     are NOT logged); the two rare tables log every INSERT/UPDATE/DELETE.
+--
+-- The companion "formalization" half — confirming every admin-readable table
+-- routes through is_admin() and documenting the admin surface — lives in
+-- docs/decisions/ADR-002-rbac-admin-surface.md (no schema change needed there;
+-- Phase C′ already wired the policies correctly).
+--
+-- Run once in Supabase Dashboard → SQL Editor. Idempotent (IF NOT EXISTS /
+-- OR REPLACE / DROP ... IF EXISTS). Mirrors the proven Phase-1/3 RL-migration
+-- shape. Uniquely-tagged dollar quotes ($guard$ / $audit_fn$) per gated-lane
+-- convention; every dollar-quoted block is uniquely tagged.
+-- ══════════════════════════════════════════════════════════════════════════
+
+-- ── 1. Prereq guard · is_admin() must exist (Phase C′) ─────────────────────
+do $guard$
+begin
+  if not exists (select 1 from pg_proc where proname = 'is_admin') then
+    raise exception 'is_admin() not found — apply 20260506_phase_c_prime.sql first.';
+  end if;
+end$guard$;
+
+-- ── 2. admin_audit_log table (append-only forensic trail) ──────────────────
+create table if not exists admin_audit_log (
+  id            bigint generated always as identity primary key,
+  actor_id      uuid,                       -- auth.uid() at write time; NULL = service-role / system
+  action        text not null,              -- 'role_change' | 'subscription_write' | 'entitlement_write'
+  target_table  text not null,              -- the mutated table (tg_table_name)
+  target_op     text not null,              -- 'INSERT' | 'UPDATE' | 'DELETE'
+  target_id     text,                       -- affected row id (profiles/entitlements: id; subscriptions: user_id)
+  old_data      jsonb,                      -- pre-image  (UPDATE/DELETE)
+  new_data      jsonb,                      -- post-image (INSERT/UPDATE)
+  at            timestamptz not null default now()
+);
+
+create index if not exists idx_admin_audit_at      on admin_audit_log (at desc);
+create index if not exists idx_admin_audit_actor   on admin_audit_log (actor_id);
+create index if not exists idx_admin_audit_target  on admin_audit_log (target_table, target_id);
+
+comment on table admin_audit_log is
+  'Append-only audit trail of privilege/entitlement-sensitive mutations (role changes, subscription + entitlement writes). admin-SELECT only; no client write path — only the admin_audit_record() SECURITY DEFINER trigger writes. NULL actor_id = service-role/system.';
+
+-- ── 3. RLS · admin-only read; NO client write policy (append-only) ─────────
+alter table admin_audit_log enable row level security;
+
+drop policy if exists "admin_audit_admin_select" on admin_audit_log;
+create policy "admin_audit_admin_select" on admin_audit_log
+  for select using (public.is_admin());
+
+-- Deliberately NO insert/update/delete policy. The SECURITY DEFINER trigger fn
+-- below is the only writer; it bypasses RLS, so clients can never forge, edit,
+-- or erase an audit row. The log is immutable from any client surface.
+
+-- ── 4. admin_audit_record() · the single SECURITY DEFINER writer ───────────
+-- Invoked by the three AFTER triggers. action label is passed as tg_argv[0].
+-- Captures the calling user (auth.uid()), the operation, the target row id
+-- (resolved generically so one fn serves both id- and user_id-keyed tables),
+-- and full old/new jsonb images.
+create or replace function admin_audit_record()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $audit_fn$
+declare
+  v_rec       jsonb;
+  v_target_id text;
+begin
+  -- Row of interest: NEW on INSERT/UPDATE, OLD on DELETE
+  if (tg_op = 'DELETE') then
+    v_rec := to_jsonb(old);
+  else
+    v_rec := to_jsonb(new);
+  end if;
+
+  -- Generic PK resolution: profiles/cert_entitlements key on `id`, subscriptions on `user_id`
+  v_target_id := coalesce(v_rec->>'id', v_rec->>'user_id');
+
+  insert into admin_audit_log (actor_id, action, target_table, target_op, target_id, old_data, new_data)
+  values (
+    auth.uid(),
+    tg_argv[0],
+    tg_table_name,
+    tg_op,
+    v_target_id,
+    case when tg_op in ('UPDATE', 'DELETE') then to_jsonb(old) else null end,
+    case when tg_op in ('INSERT', 'UPDATE') then to_jsonb(new) else null end
+  );
+
+  -- AFTER trigger: return value is ignored, but must be a valid row
+  if (tg_op = 'DELETE') then
+    return old;
+  end if;
+  return new;
+end;
+$audit_fn$;
+
+comment on function admin_audit_record is
+  'AFTER-trigger writer for admin_audit_log. SECURITY DEFINER so the audit insert always lands (bypasses RLS) regardless of which role triggered it. action label via tg_argv[0].';
+
+-- ── 5. Triggers on the three sensitive tables ──────────────────────────────
+
+-- 5a. profiles.role changes ONLY (skip the constant metadata-flush UPDATEs)
+drop trigger if exists trg_audit_profiles_role on public.profiles;
+create trigger trg_audit_profiles_role
+  after update on public.profiles
+  for each row
+  when (old.role is distinct from new.role)
+  execute function admin_audit_record('role_change');
+
+-- 5b. subscriptions — every write (rare; Stripe webhook is the only legit writer)
+drop trigger if exists trg_audit_subscriptions on public.subscriptions;
+create trigger trg_audit_subscriptions
+  after insert or update or delete on public.subscriptions
+  for each row
+  execute function admin_audit_record('subscription_write');
+
+-- 5c. cert_entitlements — every write (per-cert grant / revoke)
+drop trigger if exists trg_audit_entitlements on public.cert_entitlements;
+create trigger trg_audit_entitlements
+  after insert or update or delete on public.cert_entitlements
+  for each row
+  execute function admin_audit_record('entitlement_write');
+
+-- ══════════════════════════════════════════════════════════════════════════
+-- ROLLBACK:
+--   drop trigger if exists trg_audit_entitlements on public.cert_entitlements;
+--   drop trigger if exists trg_audit_subscriptions on public.subscriptions;
+--   drop trigger if exists trg_audit_profiles_role on public.profiles;
+--   drop function if exists admin_audit_record();
+--   drop policy if exists "admin_audit_admin_select" on admin_audit_log;
+--   drop table if exists admin_audit_log cascade;
+-- ══════════════════════════════════════════════════════════════════════════
+
+-- ══════════════════════════════════════════════════════════════════════════
+-- Verify (run as admin in SQL Editor)
+-- ══════════════════════════════════════════════════════════════════════════
+-- -- triggers present:
+-- select tgname, tgrelid::regclass from pg_trigger
+--   where tgname like 'trg_audit_%' order by 1;
+--   -- expect: trg_audit_entitlements, trg_audit_profiles_role, trg_audit_subscriptions
+--
+-- -- a real role change logs one row (the WHEN gate skips no-op self-sets):
+-- -- update public.profiles set role='admin' where id = auth.uid();
+--
+-- select id, actor_id, action, target_table, target_op, target_id, at
+--   from admin_audit_log order by at desc limit 5;
+-- ══════════════════════════════════════════════════════════════════════════

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -25095,6 +25095,90 @@ console.log('\n\x1b[1m── Security Phase 4 — XSS DEFENCE-IN-DEPTH (DOMPurif
     /^\.env$/m.test(gitig) && /^\*\.key$/m.test(gitig) && /^\*\.pem$/m.test(gitig) && /^secrets\/$/m.test(gitig));
 })();
 
+// ══════════════════════════════════════════════════════════════════════════
+// Security Phase 5 · RBAC formalization + admin audit log
+// (20260531_phase5_admin_audit_log.sql + docs/decisions/ADR-001 + ADR-002)
+// Append-only admin_audit_log table + SECURITY DEFINER triggers on the three
+// privilege/entitlement-sensitive tables (profiles.role, subscriptions,
+// cert_entitlements). M5 closed as an accepted-decision ADR (no BFF build).
+// See SECURITY-AUDIT-2026-05-29.md.
+// ══════════════════════════════════════════════════════════════════════════
+console.log('\n\x1b[1m── Security Phase 5 — RBAC + ADMIN AUDIT LOG ──\x1b[0m');
+(function () {
+  const rd = (p) => { const f = path.join(ROOT, p); return fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : ''; };
+  const p5    = rd('supabase/migrations/20260531_phase5_admin_audit_log.sql');
+  const adr1  = rd('docs/decisions/ADR-001-m5-supabase-session-cookies.md');
+  const adr2  = rd('docs/decisions/ADR-002-rbac-admin-surface.md');
+
+  // — file + gated-lane convention —
+  test('Sec-P5 migration: 20260531_phase5_admin_audit_log.sql exists',
+    p5.length > 1000);
+  test('Sec-P5 migration: carries a -- ROLLBACK block (gated-lane discipline, dated >= 2026-05-12)',
+    /-- ROLLBACK/.test(p5) && /drop table if exists admin_audit_log/i.test(p5));
+  test('Sec-P5 migration: uses uniquely-tagged dollar quotes ($guard$ / $audit_fn$), no bare $$',
+    /\$guard\$/.test(p5) && /\$audit_fn\$/.test(p5) && !/\$\$/.test(p5));
+  test('Sec-P5 migration: preflight guard requires is_admin() (Phase C′ prereq)',
+    /is_admin\(\) not found/.test(p5));
+
+  // — append-only audit table —
+  test('Sec-P5 table: creates admin_audit_log with actor/action/target/old+new jsonb',
+    /create\s+table\s+if\s+not\s+exists\s+admin_audit_log/i.test(p5)
+    && /actor_id\s+uuid/i.test(p5)
+    && /action\s+text\s+not\s+null/i.test(p5)
+    && /target_table\s+text\s+not\s+null/i.test(p5)
+    && /target_op\s+text\s+not\s+null/i.test(p5)
+    && /old_data\s+jsonb/i.test(p5)
+    && /new_data\s+jsonb/i.test(p5));
+  test('Sec-P5 RLS: admin-only SELECT policy via is_admin()',
+    /alter\s+table\s+admin_audit_log\s+enable\s+row\s+level\s+security/i.test(p5)
+    && /"admin_audit_admin_select"[\s\S]{0,120}for\s+select\s+using\s*\(\s*public\.is_admin\(\)\s*\)/i.test(p5));
+  test('Sec-P5 RLS: append-only — NO client insert/update/delete policy',
+    !/create\s+policy[\s\S]{0,200}on\s+admin_audit_log[\s\S]{0,120}for\s+(insert|update|delete)/i.test(p5));
+
+  // — the single SECURITY DEFINER writer —
+  test('Sec-P5 fn: admin_audit_record is SECURITY DEFINER with pinned search_path',
+    /create\s+or\s+replace\s+function\s+admin_audit_record\(\)/i.test(p5)
+    && /admin_audit_record[\s\S]{0,200}security\s+definer/i.test(p5)
+    && /admin_audit_record[\s\S]{0,260}set\s+search_path\s*=\s*public/i.test(p5));
+  test('Sec-P5 fn: captures auth.uid() actor + tg_op + full old/new jsonb images',
+    /auth\.uid\(\)/.test(p5)
+    && /tg_argv\[0\]/.test(p5)
+    && /tg_op/.test(p5)
+    && /to_jsonb\(old\)/i.test(p5) && /to_jsonb\(new\)/i.test(p5));
+  test('Sec-P5 fn: resolves target id generically (id OR user_id)',
+    /coalesce\(\s*v_rec->>'id'\s*,\s*v_rec->>'user_id'\s*\)/i.test(p5));
+
+  // — triggers on the three sensitive tables —
+  test('Sec-P5 trigger: profiles fires ONLY on a real role change (skips metadata flushes)',
+    /create\s+trigger\s+trg_audit_profiles_role[\s\S]{0,200}after\s+update\s+on\s+public\.profiles/i.test(p5)
+    && /when\s*\(\s*old\.role\s+is\s+distinct\s+from\s+new\.role\s*\)/i.test(p5)
+    && /execute\s+function\s+admin_audit_record\('role_change'\)/i.test(p5));
+  test('Sec-P5 trigger: subscriptions logs every write (insert/update/delete)',
+    /create\s+trigger\s+trg_audit_subscriptions[\s\S]{0,200}after\s+insert\s+or\s+update\s+or\s+delete\s+on\s+public\.subscriptions/i.test(p5)
+    && /execute\s+function\s+admin_audit_record\('subscription_write'\)/i.test(p5));
+  test('Sec-P5 trigger: cert_entitlements logs every write (insert/update/delete)',
+    /create\s+trigger\s+trg_audit_entitlements[\s\S]{0,200}after\s+insert\s+or\s+update\s+or\s+delete\s+on\s+public\.cert_entitlements/i.test(p5)
+    && /execute\s+function\s+admin_audit_record\('entitlement_write'\)/i.test(p5));
+
+  // — M5 decision (ADR-001): accept-as-inherent, no BFF unless trigger fires —
+  test('Sec-P5 M5: ADR-001 exists and records an ACCEPTED accept-as-inherent decision',
+    adr1.length > 800
+    && /Status:\*\*\s*Accepted/i.test(adr1)
+    && /accept the non-HttpOnly token storage as an inherent property/i.test(adr1));
+  test('Sec-P5 M5: ADR-001 documents the BFF revisit trigger (multi-tenant PII at scale)',
+    /Revisit trigger/i.test(adr1)
+    && /multi-tenant SaaS/i.test(adr1)
+    && /HttpOnly/i.test(adr1));
+
+  // — formalization (ADR-002): admin surface documented, no speculative roles —
+  test('Sec-P5 formalization: ADR-002 documents the admin surface + is_admin() routing',
+    adr2.length > 800
+    && /admin surface/i.test(adr2)
+    && /is_admin\(\)/.test(adr2));
+  test('Sec-P5 formalization: ADR-002 explicitly excludes a speculative role-enum expansion',
+    /NOT a role-system expansion/i.test(adr2));
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;


### PR DESCRIPTION
## Security Phase 5 — RBAC formalization + admin audit logs + M5 decision

Continues the CertAnvil security roadmap (deferred items from the 2026-05-29 ship). Closes **M5** (decision) and the **Phase 5 RBAC formalization + audit logs** line item. **M7 (CSP `unsafe-inline`) is intentionally deferred** — it's a dedicated multi-session effort (≈175 inline handlers to migrate); see notes below.

### What's in this PR

**1. Gated migration — `supabase/migrations/20260531_phase5_admin_audit_log.sql`**
- Append-only `admin_audit_log` table: `actor_id` (NULL = service-role/system), `action`, `target_table`, `target_op`, `target_id`, `old_data`/`new_data` jsonb, `at`.
- RLS: admin-`SELECT` only via `is_admin()`; **no client insert/update/delete policy** → immutable from any client.
- `admin_audit_record()` `SECURITY DEFINER` trigger fn = the single writer (bypasses RLS so even service-role writes log; captures `auth.uid()` + `tg_op` + full old/new images; generic `id`/`user_id` PK resolution).
- Triggers: `profiles` fires **only on a real role change** (skips constant metadata flushes); `subscriptions` + `cert_entitlements` log every insert/update/delete.
- Pinned `search_path`, uniquely-tagged dollar quotes (`$guard$`/`$audit_fn$`), tested `-- ROLLBACK:` block, idempotent, `is_admin()` prereq guard.

**2. M5 decision — `docs/decisions/ADR-001-m5-supabase-session-cookies.md`**
- **Accept-as-inherent.** Non-HttpOnly Supabase session cookies are intrinsic to the client-direct SDK; mitigation is the already-shipped escHtml + DOMPurify (M6) XSS depth. Records the revisit trigger (multi-tenant PII at scale → BFF). **No BFF built**, per founder instruction.

**3. Formalization — `docs/decisions/ADR-002-rbac-admin-surface.md`**
- Documents the `is_admin()` admin surface (which tables grant admin read-all + how) and the deliberate choice **not** to expand into a speculative role enum (one admin today). Notes the L4 admin=Pro-bypass behaviour.

**4. UAT — `tests/uat.js`**
- +17 Sec-P5 guards mirroring the Sec-P1..P4 IIFE blocks. **All 17 pass.**

### Verification
- `node tests/uat.js` → **2668 failed ≤ 2700 baseline, ZERO net-new** (block is purely additive; pre-existing fail set unchanged from main). 17/17 Sec-P5 pass.
- `node --check tests/uat.js` clean.
- No served-asset change (app.js/sw.js/index.html/styles.css untouched) → **no version/cache bump** required.

### Founder steps after merge (gated lane)
- Paste `20260531_phase5_admin_audit_log.sql` into Supabase SQL Editor (cert-app project) — idempotent.
- No env-var or redeploy needed (pure DB; no endpoint reads it).

### Required check
"UAT + Playwright". Lighthouse + Deploy Preview failing is expected/non-blocking. Auto-merge is OFF — **squash-merge manually** after the check is green and the branch is up-to-date with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)