### PR TITLE
SR cloud cert-keying — scope cloud SR state per cert (v7.29.0, gated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.29.0 | SR cloud cert-keying — metadata.sr.<certId> (gated; prevents cross-cert overwrite) |
 | v7.28.0 | Post-ship fixes: cert-specific page titles + theme-toggle icon + Settings desktop layout |
 | v7.27.0 | SR #8 top-up AI fallback — generate fresh weak-topic practice when no spare review cards |
 | v7.26.0 | SR Phase 6b: #8 top-up light-day practice — extra practice on weak topics, never reschedules |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.28.0
+// Network+ AI Quiz — app.js  v7.29.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.28.0';
+const APP_VERSION = '7.29.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/cloud-store.js
+++ b/cloud-store.js
@@ -266,6 +266,13 @@
     } catch (e) { return []; }
   }
 
+  // Active cert id (subdomain-derived; set by app.js as window.CURRENT_CERT).
+  // SR cloud state is cert-scoped under metadata.sr.<certId> so one cert's sync
+  // cannot overwrite another's (the localStorage queue is already per-subdomain).
+  function _ccCert() {
+    return (typeof window !== 'undefined' && window.CURRENT_CERT) ? window.CURRENT_CERT : 'netplus';
+  }
+
   // Read all USER_DATA keys from localStorage, structure for cloud write
   function buildJsonbFromLocalStorage() {
     var out = {};
@@ -280,6 +287,14 @@
       // Parse JSON-shaped values, leave strings as-is
       var parsed;
       try { parsed = JSON.parse(raw); } catch (e) { parsed = raw; }
+      // Cert-scope the SR queue: metadata.sr.<certId>.queue (never flat sr_queue).
+      if (cloudKey === 'sr_queue') {
+        var cert = _ccCert();
+        if (!out.sr) out.sr = {};
+        if (!out.sr[cert]) out.sr[cert] = {};
+        out.sr[cert].queue = parsed;
+        return;
+      }
       out[cloudKey] = parsed;
     });
     return out;
@@ -288,7 +303,26 @@
   // Inverse of buildJsonbFromLocalStorage — write cloud jsonb back to localStorage
   function applyJsonbToLocalStorage(meta) {
     if (!meta || typeof meta !== 'object') return;
+    var cert = _ccCert();
     Object.keys(meta).forEach(function (cloudKey) {
+      // Cert-scoped SR: pull only THIS cert's queue out of metadata.sr.<certId>.
+      if (cloudKey === 'sr') {
+        var certSr = (meta.sr && meta.sr[cert]) ? meta.sr[cert] : null;
+        if (certSr && certSr.queue != null) {
+          var q = certSr.queue;
+          try { localStorage.setItem('nplus_sr_queue', typeof q === 'string' ? q : JSON.stringify(q)); } catch (e) {}
+        }
+        return;
+      }
+      // Backward-compat: legacy flat metadata.sr_queue (pre-cert-scoping). Only
+      // adopt it when there's no per-cert entry for the active cert, so we never
+      // clobber the new structure. The next flush rewrites it cert-scoped.
+      if (cloudKey === 'sr_queue') {
+        if (meta.sr && meta.sr[cert] && meta.sr[cert].queue != null) return;
+        var v = meta.sr_queue;
+        if (v != null) { try { localStorage.setItem('nplus_sr_queue', typeof v === 'string' ? v : JSON.stringify(v)); } catch (e) {} }
+        return;
+      }
       var localKey = 'nplus_' + cloudKey;
       // Skip non-user-data keys defensively (in case jsonb has extra fields like
       // role / migration_v1_at / etc. that shouldn't pollute localStorage)
@@ -374,11 +408,24 @@
         if (raw) examDate = raw;
       } catch (e) {}
 
-      var update = { metadata: jsonb };
-      if (examDate) update.exam_date = examDate;
-
+      // metadata.sr is cert-scoped, but the column write is a full replace built
+      // from THIS subdomain's localStorage (which only knows its own cert). Read
+      // the existing metadata.sr first and merge ours over it, preserving OTHER
+      // certs' SR sub-objects — otherwise flushing one cert wipes the rest.
+      var writeProfile = function (mergedSr) {
+        if (mergedSr && Object.keys(mergedSr).length) jsonb.sr = mergedSr;
+        var update = { metadata: jsonb };
+        if (examDate) update.exam_date = examDate;
+        return sb.from('profiles').update(update).eq('id', userId);
+      };
       ops.push(
-        sb.from('profiles').update(update).eq('id', userId)
+        sb.from('profiles').select('metadata').eq('id', userId).single().then(function (res) {
+          var existingSr = (res && res.data && res.data.metadata && res.data.metadata.sr) || {};
+          var merged = Object.assign({}, existingSr, (jsonb.sr || {}));   // our cert overrides, others preserved
+          return writeProfile(merged);
+        }, function () {
+          return writeProfile(jsonb.sr);   // read failed — write our cert's sr only
+        })
       );
     }
 

--- a/index.html
+++ b/index.html
@@ -718,7 +718,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.28.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.29.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.28.0",
+  "version": "7.29.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.28.0
+   Network+ AI Quiz — styles.css  v7.29.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.28.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.28.0';
+// Service Worker v7.29.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.29.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -7527,6 +7527,48 @@ test('v7.28.0 titles: _syncPageHeaderCert defined (cert name + code) and wired i
     && (() => { const b = _fnBody(js, '_syncPageHeaderCert'); return b && /CERT_PACK\.meta\.name/.test(b) && /CERT_CODE/.test(b); })());
 test('v7.28.0 settings: study-setup sections default to full width (kills the desktop 1/12 squish)',
   (() => { const dg = read('dg-system.css'); return /\[data-group="study-setup"\]\s*section\.settings-section\{grid-column:1 \/ -1;\}/.test(dg); })());
+// ── Cloud cert-keying: SR cloud state scoped to metadata.sr.<certId> (gated) ──
+test('cloud cert-keying: _ccCert reads window.CURRENT_CERT (subdomain-derived)',
+  (() => { const cjs = read('cloud-store.js'); return /function\s+_ccCert\s*\(/.test(cjs) && /window\.CURRENT_CERT/.test(cjs); })());
+test('cloud cert-keying: buildJsonb writes sr per-cert (out.sr[cert].queue), never flat sr_queue',
+  (() => { const b = _fnBody(read('cloud-store.js'), 'buildJsonbFromLocalStorage'); return b && /out\.sr\[cert\]\.queue\s*=\s*parsed/.test(b) && /_ccCert\(\)/.test(b); })());
+test('cloud cert-keying: applyJsonb pulls this cert + legacy sr_queue fallback',
+  (() => { const b = _fnBody(read('cloud-store.js'), 'applyJsonbToLocalStorage'); return b && /cloudKey === 'sr'/.test(b) && /meta\.sr\[cert\]/.test(b) && /cloudKey === 'sr_queue'/.test(b); })());
+test('cloud cert-keying: doFlush read-merge-writes metadata.sr (preserves other certs)',
+  (() => { const b = _fnBody(read('cloud-store.js'), 'doFlush'); return b && /select\('metadata'\)/.test(b) && /Object\.assign\(\{\},\s*existingSr/.test(b); })());
+test('cloud cert-keying: vm — buildJsonb cert-scopes sr_queue, leaves other keys flat',
+  (() => {
+    try {
+      const cjs = read('cloud-store.js');
+      const cc = _fnBody(cjs, '_ccCert'); const build = _fnBody(cjs, 'buildJsonbFromLocalStorage');
+      if (!cc || !build) return false;
+      const vm = require('vm');
+      const store = { 'nplus_sr_queue': JSON.stringify([{ q: 'a' }]), 'nplus_streak': JSON.stringify({ current: 3 }) };
+      const ctx = { USER_DATA_KEYS: new Set(['nplus_sr_queue', 'nplus_streak']), TABLE_BACKED_KEYS: new Set(), localStorage: { getItem: (k) => (k in store ? store[k] : null) }, window: { CURRENT_CERT: 'secplus' }, JSON: JSON, Object: Object };
+      vm.createContext(ctx);
+      const out = vm.runInContext(cc + '\n' + build + '\nbuildJsonbFromLocalStorage();', ctx);
+      return out && out.sr && out.sr.secplus && Array.isArray(out.sr.secplus.queue) && out.sr.secplus.queue[0].q === 'a'
+        && out.sr_queue === undefined && out.streak && out.streak.current === 3;
+    } catch (e) { return false; }
+  })());
+test('cloud cert-keying: vm — applyJsonb extracts this cert; legacy flat sr_queue fallback',
+  (() => {
+    try {
+      const cjs = read('cloud-store.js');
+      const cc = _fnBody(cjs, '_ccCert'); const apply = _fnBody(cjs, 'applyJsonbToLocalStorage');
+      if (!cc || !apply) return false;
+      const vm = require('vm');
+      const sets = {};
+      const ctx = { USER_DATA_KEYS: new Set(['nplus_sr_queue', 'nplus_streak']), TABLE_BACKED_KEYS: new Set(), localStorage: { setItem: (k, v) => { sets[k] = v; } }, window: { CURRENT_CERT: 'secplus' }, JSON: JSON, Object: Object };
+      vm.createContext(ctx);
+      vm.runInContext(cc + '\n' + apply + '\napplyJsonbToLocalStorage({sr:{secplus:{queue:[1,2]},netplus:{queue:[9]}}});', ctx);
+      const perCert = sets['nplus_sr_queue'] === JSON.stringify([1, 2]);   // secplus, not netplus
+      delete sets['nplus_sr_queue'];
+      vm.runInContext('applyJsonbToLocalStorage({sr_queue:[7,7]});', ctx);
+      const legacy = sets['nplus_sr_queue'] === JSON.stringify([7, 7]);     // flat fallback
+      return perCert && legacy;
+    } catch (e) { return false; }
+  })());
 test('v4.74.0 CSS: .sr-option pickable button styled', css.includes('.sr-option'));
 test('v4.74.0 CSS: .sr-confidence-confident green styled', css.includes('.sr-confidence-confident'));
 test('v4.74.0 CSS: .sr-confidence-uncertain yellow styled', css.includes('.sr-confidence-uncertain'));


### PR DESCRIPTION
## What
Cert-scopes spaced-repetition cloud state so a signed-in user reviewing on 2+ certs no longer overwrites another cert's SR queue. Resolves the all-cert cloud-keying must-verify from the SR enhancements program.

`metadata.sr_queue` (flat, shared across all cert subdomains via the `.certanvil.com` cookie profile) → `metadata.sr.<certId>.queue`.

## Changes (`cloud-store.js` only + UAT)
- `_ccCert()` — active cert from `window.CURRENT_CERT` (subdomain-derived).
- `buildJsonbFromLocalStorage` — writes `nplus_sr_queue` → `metadata.sr.<cert>.queue` (never flat).
- `applyJsonbToLocalStorage` — hydrates only **this** cert's queue; legacy flat `metadata.sr_queue` still adopted when no per-cert entry exists (backward-compatible, self-heals on next flush).
- `doFlush` — the metadata column write is a full replace built from one subdomain's localStorage, so it now **reads existing `metadata.sr` first and merges our cert's sub-object over it**, preserving other certs' SR (otherwise one cert's flush wipes the rest).
- **No SQL migration** — `metadata` is schemaless jsonb; reshape is handled in-code with backward-compat.
- `exam_date` stays a shared column for now (UI countdown, not data-losing) — separate follow-up.

## Tests
UAT 4073/4073, incl. 6 cloud-keying guards (2 vm tests: build cert-scopes; apply extracts this cert + legacy fallback). chromium+landing E2E green on main.

## ⚠️ Gated — smoke-test on the preview branch before merge
This touches `cloud-store.js` + cloud data safety and was **not** validated against live Supabase solo. Before merging, on the auto-spun Vercel preview + Supabase branch DB:
1. Sign in. On `secplus` preview, build an SR queue (get a quiz question wrong); confirm cloud `metadata.sr.secplus.queue` is written (not flat `sr_queue`).
2. Switch to `netplus`, build a different SR queue; confirm `metadata.sr.netplus.queue` is written and `metadata.sr.secplus.queue` is **preserved** (read-merge-write).
3. Reload each cert → hydrate restores that cert's own queue (no cross-contamination).
4. Backward-compat: seed a flat `metadata.sr_queue`, hydrate → it loads, then a flush rewrites it cert-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)