### PR TITLE
Onboarding / first-run routing + tier chrome (gated, ?onb=1 off by default)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.30.0 | Onboarding: lobby router + first-run activation (short calibration) + tier chrome (quota meter + Pro switcher), gated behind ?onb=1 |
 | v7.29.1 | Dark-mode fix: cert-switcher lettermark glyphs were near-white on cream (invisible) |
 | v7.29.0 | SR cloud cert-keying — metadata.sr.<certId> (gated; prevents cross-cert overwrite) |
 | v7.28.0 | Post-ship fixes: cert-specific page titles + theme-toggle icon + Settings desktop layout |

--- a/app.js
+++ b/app.js
@@ -4533,7 +4533,15 @@ function dismissDiagnosticCta(ev) {
 // Top-level entry point — wired to the "Take the Diagnostic" button on the
 // home CTA. Confirms intent, fetches 20 Qs across all domains, then enters
 // the quiz flow.
-async function startDiagnostic() {
+async function startDiagnostic(opts) {
+  // v7.30.0: parameterized for the onboarding short-calibration. Called with NO
+  // args from the home Pass-Plan CTA → identical 20-Q Baseline Diagnostic. The
+  // ?onb=1 first-run passes { count, topic, skipConfirm, onboarding, onComplete,
+  // priorSession, mock } to run a reduced calibration that hands real readiness
+  // back to the first-run UI instead of the Pass-Plan results page.
+  opts = opts || {};
+  const N = (typeof opts.count === 'number' && opts.count > 0) ? opts.count : DIAGNOSTIC_QUESTION_COUNT;
+  const topic = opts.topic || MIXED_TOPIC;
   const key = (typeof getApiKey === 'function') ? getApiKey() : (localStorage.getItem(STORAGE.KEY) || '');
   // v4.99.46 fix: signed-in Pro users route through the server proxy (no
   // client BYOK key needed). validateApiKey() returns null for signed-in
@@ -4544,16 +4552,18 @@ async function startDiagnostic() {
   // v4.99.33 fix for Generate Quiz / Exam / Drills (all 5 of those use
   // validateApiKey at the top of their start* function — startDiagnostic
   // was missed because it predates the unified gate).
-  const keyErr = validateApiKey(key);
-  if (keyErr) {
-    showToast(keyErr, 'error');
-    if (typeof goSettings === 'function') goSettings();
-    return;
+  if (!opts.mock) {
+    const keyErr = validateApiKey(key);
+    if (keyErr) {
+      showToast(keyErr, 'error');
+      if (typeof goSettings === 'function') goSettings();
+      return;
+    }
   }
-  if (!confirm('Take the Baseline Diagnostic? 20 questions, ~30 minutes, single sitting. You can quit mid-flow but progress will be lost.')) return;
+  if (!opts.skipConfirm && !confirm('Take the Baseline Diagnostic? 20 questions, ~30 minutes, single sitting. You can quit mid-flow but progress will be lost.')) return;
 
   showPage('loading');
-  if (typeof showLoading === 'function') showLoading('Generating your diagnostic — 20 calibrated questions across all 5 domains…');
+  if (typeof showLoading === 'function') showLoading('Generating your diagnostic — ' + N + ' calibrated questions…');
   // v4.82.1: smooth loading bar across the diagnostic flow too.
   _loadingProgressBegin('Generating diagnostic questions…');
 
@@ -4565,21 +4575,28 @@ async function startDiagnostic() {
     // select / order / cli-sim / topology question types — and PBQs were
     // sneaking in via injectPBQs (called from fetchQuestions for n>=10).
     // Bump buffer + filter to keep MCQ-only flow.
-    const buffer = Math.max(8, Math.ceil(DIAGNOSTIC_QUESTION_COUNT * 0.4));
+    const buffer = Math.max(8, Math.ceil(N * 0.4));
     const _isMcq = (q) => q && q.options && typeof q.options === 'object' && !Array.isArray(q.options) &&
       Object.keys(q.options).length === 4 && typeof q.answer === 'string' && q.answer.length === 1 &&
       'ABCD'.includes(q.answer);
-    let qs = await fetchQuestions(key, MIXED_TOPIC, 'Mixed', DIAGNOSTIC_QUESTION_COUNT + buffer);
-    _loadingProgressUpdate('Filtering to MCQ-only…', 60);
-    qs = (qs || []).filter(_isMcq).slice(0, DIAGNOSTIC_QUESTION_COUNT);
-    if (qs.length < DIAGNOSTIC_QUESTION_COUNT) {
-      // Try one retry-to-fill to recover from a partial first batch.
-      const deficit = DIAGNOSTIC_QUESTION_COUNT - qs.length;
-      _loadingProgressUpdate('Topping up (' + deficit + ' more)…', 75);
-      try {
-        const more = await fetchQuestions(key, MIXED_TOPIC, 'Mixed', deficit + buffer);
-        qs = qs.concat((more || []).filter(_isMcq).slice(0, deficit));
-      } catch (_) { /* swallow — we ship what we have */ }
+    let qs;
+    if (opts.mock && typeof _onbMockQuestions === 'function') {
+      // Guarded onboarding-preview path — exercise the full calibration flow
+      // without an API key. Only reachable via startDiagnostic({mock:true}).
+      qs = _onbMockQuestions(N);
+    } else {
+      qs = await fetchQuestions(key, topic, 'Mixed', N + buffer);
+      _loadingProgressUpdate('Filtering to MCQ-only…', 60);
+      qs = (qs || []).filter(_isMcq).slice(0, N);
+      if (qs.length < N) {
+        // Try one retry-to-fill to recover from a partial first batch.
+        const deficit = N - qs.length;
+        _loadingProgressUpdate('Topping up (' + deficit + ' more)…', 75);
+        try {
+          const more = await fetchQuestions(key, topic, 'Mixed', deficit + buffer);
+          qs = qs.concat((more || []).filter(_isMcq).slice(0, deficit));
+        } catch (_) { /* swallow — we ship what we have */ }
+      }
     }
     if (qs.length === 0) {
       throw new Error('Could not generate diagnostic questions. Please try again in a moment.');
@@ -4592,7 +4609,11 @@ async function startDiagnostic() {
       currentIdx: 0,
       startedAt: Date.now(),
       pickedLetter: null,
-      confidence: null
+      confidence: null,
+      // v7.30.0 onboarding hooks (null for the normal Baseline Diagnostic):
+      onboarding: opts.onboarding || null,
+      onComplete: (typeof opts.onComplete === 'function') ? opts.onComplete : null,
+      priorSession: opts.priorSession || null
     };
     _diagnosticStartTimer();
     _loadingProgressFinish();
@@ -4980,6 +5001,16 @@ function completeDiagnostic() {
   if (!_diagnosticSession) return;
   _diagnosticStopTimer();
   const session = _diagnosticSession;
+
+  // v7.30.0: onboarding calibration / movement legs hand off to the first-run
+  // UI instead of the Pass-Plan results page. Guarded — only set when launched
+  // via startDiagnostic({ onboarding }) from the ?onb=1 first-run flow.
+  if (session.onboarding) {
+    _diagnosticSession = null;
+    try { _onbDiagnosticComplete(session); } catch (_) {}
+    return;
+  }
+
   const passPlan = _buildPassPlan(session);
   // Override seededCount with the actual addToSrQueue return after seeding,
   // so a dedup hit against an existing SR entry is reflected accurately.
@@ -5002,6 +5033,82 @@ function completeDiagnostic() {
   _diagnosticSession = null;
   renderDiagnosticResult();
   showPage('diagnostic-result');
+}
+
+// v7.30.0 — onboarding calibration / movement completion. Reuses _buildPassPlan
+// + _seedReviewQueueFromDiagnostic, writes the readiness snapshot directly from
+// the calibration (history-independent, unlike _writeReadinessSnapshot), then
+// hands the real numbers back to the first-run UI via the session's onComplete.
+// Activation falls out of the snapshot: the lobby router treats a per-cert
+// readiness snapshot as "activated", and the snapshot syncs cloud↔local via the
+// existing Phase C′ plumbing. Deliberately does NOT saveDiagnostic() — the short
+// calibration is separate from the full 20-Q Baseline (decision doc §2), so the
+// home keeps offering the full Baseline.
+function _onbDiagnosticComplete(session) {
+  // The movement leg combines with the calibration session so the recomputed
+  // prediction reflects every question answered, not just the last few.
+  var scored = session;
+  if (session.priorSession && session.priorSession.questions) {
+    scored = {
+      questions: session.priorSession.questions.concat(session.questions),
+      answers: session.priorSession.answers.concat(session.answers),
+      startedAt: session.priorSession.startedAt || session.startedAt
+    };
+  }
+  var passPlan = _buildPassPlan(scored);
+  // Seed only THIS leg's wrong / uncertain answers into the SR review queue.
+  try { passPlan.seededCount = _seedReviewQueueFromDiagnostic(session); } catch (_) {}
+  _onbWriteReadinessFromPassPlan(passPlan);
+  var cb = session.onComplete;
+  if (typeof cb === 'function') {
+    var passScore = (typeof EXAM_PASS_SCORE === 'number') ? EXAM_PASS_SCORE : 720;
+    try { cb({ passPlan: passPlan, session: scored, passScore: passScore }); } catch (_) {}
+  }
+}
+
+// Write the per-cert readiness snapshot straight from a calibration pass plan
+// (mirrors the shape in _writeReadinessSnapshot, but sourced from the diagnostic
+// session rather than cumulative quiz history). This is the activation signal.
+function _onbWriteReadinessFromPassPlan(passPlan) {
+  try {
+    if (!passPlan || typeof passPlan.predicted !== 'number') return;
+    var raw = localStorage.getItem(STORAGE.READINESS_SNAPSHOTS);
+    var snaps = {};
+    if (raw) { try { snaps = JSON.parse(raw) || {}; } catch (_) { snaps = {}; } }
+    var weak = (passPlan.weakDomains && passPlan.weakDomains[0]) || null;
+    snaps[CURRENT_CERT] = {
+      score: passPlan.predicted,
+      computed_at: new Date().toISOString(),
+      weak_topic: weak ? weak.label : null,
+      weak_pct: weak ? Math.round(weak.accuracy * 100) : null,
+      weak_domain: weak ? weak.key : null,
+      days_to_exam: null,
+      total_qs: passPlan.questionCount,
+      source: 'onb-calibration'
+    };
+    localStorage.setItem(STORAGE.READINESS_SNAPSHOTS, JSON.stringify(snaps));
+    if (typeof _cloudFlush === 'function') _cloudFlush(STORAGE.READINESS_SNAPSHOTS);
+  } catch (_) { /* non-fatal — never block the onboarding flow */ }
+}
+
+// Guarded preview-only mock question generator (no API key needed). Only ever
+// called via startDiagnostic({ mock:true }) from the ?onb=1 first-run, so it can
+// never affect the real diagnostic. Answers vary so the calibration score is a
+// realistic mix rather than 0% or 100%.
+function _onbMockQuestions(n) {
+  var out = [];
+  var topics = ['Subnetting & VLSM', 'OSI Model & Encapsulation', 'Routing & Switching', 'Network Security', 'Wireless Standards'];
+  for (var i = 0; i < n; i++) {
+    out.push({
+      question: 'Preview calibration question ' + (i + 1) + ' (mock — no API key).',
+      options: { A: 'Option A', B: 'Option B', C: 'Option C', D: 'Option D' },
+      answer: (i % 5 === 0) ? 'B' : 'A',
+      topic: topics[i % topics.length],
+      difficulty: 'Mixed',
+      explanation: 'Preview mock — not a real exam question.'
+    });
+  }
+  return out;
 }
 
 // v4.85.7: extracted from renderDiagnosticResult() — renders the weak-domains

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.29.1
+// Network+ AI Quiz — app.js  v7.30.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.29.1';
+const APP_VERSION = '7.30.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/auth-state.js
+++ b/auth-state.js
@@ -528,6 +528,13 @@
       if (profile && profile.role && profile.role !== 'user') {
         renderSignedIn(session.user, profile);  // re-render with admin extras
       }
+      // Onboarding lobby (Phase 0, guarded): route once auth + profile resolve.
+      // No-op unless enabled (?onb=1). Runs AFTER hydrate so the activation check
+      // sees cloud-synced readiness; still fires on hydrate failure / no-cloud so
+      // the resolve skeleton never sticks.
+      var _onbRouteSignedIn = function () {
+        try { if (window._onbRoute) window._onbRoute({ isLoggedIn: true, profile: profile }); } catch (_) {}
+      };
       var cs = getCloudStore();
       if (cs) {
         cs.hydrate().then(function () {
@@ -540,10 +547,14 @@
           if (cs.onStatusChange) {
             cs.onStatusChange(updateSyncStatusUI);
           }
+          _onbRouteSignedIn();
         }).catch(function (err) {
           console.warn('[auth-state] hydrate failed (still signed in, just no cloud data yet)', err);
           updateSyncStatusUI();
+          _onbRouteSignedIn();
         });
+      } else {
+        _onbRouteSignedIn();
       }
     });
   }
@@ -559,9 +570,15 @@
   // ── Init ───────────────────────────────────────────────────────────────
   function init() {
     var sb = getSupabase();
+    // Onboarding lobby (Phase 0, guarded): anonymous-launch route. No-op unless
+    // enabled (?onb=1); fires the router's logged-out branch + hides the skeleton.
+    var _onbRouteAnon = function () {
+      try { if (window._onbRoute) window._onbRoute({ isLoggedIn: false }); } catch (_) {}
+    };
     if (!sb) {
       console.warn('[auth-state] Supabase client not ready — rendering anonymous');
       renderAnonymous();
+      _onbRouteAnon();
       return;
     }
 
@@ -572,10 +589,12 @@
         handleSignedIn(session);
       } else {
         renderAnonymous();
+        _onbRouteAnon();
       }
     }).catch(function (err) {
       console.warn('[auth-state] getSession failed, defaulting to anonymous', err);
       renderAnonymous();
+      _onbRouteAnon();
     });
 
     // Subscribe to auth state changes

--- a/dg-system.css
+++ b/dg-system.css
@@ -3342,6 +3342,42 @@ html[data-theme] body #page-setup .dw-launch{flex:0 0 auto;padding:13px 22px;bor
 .onb-resolve{position:fixed;inset:0;z-index:9000;display:flex;align-items:center;justify-content:center;background:var(--bg);color:var(--text);transition:opacity .3s cubic-bezier(0.16,1,0.3,1);}
 .onb-resolve[hidden]{display:none!important;}
 .onb-resolve.onb-resolve-out{opacity:0;pointer-events:none;}
+
+/* ══ Onboarding first-run spine (Phase 1) ════════════════════════════════════
+   Activation sequence overlay, lifted from mockups/onboarding-first-run-concept
+   and mapped to the real dg tokens. Screens rendered by lib/onboarding-firstrun.
+   Mobile-first column, centered on wider viewports. One focal action per screen. */
+.onb-fr{position:fixed;inset:0;z-index:8995;background:var(--bg);color:var(--text);overflow-y:auto;display:flex;justify-content:center;}
+.onb-fr[hidden]{display:none!important;}
+.onb-fr .fr-screen{width:100%;max-width:440px;padding:40px 24px 28px;display:flex;flex-direction:column;min-height:100%;}
+.onb-fr .fr-kicker{font:800 10.5px/1 Inter,sans-serif;letter-spacing:0.13em;text-transform:uppercase;color:var(--accent);margin:0 0 10px;}
+.onb-fr .fr-title{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:27px;line-height:1.1;letter-spacing:-0.02em;color:var(--text);margin:0 0 10px;}
+.onb-fr .fr-body{font-size:14.5px;line-height:1.5;color:var(--text-mid);margin:0 0 18px;}
+.onb-fr .fr-cert-list{display:flex;flex-direction:column;gap:8px;margin:2px 0 10px;}
+.onb-fr .fr-cert{display:flex;align-items:center;gap:13px;width:100%;text-align:left;padding:13px 14px;border:1px solid var(--border);border-radius:14px;background:var(--surface);cursor:pointer;transition:border-color .18s cubic-bezier(0.16,1,0.3,1),background .18s cubic-bezier(0.16,1,0.3,1),transform .15s cubic-bezier(0.16,1,0.3,1);}
+.onb-fr .fr-cert:active{transform:scale(0.992);}
+.onb-fr .fr-cert:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+.onb-fr .fr-cert.fr-sel{border-color:var(--accent);background:color-mix(in oklab,var(--accent) 8%,var(--surface));}
+.onb-fr .fr-mark{flex:0 0 auto;width:42px;height:42px;border-radius:11px;display:grid;place-items:center;font:800 13px/1 Inter,sans-serif;color:var(--accent);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border));}
+.onb-fr .fr-cert.fr-sel .fr-mark{color:var(--bg);background:var(--accent);border-color:var(--accent);}
+.onb-fr .fr-cmeta{flex:1 1 auto;min-width:0;}
+.onb-fr .fr-cname{display:block;font-weight:650;font-size:14.5px;line-height:1.15;color:var(--text);}
+.onb-fr .fr-cvendor{display:block;font-size:12px;color:var(--text-dim);margin-top:2px;}
+.onb-fr .fr-check{flex:0 0 auto;width:20px;height:20px;opacity:0;}
+.onb-fr .fr-cert.fr-sel .fr-check{opacity:1;}
+.onb-fr .fr-check svg{width:20px;height:20px;stroke:var(--accent);fill:none;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;}
+.onb-fr .fr-reassure{display:flex;align-items:flex-start;gap:10px;padding:13px 15px;border-radius:13px;background:color-mix(in oklab,var(--accent) 7%,var(--surface));border:1px solid color-mix(in oklab,var(--accent) 16%,var(--border));margin-bottom:18px;}
+.onb-fr .fr-reassure svg{flex:0 0 auto;width:19px;height:19px;stroke:var(--accent);fill:none;stroke-width:1.9;stroke-linecap:round;stroke-linejoin:round;margin-top:1px;}
+.onb-fr .fr-reassure span{font-size:13px;line-height:1.4;color:var(--text-mid);}
+.onb-fr .fr-reassure b{color:var(--text);font-weight:650;}
+.onb-fr .fr-foot{margin-top:auto;padding-top:18px;}
+.onb-fr .fr-btn{display:block;width:100%;text-align:center;font:700 15px/1 Inter,sans-serif;border-radius:13px;padding:16px 18px;cursor:pointer;border:1px solid transparent;transition:transform .15s cubic-bezier(0.16,1,0.3,1),filter .2s;}
+.onb-fr .fr-btn:active{transform:scale(0.978);}
+.onb-fr .fr-btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+.onb-fr .fr-btn-primary{background:var(--accent);color:var(--bg);border-color:var(--accent);}
+.onb-fr .fr-btn-ghost{background:transparent;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 32%,var(--border));margin-top:9px;}
+.onb-fr .fr-micro{text-align:center;font-size:12px;line-height:1.45;color:var(--text-dim);margin:11px 0 0;}
+@media (hover:hover) and (pointer:fine){.onb-fr .fr-btn-primary:hover{filter:brightness(1.04);}.onb-fr .fr-cert:hover{border-color:color-mix(in oklab,var(--accent) 40%,var(--border));}}
 .onb-resolve-inner{display:flex;flex-direction:column;align-items:center;gap:20px;padding:24px;}
 .onb-resolve-mark svg{width:58px;height:58px;display:block;}
 .onb-resolve-word{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:21px;letter-spacing:-0.01em;color:var(--text);}

--- a/dg-system.css
+++ b/dg-system.css
@@ -3451,3 +3451,67 @@ html[data-theme] body #page-setup .dw-launch{flex:0 0 auto;padding:13px 22px;bor
 @keyframes onbShimmer{0%{background-position:200% 0;}100%{background-position:-200% 0;}}
 @media (prefers-reduced-motion: reduce){.onb-resolve-skel span{animation:none;background:var(--surface2);}}
 
+/* ══ Onboarding tier chrome (Phase 2) · home bar (quota meter · Pro switcher) ═══
+   Injected as the first child of the home bento (main.board) by lib/onboarding-home.js,
+   only when ?onb=1. Forged-bronze, scoped; never touches the existing home. */
+#onb-home-bar-host{grid-column:1/-1;width:100%;}
+.onb-home-bar{border:1px solid var(--border);border-radius:16px;background:var(--surface);padding:15px 16px 16px;margin:0 0 16px;box-shadow:0 1px 0 color-mix(in oklab,var(--text) 4%,transparent),0 16px 36px -24px color-mix(in oklab,var(--text) 20%,transparent);}
+/* Entrance plays once per session (added on first mount only). Returning to the
+   home tens of times/day should not replay it — Emil: don't animate frequent actions. */
+.onb-home-bar.onb-hb-enter{opacity:0;transform:translateY(6px);animation:onbHbIn .42s cubic-bezier(0.16,1,0.3,1) forwards;}
+@keyframes onbHbIn{to{opacity:1;transform:none;}}
+.onb-hb-top{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:13px;}
+.onb-hb-switcher,.onb-hb-cert{display:inline-flex;align-items:center;gap:9px;min-width:0;}
+.onb-hb-switcher{padding:6px 8px 6px 6px;border-radius:12px;border:1px solid var(--border);background:var(--surface);cursor:pointer;transition:transform .15s cubic-bezier(0.16,1,0.3,1),border-color .18s cubic-bezier(0.16,1,0.3,1);}
+.onb-hb-switcher:active{transform:scale(0.98);}
+.onb-hb-switcher:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+@media (hover:hover) and (pointer:fine){.onb-hb-switcher:hover{border-color:color-mix(in oklab,var(--accent) 40%,var(--border));}}
+.onb-hb-mark{flex:0 0 auto;width:34px;height:34px;border-radius:9px;display:grid;place-items:center;font:800 11px/1 Inter,sans-serif;color:var(--accent);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border));}
+.onb-hb-ct{display:flex;flex-direction:column;min-width:0;text-align:left;}
+.onb-hb-name{font-weight:700;font-size:14px;line-height:1.1;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.onb-hb-code{font-size:11px;color:var(--text-dim);margin-top:1px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.onb-hb-chev{flex:0 0 auto;width:16px;height:16px;stroke:var(--text-dim);fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;margin-left:1px;}
+.onb-hb-plan{flex:0 0 auto;font:800 10px/1 Inter,sans-serif;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-dim);border:1px solid var(--border);border-radius:999px;padding:5px 9px;}
+.onb-hb-plan-pro{color:var(--accent);border-color:color-mix(in oklab,var(--accent) 32%,var(--border));background:color-mix(in oklab,var(--accent) 9%,transparent);}
+.onb-hb-quota{border-top:1px solid var(--border-soft,color-mix(in oklab,var(--border) 60%,transparent));padding-top:4px;}
+.onb-hb-row{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 0;}
+.onb-hb-row + .onb-hb-row{border-top:1px solid color-mix(in oklab,var(--border) 55%,transparent);}
+.onb-hb-rn{font-size:13.5px;font-weight:650;color:var(--text);}
+.onb-hb-rv{font-size:12.5px;color:var(--text-dim);}
+.onb-hb-rv-free{color:var(--accent);font-weight:650;}
+.onb-hb-capbtn{font:650 12.5px/1 Inter,sans-serif;color:var(--accent);background:none;border:none;padding:0;cursor:pointer;text-decoration:underline;text-underline-offset:3px;}
+.onb-hb-capbtn:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:4px;}
+.onb-hb-meter{height:6px;border-radius:999px;background:var(--surface2);border:1px solid color-mix(in oklab,var(--border) 70%,transparent);overflow:hidden;margin:2px 0 4px;}
+.onb-hb-meter span{display:block;height:100%;border-radius:999px;background:linear-gradient(90deg,color-mix(in oklab,var(--accent) 70%,var(--text)),var(--accent));transition:width .5s cubic-bezier(0.16,1,0.3,1);}
+.onb-hb-add{display:flex;align-items:center;gap:11px;width:100%;margin-top:13px;padding:11px 13px;border-radius:13px;border:1px dashed color-mix(in oklab,var(--accent) 34%,var(--border));background:transparent;cursor:pointer;transition:border-color .18s cubic-bezier(0.16,1,0.3,1),background .18s cubic-bezier(0.16,1,0.3,1),transform .15s cubic-bezier(0.16,1,0.3,1);}
+.onb-hb-add:active{transform:scale(0.99);}
+.onb-hb-add:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+@media (hover:hover) and (pointer:fine){.onb-hb-add:hover{border-color:color-mix(in oklab,var(--accent) 50%,var(--border));background:color-mix(in oklab,var(--accent) 5%,transparent);}}
+.onb-hb-plus{flex:0 0 auto;width:24px;height:24px;border-radius:7px;display:grid;place-items:center;color:var(--accent);background:color-mix(in oklab,var(--accent) 10%,transparent);font-weight:700;font-size:15px;}
+.onb-hb-add > span:nth-child(2){flex:1 1 auto;text-align:left;font-size:13.5px;font-weight:600;color:var(--text-mid);}
+.onb-hb-protag{flex:0 0 auto;font:800 9.5px/1 Inter,sans-serif;letter-spacing:0.08em;text-transform:uppercase;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 30%,var(--border));border-radius:999px;padding:4px 8px;}
+@media (prefers-reduced-motion:reduce){.onb-home-bar.onb-hb-enter{animation:none;opacity:1;transform:none;}.onb-hb-meter span{transition:none;}}
+
+/* "Your exams" switcher sheet — reuses the .onb-ov sheet shell (scrim/sheet/grab). */
+.onb-ov .onb-sw-list{display:flex;flex-direction:column;gap:8px;margin:2px 0 12px;}
+.onb-ov .onb-sw-row{display:flex;align-items:center;gap:13px;width:100%;text-align:left;padding:12px;border:1px solid var(--border);border-radius:14px;background:var(--surface);cursor:pointer;transition:border-color .18s cubic-bezier(0.16,1,0.3,1),background .18s cubic-bezier(0.16,1,0.3,1),transform .15s cubic-bezier(0.16,1,0.3,1);}
+.onb-ov .onb-sw-row:active{transform:scale(0.992);}
+.onb-ov .onb-sw-row:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+.onb-ov .onb-sw-row.onb-sw-sel{border-color:var(--accent);background:color-mix(in oklab,var(--accent) 8%,var(--surface));}
+@media (hover:hover) and (pointer:fine){.onb-ov .onb-sw-row:hover{border-color:color-mix(in oklab,var(--accent) 40%,var(--border));}}
+.onb-ov .onb-sw-mark{flex:0 0 auto;width:42px;height:42px;border-radius:11px;display:grid;place-items:center;font:800 13px/1 Inter,sans-serif;color:var(--accent);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border));}
+.onb-ov .onb-sw-meta{flex:1 1 auto;min-width:0;}
+.onb-ov .onb-sw-cn{display:block;font-weight:650;font-size:14px;line-height:1.15;color:var(--text);}
+.onb-ov .onb-sw-cs{display:block;font-size:12px;color:var(--text-dim);margin-top:2px;}
+.onb-ov .onb-sw-score{flex:0 0 auto;text-align:right;}
+.onb-ov .onb-sw-v{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:19px;color:var(--text);font-variant-numeric:lining-nums tabular-nums;}
+.onb-ov .onb-sw-l{font-size:10px;color:var(--text-dim);letter-spacing:0.05em;margin-left:3px;}
+.onb-ov .onb-sw-start{flex:0 0 auto;font:700 11.5px/1 Inter,sans-serif;color:var(--accent);}
+.onb-ov .onb-sw-add{display:flex;align-items:center;gap:11px;width:100%;padding:12px 14px;border-radius:13px;border:1px dashed color-mix(in oklab,var(--accent) 34%,var(--border));background:transparent;cursor:pointer;transition:border-color .18s cubic-bezier(0.16,1,0.3,1),background .18s cubic-bezier(0.16,1,0.3,1),transform .15s cubic-bezier(0.16,1,0.3,1);}
+.onb-ov .onb-sw-add:active{transform:scale(0.99);}
+.onb-ov .onb-sw-add:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+.onb-ov .onb-sw-plus{flex:0 0 auto;width:26px;height:26px;border-radius:8px;display:grid;place-items:center;color:var(--accent);background:color-mix(in oklab,var(--accent) 10%,transparent);font-weight:700;}
+.onb-ov .onb-sw-add > span:nth-child(2){flex:1 1 auto;text-align:left;font-size:13.5px;font-weight:600;color:var(--text-mid);}
+.onb-ov .onb-sw-link{display:block;width:100%;text-align:center;background:none;border:none;color:var(--accent);font:600 13px/1 Inter,sans-serif;padding:14px 0 4px;cursor:pointer;}
+.onb-ov .onb-sw-link:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:6px;}
+

--- a/dg-system.css
+++ b/dg-system.css
@@ -3334,3 +3334,20 @@ html[data-theme] body #page-setup .dw-launch{flex:0 0 auto;padding:13px 22px;bor
   #page-setup .mo-stat{flex-direction:column!important;align-items:flex-start!important;gap:1px!important;}
 }
 
+/* ══ Onboarding lobby · boot resolve skeleton (Phase 0) ═══════════════════════
+   Neutral forged-bronze loading state shown while auth + routing resolve, so a
+   logged-in launch never flashes the wrong surface (decision doc §6). Hidden by
+   default; the router wiring toggles [hidden]. Fully token-driven -> themes
+   automatically. Brand: skeleton shimmer over a generic spinner; no emoji. */
+.onb-resolve{position:fixed;inset:0;z-index:9000;display:flex;align-items:center;justify-content:center;background:var(--bg);color:var(--text);}
+.onb-resolve[hidden]{display:none!important;}
+.onb-resolve-inner{display:flex;flex-direction:column;align-items:center;gap:20px;padding:24px;}
+.onb-resolve-mark svg{width:58px;height:58px;display:block;}
+.onb-resolve-word{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:21px;letter-spacing:-0.01em;color:var(--text);}
+.onb-resolve-skel{display:flex;flex-direction:column;gap:10px;width:210px;margin-top:2px;}
+.onb-resolve-skel span{height:11px;border-radius:999px;background:linear-gradient(90deg,var(--surface2) 0%,var(--accent-dim) 50%,var(--surface2) 100%);background-size:200% 100%;animation:onbShimmer 1.4s cubic-bezier(0.16,1,0.3,1) infinite;}
+.onb-resolve-skel span:nth-child(2){width:62%;align-self:center;}
+.onb-resolve-note{font-size:12.5px;color:var(--text-dim);}
+@keyframes onbShimmer{0%{background-position:200% 0;}100%{background-position:-200% 0;}}
+@media (prefers-reduced-motion: reduce){.onb-resolve-skel span{animation:none;background:var(--surface2);}}
+

--- a/dg-system.css
+++ b/dg-system.css
@@ -3339,8 +3339,9 @@ html[data-theme] body #page-setup .dw-launch{flex:0 0 auto;padding:13px 22px;bor
    logged-in launch never flashes the wrong surface (decision doc §6). Hidden by
    default; the router wiring toggles [hidden]. Fully token-driven -> themes
    automatically. Brand: skeleton shimmer over a generic spinner; no emoji. */
-.onb-resolve{position:fixed;inset:0;z-index:9000;display:flex;align-items:center;justify-content:center;background:var(--bg);color:var(--text);}
+.onb-resolve{position:fixed;inset:0;z-index:9000;display:flex;align-items:center;justify-content:center;background:var(--bg);color:var(--text);transition:opacity .3s cubic-bezier(0.16,1,0.3,1);}
 .onb-resolve[hidden]{display:none!important;}
+.onb-resolve.onb-resolve-out{opacity:0;pointer-events:none;}
 .onb-resolve-inner{display:flex;flex-direction:column;align-items:center;gap:20px;padding:24px;}
 .onb-resolve-mark svg{width:58px;height:58px;display:block;}
 .onb-resolve-word{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:21px;letter-spacing:-0.01em;color:var(--text);}

--- a/dg-system.css
+++ b/dg-system.css
@@ -3408,6 +3408,39 @@ html[data-theme] body #page-setup .dw-launch{flex:0 0 auto;padding:13px 22px;bor
 .onb-fr .fr-streak{display:inline-flex;align-items:center;gap:7px;margin-top:14px;font-size:12.5px;color:var(--text-dim);}
 .onb-fr .fr-streak b{color:var(--text);}
 @media (prefers-reduced-motion:reduce){.onb-fr .fr-bar-fill{transition:none;}.onb-fr .fr-delta{transition:opacity .2s ease;transform:none;}}
+
+/* ══ Onboarding tier chrome (Phase 2) · upgrade sheets ═══════════════════════ */
+.onb-ov{position:fixed;inset:0;z-index:9001;}
+.onb-ov[hidden]{display:none!important;}
+.onb-ov .onb-ov-scrim{position:absolute;inset:0;background:oklch(0.12 0.01 275 / 0.52);opacity:0;transition:opacity .3s cubic-bezier(0.16,1,0.3,1);}
+.onb-ov .onb-sheet{position:absolute;left:0;right:0;bottom:0;max-width:480px;margin:0 auto;background:var(--surface);border-radius:22px 22px 0 0;border-top:1px solid var(--border);padding:10px 22px max(26px,env(safe-area-inset-bottom));box-shadow:0 -18px 50px -20px color-mix(in oklab,var(--text) 30%,transparent);transform:translateY(100%);transition:transform .4s cubic-bezier(0.16,1,0.3,1);}
+.onb-ov.onb-ov-in .onb-ov-scrim{opacity:1;}
+.onb-ov.onb-ov-in .onb-sheet{transform:translateY(0);}
+.onb-ov.onb-ov-out .onb-ov-scrim{opacity:0;}
+.onb-ov.onb-ov-out .onb-sheet{transform:translateY(100%);}
+.onb-ov .onb-grab{width:38px;height:4px;border-radius:999px;background:var(--border);margin:4px auto 16px;}
+.onb-ov .onb-sh-title{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:21px;line-height:1.15;letter-spacing:-0.01em;color:var(--text);margin:0 0 8px;}
+.onb-ov .onb-sh-body{font-size:14px;line-height:1.5;color:var(--text-mid);margin:0 0 16px;}
+.onb-ov .onb-reset{display:inline-flex;align-items:center;gap:7px;font-size:12.5px;color:var(--text-dim);margin:0 0 16px;}
+.onb-ov .onb-reset svg{width:15px;height:15px;stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;}
+.onb-ov .onb-feat{display:flex;align-items:flex-start;gap:10px;padding:7px 0;}
+.onb-ov .onb-feat svg{flex:0 0 auto;width:18px;height:18px;stroke:var(--accent);fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;margin-top:1px;}
+.onb-ov .onb-feat span{font-size:13.5px;line-height:1.4;color:var(--text-mid);}
+.onb-ov .onb-feat b{color:var(--text);font-weight:650;}
+.onb-ov .onb-price-row{display:flex;gap:10px;margin:14px 0 16px;}
+.onb-ov .onb-price{flex:1 1 0;border:1px solid var(--border);border-radius:13px;padding:13px 14px;}
+.onb-ov .onb-price-sel{border-color:var(--accent);background:color-mix(in oklab,var(--accent) 7%,var(--surface));}
+.onb-ov .onb-pl{font-size:11.5px;color:var(--text-dim);font-weight:650;}
+.onb-ov .onb-pv{font-family:'Fraunces',serif;font-weight:600;font-size:22px;color:var(--text);margin-top:4px;font-variant-numeric:lining-nums;}
+.onb-ov .onb-pp{font-size:11.5px;color:var(--text-dim);margin-top:2px;}
+.onb-ov .onb-save{display:inline-block;margin-top:7px;font:800 10px/1 Inter,sans-serif;letter-spacing:0.04em;text-transform:uppercase;color:var(--green);background:var(--green-bg);border-radius:999px;padding:4px 8px;}
+.onb-ov .onb-btn{display:block;width:100%;text-align:center;font:700 15px/1 Inter,sans-serif;border-radius:13px;padding:16px 18px;cursor:pointer;border:1px solid transparent;transition:transform .15s cubic-bezier(0.16,1,0.3,1),filter .2s;}
+.onb-ov .onb-btn:active{transform:scale(0.978);}
+.onb-ov .onb-btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
+.onb-ov .onb-btn-primary{background:var(--accent);color:var(--bg);border-color:var(--accent);}
+.onb-ov .onb-btn-ghost{background:transparent;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 32%,var(--border));margin-top:9px;}
+.onb-ov .onb-fine{text-align:center;font-size:11.5px;color:var(--text-dim);margin:12px 0 0;}
+@media (hover:hover) and (pointer:fine){.onb-ov .onb-btn-primary:hover{filter:brightness(1.04);}}
 .onb-resolve-inner{display:flex;flex-direction:column;align-items:center;gap:20px;padding:24px;}
 .onb-resolve-mark svg{width:58px;height:58px;display:block;}
 .onb-resolve-word{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:21px;letter-spacing:-0.01em;color:var(--text);}

--- a/dg-system.css
+++ b/dg-system.css
@@ -3378,6 +3378,36 @@ html[data-theme] body #page-setup .dw-launch{flex:0 0 auto;padding:13px 22px;bor
 .onb-fr .fr-btn-ghost{background:transparent;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 32%,var(--border));margin-top:9px;}
 .onb-fr .fr-micro{text-align:center;font-size:12px;line-height:1.45;color:var(--text-dim);margin:11px 0 0;}
 @media (hover:hover) and (pointer:fine){.onb-fr .fr-btn-primary:hover{filter:brightness(1.04);}.onb-fr .fr-cert:hover{border-color:color-mix(in oklab,var(--accent) 40%,var(--border));}}
+/* first-run · score-reveal / +5 movement / habit screen elements */
+.onb-fr .fr-screen-center{text-align:center;}
+.onb-fr .fr-kicker-dim{color:var(--text-dim);}
+.onb-fr .fr-readiness{display:flex;flex-direction:column;align-items:center;margin:10px 0 4px;}
+.onb-fr .fr-num{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:clamp(76px,22vw,104px);line-height:1;letter-spacing:-0.03em;color:var(--text);font-variant-numeric:lining-nums tabular-nums;font-feature-settings:"lnum","tnum";}
+.onb-fr .fr-outof{font-size:12px;font-weight:700;letter-spacing:0.09em;text-transform:uppercase;color:var(--text-dim);margin-top:4px;}
+.onb-fr .fr-delta{display:inline-flex;align-items:center;gap:5px;margin-top:12px;padding:6px 12px;border-radius:999px;font-size:13px;font-weight:700;color:var(--green);background:var(--green-bg);border:1px solid var(--green-border);opacity:0;transform:translateY(4px) scale(0.92);transition:opacity .32s cubic-bezier(0.16,1,0.3,1),transform .42s cubic-bezier(0.34,1.4,0.64,1);}
+.onb-fr .fr-delta.show{opacity:1;transform:none;}
+.onb-fr .fr-delta svg{width:14px;height:14px;stroke:currentColor;fill:none;stroke-width:2.4;stroke-linecap:round;stroke-linejoin:round;}
+.onb-fr .fr-bar-wrap{margin:20px 0 6px;}
+.onb-fr .fr-bar-track{position:relative;height:9px;border-radius:999px;background:var(--surface2);border:1px solid var(--border);}
+.onb-fr .fr-bar-fill{position:absolute;left:0;top:0;bottom:0;border-radius:999px;background:linear-gradient(90deg,color-mix(in oklab,var(--accent) 70%,var(--text)),var(--accent));width:0;transition:width 1s cubic-bezier(0.16,1,0.3,1);}
+.onb-fr .fr-bar-tick{position:absolute;top:-7px;bottom:-7px;width:2px;background:var(--text-mid);left:80%;border-radius:2px;}
+.onb-fr .fr-bar-legend{display:flex;justify-content:space-between;margin-top:9px;font-size:11px;color:var(--text-dim);}
+.onb-fr .fr-bar-legend .fr-pass{color:var(--text-mid);font-weight:700;}
+.onb-fr .fr-gap{font-size:14px;color:var(--text-mid);margin:16px 0 0;}
+.onb-fr .fr-gap b{color:var(--text);font-weight:700;}
+.onb-fr .fr-honest{font-size:12.5px;line-height:1.5;color:var(--text-dim);margin:16px 2px 0;}
+.onb-fr .fr-chip-wrap{margin-bottom:18px;}
+.onb-fr .fr-chip{display:inline-flex;align-items:center;gap:7px;padding:7px 13px;border-radius:999px;background:color-mix(in oklab,var(--accent) 11%,var(--surface));border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border));font-size:12.5px;font-weight:650;color:var(--accent);}
+.onb-fr .fr-chip .fr-dot{width:6px;height:6px;border-radius:50%;background:var(--accent);}
+.onb-fr .fr-card-focal{border:1px solid var(--accent);border-radius:16px;background:var(--accent);color:var(--bg);padding:18px;}
+.onb-fr .fr-rev{display:flex;align-items:center;gap:14px;}
+.onb-fr .fr-rev-ring{flex:0 0 auto;width:54px;height:54px;border-radius:14px;display:grid;place-items:center;background:color-mix(in oklab,var(--bg) 20%,transparent);border:1px solid color-mix(in oklab,var(--bg) 30%,transparent);}
+.onb-fr .fr-rev-ring span{font-family:'Fraunces',serif;font-weight:600;font-size:24px;color:var(--bg);font-variant-numeric:lining-nums;}
+.onb-fr .fr-rev-title{font-weight:700;font-size:15px;color:var(--bg);}
+.onb-fr .fr-rev-sub{font-size:12.5px;color:color-mix(in oklab,var(--bg) 78%,transparent);margin-top:2px;}
+.onb-fr .fr-streak{display:inline-flex;align-items:center;gap:7px;margin-top:14px;font-size:12.5px;color:var(--text-dim);}
+.onb-fr .fr-streak b{color:var(--text);}
+@media (prefers-reduced-motion:reduce){.onb-fr .fr-bar-fill{transition:none;}.onb-fr .fr-delta{transition:opacity .2s ease;transform:none;}}
 .onb-resolve-inner{display:flex;flex-direction:column;align-items:center;gap:20px;padding:24px;}
 .onb-resolve-mark svg{width:58px;height:58px;display:block;}
 .onb-resolve-word{font-family:'Fraunces',Georgia,serif;font-weight:600;font-size:21px;letter-spacing:-0.01em;color:var(--text);}

--- a/docs/planning/ONBOARDING_ACTIVATION_DECISIONS.md
+++ b/docs/planning/ONBOARDING_ACTIVATION_DECISIONS.md
@@ -1,0 +1,148 @@
+# Onboarding / Activation / Routing · LOCKED DECISIONS
+
+> **Status:** Strategy LOCKED 2026-06-07. No code written yet. This is the source of truth for the App Store first-run / returning-user UX layer (routing + guided first action + coachmarks + feedback). Supersedes the open questions in `HANDOFF-app-entry-routing-and-feedback-2026-06-06.md` and the memory file `planning_app_entry_routing.md`.
+>
+> **Visual source of truth:** `~/Desktop/CertAnvil-launch-routing-diagram.html` (v0.3, tier-aware, forged-bronze, light/dark toggle). The diagram is canonical for the flow; this doc is canonical for the rationale + the build rules.
+
+---
+
+## 0 · The build workflow — HARD RULE (do not deviate)
+
+Every build step in this onboarding flow MUST run, in order:
+
+1. **`/design-taste-frontend`** — design pass (first).
+2. **`/emil-design-eng`** — polish / interaction pass (second).
+3. **`/humanizer`** — copy pass (third), so all user-facing text reads human, not AI.
+
+And **`/onboarding`** is invoked **throughout the entire build** — it is the activation lens that every routing / tour / empty-state / feedback decision is checked against. This is the founder's explicit, non-negotiable instruction (2026-06-07). Any agent picking up this work follows this sequence on every surface; do not skip a pass, do not reorder.
+
+Plus the existing project discipline still applies: forged-bronze (`design/brand/BRAND.md`), concept-mockup-first, the Ship checklist, and the gated-lane PR flow (see §7).
+
+---
+
+## 1 · Activation definition + metric
+
+- **Aha moment:** NOT a static readiness score. The aha is the readiness number **moving in response to the user's own effort**, delivered **in the first session** (never split to a day-2 return — that is where anxious users are lost).
+- **Activation event:** a new account, in session one, (1) establishes a readiness baseline AND (2) sees that number move after answering its own questions.
+- **Per-cert:** activation is tracked per cert (`activated[certId]`), same shape as the shipped `metadata.sr.<certId>` cert-keying — NOT a per-account flag.
+- **Single activation metric:** **% of new accounts that reach a *moved* readiness score in their first session.**
+  - Leading proxy to instrument first (cheaper): % completing the diagnostic and hitting the score screen.
+  - Supporting: time-to-first-score (target < ~3 min), D1 return to Daily Review.
+- Pre-scale today, so these are hypotheses to **instrument from day one**, not yet validated. Wire the activation event before launch so the funnel exists when real users arrive.
+
+---
+
+## 2 · First-session flow (one goal: "a number that moves when I study")
+
+Minimal path, everything else deferred:
+
+1. **(Pro only) Pick your exam.** Free auto-assigns the user's single locked cert, so free users skip this step.
+2. **Exam date?** Optional, skippable, default "not sure yet."
+3. **Diagnostic ~15Q** — framed as calibration, not a test: "Answer ~15 questions so we can calibrate where you stand. No studying needed — wrong answers just become your first review set." **FREE and uncounted** (does NOT draw from the daily cap; one-time per cert). Seeds the Daily Review deck.
+4. **Readiness score reveal** — the number, the pass mark, the gap, honest framing ("estimates where you are today, not a guarantee").
+5. **+5 targeted practice → watch the score move** ← the ACTIVATION EVENT, in-session. These 5 draw from the 15 new-practice bucket (see §4).
+6. **Habit hook** — "5 review cards ready tomorrow" (the deck was seeded by the diagnostic, so the day-2 promise is real).
+
+**Skip in session 1:** exam mode, paywall, full feature tour, analytics deep-dives, settings, multi-cert concepts.
+
+**Diagnostic is SKIPPABLE (LOCKED 2026-06-07).** It is the default and the activation event, but NOT a hard gate. Offer "Skip for now, take it later." This matters most for a confident user (often Pro) adding a new cert who wants to dive straight into quizzes. Skipping drops them into the cert home with readiness showing "Take the diagnostic to unlock your score" until they do (an empty-state CTA, see §5). Do not force calibration on someone who is paying to study a cert they already know.
+
+---
+
+## 3 · Do-don't-show vs coachmarks
+
+- **Guided first action wins across the entire value spine** (diagnostic → score → movement). Don't explain the readiness score in a tooltip; let the user earn one and feel it move. The session-1 flow IS the "do, don't show."
+- **Light coachmarks annotate navigation only, never explain value.** Allowed: the cert switcher (Pro, first time owning 2+), a persistent "?" replay-help affordance, one just-in-time note on the readiness gauge.
+- **Rules:** one coachmark at a time, anchored, dismissible, fired by first-arrival-to-surface (not a time delay), stored per-surface (`metadata.tours.<surfaceId>`), global "skip all tips" in Settings. **Never fire mid-redirect** — only after a surface settles.
+
+---
+
+## 4 · Tier model (LOCKED 2026-06-07)
+
+- **Free = ONE cert, locked to the user's pick** (any cert: Network+, Security+, AZ-900, etc. — NOT Network+ only). They study that one cert fully. No switching.
+- **Free daily budget = 20 = 5 Daily-Review (hard cap) + 15 AI new-practice.** The diagnostic is excluded (free, one-time). The activation "+5 practice" draws from the 15 new-practice bucket.
+- **Pro = all 7 certs + cert switching + unlimited questions.**
+- **Switcher renders for Pro only.** In the free user's switcher slot, show a quiet "＋ Add a cert · Pro" upsell — absence becomes discovery, not a nag.
+- **Upgrade prompts fire only AFTER the aha**, on triggers the free user already cares about: (a) out of the 15 new questions ("Pro = unlimited"), (b) wanting a 2nd cert ("Pro = all 7 + switching"). Honest framing — access and volume, never a pass guarantee.
+- **WATCH the 5/day review cap.** SR backlogs grow; a committed free user could have 25 cards due but clear only 5/day. Strong upgrade lever ("Pro clears your full review queue") but instrument it so it does not starve the retention habit that drives conversion.
+
+---
+
+## 5 · Empty states (brand-new account)
+
+- **0 certs:** the empty "My Certs" IS the front door — render the cert picker framed as the goal: "Pick your exam to get your readiness score."
+- **0 history in a chosen cert:** never a dashboard of zeros (reads as failure to an anxious user). Single primary CTA over a ghosted preview of the populated dashboard: "Take your 15-question diagnostic to unlock your readiness score."
+- **Empty Daily Review:** "Your review deck builds as you study. Take the diagnostic to seed your first cards."
+- **Tone:** honest, calm. "Where you stand today," not "your score." "Estimate," not "prediction." The gap is closeable, never a verdict. No "you'll pass."
+
+---
+
+## 6 · Returning users + routing (never nag daily users)
+
+**Native shell = Option B (the "lobby" / thin router) — LOCKED.** The Capacitor app opens to ONE controlled entry point that runs the routing; it does NOT deep-link straight into a cert subdomain. Reasons: simpler, more reliable, safe for Apple review (opens into "the app," not a website), and it is the single place the routing logic lives. Cost (one tiny redirect) is hidden behind the neutral loading skeleton.
+
+**Routing order (the lobby):**
+
+```
+Launch → native shell loads start URL → fast auth resolve (neutral skeleton, NO flash of landing)
+  → Logged in?
+      No  → marketing landing (strangers only)
+      Yes → Tier?
+          Free → current cert = their one locked cert
+          Pro  → current cert = last-active cert
+        → Activated for THIS cert?
+            No  → first-run diagnostic FOR that cert (resumable — jump to first incomplete step)
+            Yes → cert home
+                   Free: quota meter (5 review + 15 new), no switcher, "＋ Add a cert · Pro"
+                   Pro:  switcher 1 tap, My Certs hub, unlimited
+        → surface settled → coachmarks may fire
+```
+
+- **Pro switching to an undiagnosed cert re-enters first-run** for that cert (per-cert activation). The switcher is an activation surface, not just navigation.
+- **Gate first-run on activation STATE, not on "is this a new session."** This is what stops onboarding from nagging daily users. The one returning user who *should* see onboarding is "returning + never activated" — resume their first-run.
+- **Last-active cert lives in profile/cloud** (`metadata.lastActiveCertId`), cross-device, same shape as the shipped cert-keying.
+
+---
+
+## 6b · Integration with the existing app (ON-RAMP, NOT A REBUILD)
+
+This is the most important framing for the build: **the onboarding flow wraps the entry to the product that already exists. It does NOT replace the quiz engine, My Certs, the cert switcher, readiness, the cert home (`#page-setup`), or Daily Review.** Almost everything the flow shows is existing data and engines, re-sequenced and re-framed for the first run.
+
+| Already exists (reuse as-is) | New thin layer this project adds |
+|---|---|
+| Quiz / exam engine | The lobby router (Option B entry) |
+| My Certs + cert switcher | Per-cert activation gate (`activated[certId]`) |
+| Readiness score + cert home (`#page-setup`) | First-run orchestration (diagnostic → score → +5 movement) |
+| Daily Review (spaced repetition) | Tier chrome (quota meter, upgrade sheets, "Add a cert", coachmark) |
+| Diagnostic questions | — |
+
+- **The "free home" and "Pro home" mockups ARE the existing cert home** (`#page-setup`) with tier chrome added. The "Start Daily Review" / "Practice new questions" buttons wire into the existing engine, not new screens.
+- **The switcher sheet ("Your exams")** is the existing My Certs, promoted into the app topbar.
+- **Activated users skip the on-ramp entirely.** A Pro user already activated on their certs: lobby → straight into the cert home → switch/pick cert → quizzes, exactly as the app works today. The "pick it up and go" experience is preserved. The on-ramp (and the skippable diagnostic) only fires once per cert, for a cert not yet diagnosed.
+
+**Net new code is small and bounded:** the router, the activation gate + flag, the first-run sequence, and the tier chrome. The quizzes/readiness/Daily Review/My Certs are reused.
+
+---
+
+## 7 · Build sequencing + constraints
+
+- **Gated lane:** routing touches `auth-state.js` / `cloud-store.js` / `lib/supabase.js` (and possibly `sw.js`), so it goes feature branch → PR → Supabase preview + Vercel preview → smoke test → squash-merge. NOT a fast-lane push. See `ENVIRONMENT_STRATEGY.md`.
+- **Tier/entitlements are `saas-gated` (#136).** The routing skeleton (lobby + auth + cert resolution + per-cert activation gate) can be built now; the *real* tier/quota checks (free vs Pro, 5+15 budget, upgrade walls) may need to stub until the paid-SaaS pivot triggers. Confirm with founder before wiring live entitlements.
+- **Stack:** vanilla static HTML/JS, no React. Forged-bronze via scoped `dg-system.css` overrides (never edit `styles.css`). Sec-P7: no inline `on*=` handlers.
+- **In-app feedback / App Store review prompt** (Topic 2 from the handoff) is a sibling workstream, not blocking this one. Extends the existing bug-report drawer (type selector: bug / suggestion / praise) + native `SKStoreReviewController` timed after a pass/streak. Design later under the same skill discipline.
+
+---
+
+## 8 · Confirmed assumptions (founder, 2026-06-07)
+
+1. Diagnostic stays **free / uncounted** even though Daily Review now counts toward the cap. ✅
+2. Free signup **auto-assigns the single cert** → most first-runs skip the "pick which exam" step; the picker only matters for Pro. ✅
+3. Free cert model = **any one cert, locked to their pick** (not Network+ only). ✅
+4. Cap accounting = **5 Daily-Review + 15 new-practice = 20/day**; diagnostic excluded. ✅
+5. Native shell = **Option B (lobby / thin router)**. ✅
+6. Diagnostic is **skippable** (default + activation event, not a hard gate); skippers land in the cert home with a "take the diagnostic to unlock your score" empty state. ✅
+7. The flow is an **on-ramp, not a rebuild** (see §6b): it wraps entry to the existing app; activated users go straight to quizzes. ✅
+
+---
+
+**Next step after capture:** build the routing skeleton on a feature branch (tier checks stubbed per §7), following the §0 skill sequence on every surface.

--- a/docs/planning/ONBOARDING_ROUTING_BUILD_PLAN.md
+++ b/docs/planning/ONBOARDING_ROUTING_BUILD_PLAN.md
@@ -1,0 +1,95 @@
+# Onboarding / Activation / Routing · BUILD PLAN
+
+> Implementation plan for lifting the approved mockups to prod. Reads against `ONBOARDING_ACTIVATION_DECISIONS.md` (strategy, LOCKED) and the two approved mockups (`mockups/onboarding-first-run-concept.html`, `mockups/onboarding-batch2-concept.html`). Status: DRAFT for walkthrough, no code written.
+>
+> **Core framing (decision doc §6b):** this is an ON-RAMP, not a rebuild. Net-new code is small: the router, the activation gate, the first-run sequence, and the tier chrome. Quizzes / readiness / Daily Review / My Certs are reused as-is.
+>
+> **Build discipline (founder hard-rule):** every surface runs `/design-taste-frontend` → `/emil-design-eng` → `/humanizer`, framed throughout by `/onboarding`. Forged-bronze via scoped `dg-system.css` overrides only (never edit `styles.css`). Sec-P7: no inline `on*=`.
+
+---
+
+## Current state (from codebase mapping, read-only)
+
+| Concern | Today | File anchors |
+|---|---|---|
+| Entry / boot | No router. `goSetup()` → `showPage('setup')` lands on `#page-setup` (cert home) | `app.js` showPage ~2205, goSetup ~2259-2300 |
+| Cert resolution | `detectCert()` (subdomain → `?cert=` → localStorage → default netplus) | `app.js` 75-172, `window.CURRENT_CERT` / `CERT_PACK` |
+| Auth | Supabase, cookie-backed cross-subdomain session; `getSession()` at boot; `onAuthStateChange` SIGNED_IN | `auth-state.js`, `lib/supabase.js` |
+| Cloud profile | `profiles.metadata` jsonb + `quiz_history`; hydrate on SIGNED_IN; per-cert `metadata.sr.<certId>` | `cloud-store.js` |
+| My Certs / switcher | Exist (landing My Certs modal + topbar cert switcher + cross-cert analytics) | `auth-state.js`, `landing/auth.js` |
+| Quiz / diagnostic / readiness / Daily Review | All exist and work | `app.js` + `certs/*.js` |
+| lastActiveCertId / activation flag / lobby router | **Do not exist yet** | — (this build) |
+
+---
+
+## What we build (the thin layer)
+
+### Phase 0 · Foundations — the router + state (GATED LANE)
+1. **Lobby router** `routeOnLaunch(session, profile)` — new `lib/router.js` (or scoped into `auth-state.js`). Runs after auth resolves on boot. Implements the decision-doc §6 order: logged out → landing; logged in → tier → current cert → `activated[certId]?` → first-run vs cert home. The app boot (`goSetup()` path) defers to this instead of always showing `#page-setup`.
+2. **Per-cert activation flag** `metadata.activated.<certId>` — same shape as shipped `metadata.sr.<certId>`. Derive from "has a readiness score for this cert" or set explicitly at first-run completion. Read/write via `cloud-store.js`.
+3. **`metadata.lastActiveCertId`** — written on cert switch / cert use; read by the router for Pro last-active routing. `cloud-store.js` + `auth-state.js`.
+4. **Neutral boot skeleton** — a brief forged-bronze loading state so auth resolves with no flash of landing (decision-doc §6). Maps to spine mockup screen 1.
+5. **Schema** — if `metadata` shape needs a migration, it carries a tested `-- ROLLBACK:` block (gated-lane rule).
+
+### Phase 1 · First-run spine — maps to `onboarding-first-run-concept.html`
+| Mockup screen | Real surface | Reuses |
+|---|---|---|
+| Lobby resolve | the boot skeleton (Phase 0.4) | — |
+| Cert picker | new first-run screen (free auto-assigns; Pro picks) | cert packs, My Certs data |
+| Diagnostic intro (+ **Skip for now**) | new framing screen | — |
+| Diagnostic ~15Q | **existing** diagnostic/quiz engine, "calibration" framing | quiz engine |
+| Score reveal | **existing** readiness score, first-run framing + count-up | readiness |
+| +5 movement (the aha) | **existing** quiz + readiness recompute | quiz + readiness |
+| Habit hook | seeds **existing** Daily Review (SR) | SR / `metadata.sr.<certId>` |
+
+Surfaces: `index.html` (new first-run page structures), `app.js` (first-run state machine wiring the existing engines), `dg-system.css` (lift forged-bronze from the mockup). Diagnostic is FREE/uncounted and SKIPPABLE (decision-doc §2).
+
+### Phase 2 · Tier chrome — maps to `onboarding-batch2-concept.html`
+| Mockup screen | Real surface | Reuses |
+|---|---|---|
+| Free home (quota 5+15, no switcher, +Add a cert·Pro) | `#page-setup` cert home + tier chrome | cert home |
+| Pro home (switcher, unlimited) | `#page-setup` + promoted switcher | cert home + existing switcher |
+| Switcher sheet ("Your exams", per-cert readiness, Take-diagnostic) | existing My Certs promoted into topbar | My Certs + activation flag |
+| Upgrade: daily cap | new sheet, **tier/quota STUBBED** | — |
+| Upgrade: add a 2nd exam ($9.99/mo · $89/yr) | new sheet, links to pricing; **no Stripe yet** | `landing/pricing.html` |
+| Coachmark | new lightweight component, `metadata.tours.<surfaceId>` + "skip all tips" Settings toggle | — |
+
+Surfaces: `index.html` (home chrome, sheets, coachmark), `app.js` (tier logic stubs, quota display, switcher promotion), `dg-system.css`.
+
+---
+
+## Tier / entitlements = STUBBED (saas-gated #136)
+
+The routing skeleton + chrome can be built now; the **real** tier checks are frozen until the paid-SaaS pivot. Stubs:
+- `profile.tier` → `'free' | 'pro'` read from profile, stubbed (default free, or a dev override) until #136.
+- Quota (5 review + 15 new) → display + soft counters stubbed; hard enforcement gated.
+- Upgrade CTAs → point at `landing/pricing.html`; no Stripe (that is `phase_4_stripe_architecture`, separate).
+
+---
+
+## Build order
+
+1. **Phase 0** — router + activation gate + lastActiveCert + boot skeleton. Invisible plumbing, independently testable (route a logged-in user correctly; no first-run regressions for existing users).
+2. **Phase 1** — first-run spine (the activation path), wiring existing diagnostic/readiness/SR.
+3. **Phase 2** — tier chrome (homes, switcher, upgrades, coachmark) with tier stubbed.
+
+Each phase: build → `/design-taste-frontend` → `/emil-design-eng` → `/humanizer`, then the Ship checklist + post-deploy live-verify.
+
+---
+
+## Gated-lane process (CLAUDE.md / ENVIRONMENT_STRATEGY.md)
+
+Touches `auth-state.js`, `cloud-store.js`, `lib/supabase.js`, possibly `sw.js` + a migration → **gated lane**: feature branch → PR (auto Supabase branch DB + Vercel preview + CI) → smoke-test preview → squash-merge. NOT a fast-lane push. Migrations dated ≥ 2026-05-12 carry a tested `-- ROLLBACK:`.
+
+---
+
+## Open risks / coordination
+
+1. **`auth-state.js` overlap with in-flight `feat/mobile-fit2`** — that branch has uncommitted edits to `auth-state.js` (+ `app.js`, `index.html`). Building routing in parallel on the same file risks a painful merge. **Resolve before cutting the routing branch** (land/commit mobile-fit2 first, or accept careful manual merge).
+2. **Native shell (Capacitor) packaging** — the Option B lobby must work inside the webview; entangled with the PWA-vs-IPA decision and OAuth (~July). The router is shell-agnostic (decides destination), but verify the start-URL behavior when the native shell lands.
+3. **Tier entitlements frozen (#136)** — confirm with founder before wiring any live tier/quota enforcement.
+4. **Mockups + decision doc are untracked** — commit them (fast-lane, docs/mockups) so the build references a committed baseline.
+
+---
+
+**Next:** walk this plan, settle the `auth-state.js` / branch question, then build Phase 0 on an isolated branch.

--- a/index.html
+++ b/index.html
@@ -1661,6 +1661,7 @@
 <script defer src="lib/onboarding-boot.js"></script>
 <script defer src="lib/onboarding-firstrun.js"></script>
 <script defer src="lib/onboarding-chrome.js"></script>
+<script defer src="lib/onboarding-home.js"></script>
 <script defer src="app.js"></script>
 <!-- codex-home reveal animation. Purely presentational + additive: a
      staggered IntersectionObserver fade-up for #page-setup .reveal blocks,

--- a/index.html
+++ b/index.html
@@ -181,6 +181,13 @@
 </div>
 
 <!-- ══════════════════════════════════════════
+     ONBOARDING FIRST-RUN (Phase 1) — the activation spine.
+     Screens rendered by lib/onboarding-firstrun.js into this container; launched
+     by the lobby router's 'first-run' decision (guarded). Hidden by default.
+══════════════════════════════════════════ -->
+<div id="onb-firstrun" class="onb-fr" hidden></div>
+
+<!-- ══════════════════════════════════════════
      PERSISTENT APP SIDEBAR (v4.53.0)
      Rendered client-side by renderAppSidebar() so the active state
      stays in sync with showPage(). Mobile: hidden off-screen, opens
@@ -1645,6 +1652,7 @@
      skeleton handler registers before the home-render handler. -->
 <script defer src="lib/router.js"></script>
 <script defer src="lib/onboarding-boot.js"></script>
+<script defer src="lib/onboarding-firstrun.js"></script>
 <script defer src="app.js"></script>
 <!-- codex-home reveal animation. Purely presentational + additive: a
      staggered IntersectionObserver fade-up for #page-setup .reveal blocks,

--- a/index.html
+++ b/index.html
@@ -188,6 +188,13 @@
 <div id="onb-firstrun" class="onb-fr" hidden></div>
 
 <!-- ══════════════════════════════════════════
+     ONBOARDING TIER CHROME (Phase 2) — upgrade sheets + coachmark.
+     Rendered by lib/onboarding-chrome.js. Sheets fire post-aha (daily cap / add
+     a cert); tier/quota are saas-gated (#136) so triggers are stubbed for now.
+══════════════════════════════════════════ -->
+<div id="onb-overlay" class="onb-ov" hidden></div>
+
+<!-- ══════════════════════════════════════════
      PERSISTENT APP SIDEBAR (v4.53.0)
      Rendered client-side by renderAppSidebar() so the active state
      stays in sync with showPage(). Mobile: hidden off-screen, opens
@@ -1653,6 +1660,7 @@
 <script defer src="lib/router.js"></script>
 <script defer src="lib/onboarding-boot.js"></script>
 <script defer src="lib/onboarding-firstrun.js"></script>
+<script defer src="lib/onboarding-chrome.js"></script>
 <script defer src="app.js"></script>
 <!-- codex-home reveal animation. Purely presentational + additive: a
      staggered IntersectionObserver fade-up for #page-setup .reveal blocks,

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.29.1">
+<link rel="stylesheet" href="dg-system.css?v=7.30.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v5.5.1 — Fraunces display face for the editorial system (Home v3
      reimagining + cross-surface). Body stays the app font; Fraunces is
@@ -753,7 +753,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.29.1</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.30.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/index.html
+++ b/index.html
@@ -160,6 +160,27 @@
 <a href="#api-key" class="skip-link" id="skip-link">Skip to content</a>
 
 <!-- ══════════════════════════════════════════
+     ONBOARDING LOBBY · boot resolve skeleton (Phase 0)
+     Neutral forged-bronze loading state shown while auth + routing resolve, so
+     a logged-in launch never flashes the wrong surface (decision doc §6).
+     Hidden by default; the router wiring toggles [hidden]. Additive + inert.
+══════════════════════════════════════════ -->
+<div id="onb-resolve" class="onb-resolve" role="status" aria-live="polite" aria-label="Getting things ready" hidden>
+  <div class="onb-resolve-inner">
+    <div class="onb-resolve-mark" aria-hidden="true">
+      <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" class="sb-brand-c" stroke-width="7" stroke-linecap="round"/>
+        <line x1="30" y1="84" x2="70" y2="16" class="sb-brand-slash" stroke-width="5" stroke-linecap="round"/>
+        <path d="M46 88 L64 50 L82 88 M53 74 L75 74" class="sb-brand-a" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </div>
+    <div class="onb-resolve-word">CertAnvil</div>
+    <div class="onb-resolve-skel" aria-hidden="true"><span></span><span></span></div>
+    <div class="onb-resolve-note">Getting things ready</div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════
      PERSISTENT APP SIDEBAR (v4.53.0)
      Rendered client-side by renderAppSidebar() so the active state
      stays in sync with showPage(). Mobile: hidden off-screen, opens
@@ -1618,6 +1639,9 @@
 <!-- M7: CSP-clean event delegation. Must load before app.js so its document
      listeners are installed; dispatches to app.js globals lazily at event time. -->
 <script defer src="event-actions.js"></script>
+<!-- Onboarding lobby router (Phase 0). Pure decision logic (window.certanvilRouter);
+     inert until the boot/auth wiring calls it. Loads before app.js so it's available. -->
+<script defer src="lib/router.js"></script>
 <script defer src="app.js"></script>
 <!-- codex-home reveal animation. Purely presentational + additive: a
      staggered IntersectionObserver fade-up for #page-setup .reveal blocks,

--- a/index.html
+++ b/index.html
@@ -1639,9 +1639,12 @@
 <!-- M7: CSP-clean event delegation. Must load before app.js so its document
      listeners are installed; dispatches to app.js globals lazily at event time. -->
 <script defer src="event-actions.js"></script>
-<!-- Onboarding lobby router (Phase 0). Pure decision logic (window.certanvilRouter);
-     inert until the boot/auth wiring calls it. Loads before app.js so it's available. -->
+<!-- Onboarding lobby router + wiring (Phase 0). router.js = pure decision logic
+     (window.certanvilRouter); onboarding-boot.js = guarded wiring (OFF by default,
+     ?onb=1 to enable). Both load before app.js so they're available + the resolve
+     skeleton handler registers before the home-render handler. -->
 <script defer src="lib/router.js"></script>
+<script defer src="lib/onboarding-boot.js"></script>
 <script defer src="app.js"></script>
 <!-- codex-home reveal animation. Purely presentational + additive: a
      staggered IntersectionObserver fade-up for #page-setup .reveal blocks,

--- a/lib/onboarding-boot.js
+++ b/lib/onboarding-boot.js
@@ -88,8 +88,10 @@
         hideSkeleton();
         break;
       case 'first-run':
-        // Phase 1 will render the first-run flow here. STUB for now: reveal home.
+        // Phase 1: launch the first-run spine (it manages its own overlay above
+        // the home). Hide the resolve skeleton underneath it.
         hideSkeleton();
+        try { if (window.onbFirstRun) window.onbFirstRun.start(decision); } catch (_) {}
         break;
       case 'landing':
       default:

--- a/lib/onboarding-boot.js
+++ b/lib/onboarding-boot.js
@@ -1,0 +1,101 @@
+// lib/onboarding-boot.js — Onboarding lobby WIRING (Phase 0, guarded).
+//
+// Connects the pure router (lib/router.js) to the live boot/auth sequence:
+//   1. On boot (if enabled) show the neutral resolve skeleton, covering the home
+//      flash while auth resolves (decision doc §6 — "no flash of landing").
+//   2. auth-state.js calls window._onbRoute() once auth resolves (signed-in:
+//      after cloud hydrate; anonymous: immediately). We gather inputs, ask the
+//      router for a decision, and act on it.
+//
+// SAFETY — OFF BY DEFAULT. The feature is gated behind localStorage 'onb_router'
+// (toggle with ?onb=1 / ?onb=0). When off: this module is inert, the skeleton is
+// never shown, _onbRoute is a no-op, and the existing boot path is untouched.
+//
+// Phase 0 scope: routes the ACTIVATED case to the existing cert home. 'first-run'
+// is STUBBED (reveals home + logs the decision) until Phase 1 builds the first-run
+// UI; 'landing' (native/logged-out redirect) is deferred to the Capacitor work.
+
+(function () {
+  'use strict';
+
+  function guardOn() {
+    try {
+      var s = location.search || '';
+      if (s.indexOf('onb=1') !== -1) localStorage.setItem('onb_router', '1');
+      if (s.indexOf('onb=0') !== -1) localStorage.removeItem('onb_router');
+      return localStorage.getItem('onb_router') === '1';
+    } catch (_) { return false; }
+  }
+
+  var ENABLED = guardOn();
+  var resolved = false;
+  var REDUCE = false;
+  try { REDUCE = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (_) {}
+
+  function el() { return document.getElementById('onb-resolve'); }
+
+  function showSkeleton() { var e = el(); if (e) e.hidden = false; }
+
+  function hideSkeleton() {
+    var e = el();
+    if (!e || e.hidden) return;
+    if (REDUCE) { e.hidden = true; return; }
+    e.classList.add('onb-resolve-out');          // fade out (emil: resolve recedes, not snaps)
+    setTimeout(function () { e.hidden = true; e.classList.remove('onb-resolve-out'); }, 320);
+  }
+
+  // Show the skeleton as early as possible so it covers the synchronous home
+  // render (app.js DOMContentLoaded ~:2001). Loaded before app.js so this
+  // handler registers first.
+  if (ENABLED) {
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', showSkeleton);
+    else showSkeleton();
+    // Failsafe: the skeleton can never stick, even if auth never resolves.
+    setTimeout(function () { if (!resolved) hideSkeleton(); }, 4000);
+  }
+
+  // Build a metadata-like profile for the router from the fetched profile +
+  // hydrated localStorage. Readiness snapshots (nplus_readiness_snapshots) are
+  // the per-cert "has been scored" signal the activation check reads.
+  function gatherProfile(fetched) {
+    var meta = (fetched && fetched.metadata) ? Object.assign({}, fetched.metadata) : {};
+    try {
+      var raw = localStorage.getItem('nplus_readiness_snapshots');
+      if (raw && !meta.readiness_snapshots) meta.readiness_snapshots = JSON.parse(raw);
+    } catch (_) {}
+    return { metadata: meta };
+  }
+
+  // Called by auth-state.js after auth resolves. Inert unless enabled.
+  // opts = { isLoggedIn: bool, profile?: object }
+  window._onbRoute = function (opts) {
+    if (!ENABLED) return;
+    opts = opts || {};
+    resolved = true;
+    var R = window.certanvilRouter;
+    if (!R) { hideSkeleton(); return; }
+
+    var decision = R.routeOnLaunch({
+      isLoggedIn: !!opts.isLoggedIn,
+      profile: gatherProfile(opts.profile),
+      detectedCert: window.CURRENT_CERT || null
+    });
+    try { console.info('[onb] route decision:', decision.kind, '(' + decision.reason + ')', decision.certId || ''); } catch (_) {}
+
+    switch (decision.kind) {
+      case 'cert-home':
+        // The existing home already rendered underneath; just reveal it.
+        hideSkeleton();
+        break;
+      case 'first-run':
+        // Phase 1 will render the first-run flow here. STUB for now: reveal home.
+        hideSkeleton();
+        break;
+      case 'landing':
+      default:
+        // Native/logged-out redirect is deferred (Capacitor). Web stays in-app.
+        hideSkeleton();
+        break;
+    }
+  };
+})();

--- a/lib/onboarding-chrome.js
+++ b/lib/onboarding-chrome.js
@@ -1,0 +1,89 @@
+// lib/onboarding-chrome.js — Onboarding tier chrome (Phase 2): upgrade sheets.
+//
+// Post-aha upgrade moments lifted from mockups/onboarding-batch2-concept.html:
+//   • 'cap'      — free user hit the daily 15 new-questions cap (not a dead-end).
+//   • 'add-cert' — free user wants a second exam (Pro value + pricing).
+//
+// Rendered into #onb-overlay (scrim + bottom sheet). API: window.onbUpgrade.show(kind).
+// Tier/quota triggers are saas-gated (#136), so these are wired to events later;
+// for now they are show-on-demand + fully dismissible. Sec-P7: delegated clicks,
+// no inline on*. honest framing, no pass guarantee.
+
+(function () {
+  'use strict';
+
+  var host = null;
+  var REDUCE = false;
+  try { REDUCE = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (_) {}
+
+  function el() { return host || (host = document.getElementById('onb-overlay')); }
+
+  var CHECK = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>';
+  var CLOCK = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>';
+
+  function sheetCap() {
+    return ''
+      + '<h2 class="onb-sh-title">That’s today’s 15 new questions.</h2>'
+      + '<p class="onb-sh-body">Your Daily Review is still open, and your 15 new questions reset tomorrow. Pro lifts the daily cap so you can keep going.</p>'
+      + '<div class="onb-reset">' + CLOCK + '<span>New questions reset in 6 hours</span></div>'
+      + '<button type="button" class="onb-btn onb-btn-primary" data-up-action="see-pro">See Pro</button>'
+      + '<button type="button" class="onb-btn onb-btn-ghost" data-up-action="dismiss">Keep reviewing</button>';
+  }
+
+  function sheetAddCert() {
+    var feat = function (b, rest) { return '<div class="onb-feat">' + CHECK + '<span><b>' + b + '</b> ' + rest + '</span></div>'; };
+    return ''
+      + '<h2 class="onb-sh-title">Study more than one exam</h2>'
+      + '<p class="onb-sh-body">Pro opens up every exam, lets you switch between them, and removes the daily question cap.</p>'
+      + feat('All 8 exams', ', each with its own readiness score')
+      + feat('Switch anytime', ', your place in each is saved')
+      + feat('No daily cap', ' on new questions')
+      + '<div class="onb-price-row">'
+      + '  <div class="onb-price"><div class="onb-pl">Monthly</div><div class="onb-pv">$9.99</div><div class="onb-pp">per month</div></div>'
+      + '  <div class="onb-price onb-price-sel"><div class="onb-pl">Yearly</div><div class="onb-pv">$89</div><div class="onb-pp">per year</div><span class="onb-save">Save 25%</span></div>'
+      + '</div>'
+      + '<button type="button" class="onb-btn onb-btn-primary" data-up-action="go-pro">Go Pro</button>'
+      + '<button type="button" class="onb-btn onb-btn-ghost" data-up-action="dismiss">Not now</button>'
+      + '<p class="onb-fine">Cancel anytime. We never promise a passing grade.</p>';
+  }
+
+  function render(kind) {
+    var body = kind === 'add-cert' ? sheetAddCert() : sheetCap();
+    return '<div class="onb-ov-scrim" data-up-action="dismiss"></div>'
+      + '<div class="onb-sheet" role="dialog" aria-modal="true"><div class="onb-grab" aria-hidden="true"></div>' + body + '</div>';
+  }
+
+  function hide() {
+    var h = el();
+    if (!h || h.hidden) return;
+    h.classList.add('onb-ov-out');
+    var done = function () { h.hidden = true; h.classList.remove('onb-ov-out', 'onb-ov-in'); h.innerHTML = ''; };
+    if (REDUCE) { done(); return; }
+    setTimeout(done, 340);
+  }
+
+  function onClick(e) {
+    var t = e.target && e.target.closest ? e.target.closest('[data-up-action]') : null;
+    if (!t) return;
+    var action = t.getAttribute('data-up-action');
+    if (action === 'dismiss') { hide(); }
+    else if (action === 'see-pro') { window.onbUpgrade.show('add-cert'); }   // cap -> the Pro pitch
+    else if (action === 'go-pro') {
+      // TODO(saas pivot #136): real checkout. For now route to the pricing page.
+      try { console.info('[onb] upgrade: go-pro'); } catch (_) {}
+      try { window.location.href = 'https://certanvil.com/pricing.html'; } catch (_) { hide(); }
+    }
+  }
+
+  window.onbUpgrade = {
+    show: function (kind) {
+      var h = el();
+      if (!h) return;
+      if (!h._upWired) { h.addEventListener('click', onClick); h._upWired = true; }
+      h.innerHTML = render(kind);
+      h.hidden = false;
+      if (!REDUCE) { void h.offsetWidth; h.classList.add('onb-ov-in'); }
+    },
+    hide: hide
+  };
+})();

--- a/lib/onboarding-firstrun.js
+++ b/lib/onboarding-firstrun.js
@@ -37,11 +37,17 @@
   function show() { var h = container(); if (h) h.hidden = false; }
   function close() { var h = container(); if (h) { h.hidden = true; h.innerHTML = ''; } }
 
-  // Placeholder readiness until the short-calibration engine is wired (next pass).
-  // Decision (founder, 2026-06-07): first-run uses a SHORT calibration (~12-15Q),
-  // reusing the diagnostic engine with a reduced count + no confirm; the full 20-Q
-  // Baseline Diagnostic stays separate. These numbers become real once that lands.
-  var PH = { score: 465, pass: 720, weakArea: 'Subnetting', moveTo: 482, reviewCards: 5 };
+  // Placeholder readiness — used only for force-show / design review (when the
+  // flow is opened directly without running the calibration engine).
+  var PH = { score: 465, pass: 720, weakArea: 'Subnetting', moveFrom: 465, moveTo: 482, reviewCards: 5 };
+  // Real readiness, populated by the diagnostic engine (app.js startDiagnostic
+  // onboarding legs). Falls back to PH until the calibration runs.
+  var real = null;
+  function data() { return real || PH; }
+  // Preview without an API key: ?onbmock=1 (or localStorage onb_mock=1) runs the
+  // calibration on mock questions so the full flow is exercisable end-to-end.
+  var mockMode = false;
+  try { mockMode = /[?&]onbmock=1/.test(location.search) || localStorage.getItem('onb_mock') === '1'; } catch (_) {}
   function pct(s) { return ((s - 100) / 800 * 100) + '%'; }
   var REDUCE = false; try { REDUCE = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (_) {}
 
@@ -102,13 +108,14 @@
   }
 
   function screenScoreReveal() {
+    var D = data();
     var certName = (certById(state.certId) || {}).name || 'your';
-    var gap = PH.pass - PH.score;
+    var gap = Math.max(0, D.pass - D.score);
     return ''
       + '<div class="fr-screen fr-screen-center" data-fr-screen="score-reveal">'
       + '  <p class="fr-kicker fr-kicker-dim">Your readiness today</p>'
       + '  <div class="fr-readiness"><span class="fr-num" id="fr-reveal-num">0</span><span class="fr-outof">out of 900</span></div>'
-      + '  <div class="fr-bar-wrap"><div class="fr-bar-track"><div class="fr-bar-fill" id="fr-reveal-bar"></div><div class="fr-bar-tick"></div></div><div class="fr-bar-legend"><span>100</span><span class="fr-pass">Pass ' + PH.pass + '</span><span>900</span></div></div>'
+      + '  <div class="fr-bar-wrap"><div class="fr-bar-track"><div class="fr-bar-fill" id="fr-reveal-bar"></div><div class="fr-bar-tick"></div></div><div class="fr-bar-legend"><span>100</span><span class="fr-pass">Pass ' + D.pass + '</span><span>900</span></div></div>'
       + '  <p class="fr-gap">You are <b>' + gap + ' points</b> from the ' + esc(certName) + ' pass mark.</p>'
       + '  <p class="fr-honest">This estimates where you stand today, based on your diagnostic. It is not a prediction or a pass guarantee. It moves as you study.</p>'
       + '  <div class="fr-foot"><button type="button" class="fr-btn fr-btn-primary" data-fr-action="to-movement">Start closing the gap</button></div>'
@@ -116,25 +123,35 @@
   }
 
   function screenMovement() {
-    var delta = PH.moveTo - PH.score;
+    var D = data();
+    var from = (typeof D.moveFrom === 'number') ? D.moveFrom : D.score;
+    var to = (typeof D.moveTo === 'number') ? D.moveTo : D.score;
+    var delta = to - from;
+    var deltaTxt = (delta >= 0 ? '+' : '') + delta;
+    var honest = delta > 0
+      ? 'You just moved your readiness. A few questions, ' + delta + ' points. That is the whole loop: study a little, watch the number climb.'
+      : 'That is the loop: answer a few and your readiness recalculates from what you actually know. It climbs as you study.';
     return ''
       + '<div class="fr-screen fr-screen-center" data-fr-screen="movement">'
       + '  <p class="fr-kicker">Your weakest area</p>'
-      + '  <div class="fr-chip-wrap"><span class="fr-chip"><span class="fr-dot"></span>' + esc(PH.weakArea) + ' · 5 answered</span></div>'
-      + '  <div class="fr-readiness"><span class="fr-num" id="fr-move-num">' + PH.score + '</span><span class="fr-outof">out of 900</span><span class="fr-delta" id="fr-move-delta"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg>+' + delta + ' today</span></div>'
-      + '  <div class="fr-bar-wrap"><div class="fr-bar-track"><div class="fr-bar-fill" id="fr-move-bar"></div><div class="fr-bar-tick"></div></div><div class="fr-bar-legend"><span>100</span><span class="fr-pass">Pass ' + PH.pass + '</span><span>900</span></div></div>'
-      + '  <p class="fr-honest">You just moved your readiness. A few questions, ' + delta + ' points. That is the whole loop: study a little, watch the number climb.</p>'
+      + '  <div class="fr-chip-wrap"><span class="fr-chip"><span class="fr-dot"></span>' + esc(D.weakArea) + ' · 5 answered</span></div>'
+      + '  <div class="fr-readiness"><span class="fr-num" id="fr-move-num">' + from + '</span><span class="fr-outof">out of 900</span><span class="fr-delta" id="fr-move-delta"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg>' + deltaTxt + ' today</span></div>'
+      + '  <div class="fr-bar-wrap"><div class="fr-bar-track"><div class="fr-bar-fill" id="fr-move-bar"></div><div class="fr-bar-tick"></div></div><div class="fr-bar-legend"><span>100</span><span class="fr-pass">Pass ' + D.pass + '</span><span>900</span></div></div>'
+      + '  <p class="fr-honest">' + honest + '</p>'
       + '  <div class="fr-foot"><button type="button" class="fr-btn fr-btn-primary" data-fr-action="to-habit">Set up my daily habit</button></div>'
       + '</div>';
   }
 
   function screenHabit() {
+    var D = data();
+    var n = (typeof D.reviewCards === 'number') ? D.reviewCards : 0;
+    var sub = n > 0 ? (n + ' cards from what you missed today') : 'We’ll build your review deck as you practice';
     return ''
       + '<div class="fr-screen" data-fr-screen="habit">'
       + '  <p class="fr-kicker">You’re set up</p>'
       + '  <h2 class="fr-title">A few minutes a day is how it sticks.</h2>'
       + '  <p class="fr-body">Your diagnostic seeded your first review cards. Spaced practice is what moves the number, so we’ll line up a small set each day.</p>'
-      + '  <div class="fr-card-focal"><div class="fr-rev"><div class="fr-rev-ring"><span>' + PH.reviewCards + '</span></div><div><div class="fr-rev-title">Daily Review ready tomorrow</div><div class="fr-rev-sub">' + PH.reviewCards + ' cards from what you missed today</div></div></div></div>'
+      + '  <div class="fr-card-focal"><div class="fr-rev"><div class="fr-rev-ring"><span>' + n + '</span></div><div><div class="fr-rev-title">Daily Review ready tomorrow</div><div class="fr-rev-sub">' + sub + '</div></div></div></div>'
       + '  <div class="fr-streak"><span>Streak started.</span><b>Day 1</b></div>'
       + '  <div class="fr-foot"><button type="button" class="fr-btn fr-btn-primary" data-fr-action="finish-firstrun">Go to my home</button></div>'
       + '</div>';
@@ -147,21 +164,62 @@
 
   function goScoreReveal() {
     show(); render(screenScoreReveal());
+    var D = data();
     var bar = document.getElementById('fr-reveal-bar');
-    if (bar) { bar.style.transition = 'none'; bar.style.width = '0'; void bar.offsetWidth; bar.style.transition = ''; bar.style.width = pct(PH.score); }
-    animateNum(document.getElementById('fr-reveal-num'), 0, PH.score, 1100);
+    if (bar) { bar.style.transition = 'none'; bar.style.width = '0'; void bar.offsetWidth; bar.style.transition = ''; bar.style.width = pct(D.score); }
+    animateNum(document.getElementById('fr-reveal-num'), 0, D.score, 1100);
   }
 
   function goMovement() {
     show(); render(screenMovement());
+    var D = data();
+    var from = (typeof D.moveFrom === 'number') ? D.moveFrom : D.score;
+    var to = (typeof D.moveTo === 'number') ? D.moveTo : D.score;
     var bar = document.getElementById('fr-move-bar');
     var delta = document.getElementById('fr-move-delta');
     var num = document.getElementById('fr-move-num');
-    if (bar) { bar.style.transition = 'none'; bar.style.width = pct(PH.score); void bar.offsetWidth; }
+    if (bar) { bar.style.transition = 'none'; bar.style.width = pct(from); void bar.offsetWidth; }
     setTimeout(function () {
-      if (bar) { bar.style.transition = ''; bar.style.width = pct(PH.moveTo); }
-      animateNum(num, PH.score, PH.moveTo, 900, function () { if (delta) delta.classList.add('show'); });
+      if (bar) { bar.style.transition = ''; bar.style.width = pct(to); }
+      animateNum(num, from, to, 900, function () { if (delta && to > from) delta.classList.add('show'); });
     }, 420);
+  }
+
+  // ── engine bridge: launch the real diagnostic, consume real readiness ────────
+  // The calibration + movement legs hand off to app.js's diagnostic engine
+  // (startDiagnostic with onboarding opts). The overlay is hidden while the
+  // diagnostic-quiz page is up, then re-shown at the relevant screen on
+  // completion with the real numbers.
+  function onCalibrationDone(res) {
+    var pp = (res && res.passPlan) ? res.passPlan : {};
+    var weak = (pp.weakDomains && pp.weakDomains[0]) || null;
+    var score = (typeof pp.predicted === 'number') ? pp.predicted : PH.score;
+    real = {
+      score: score,
+      pass: (res && typeof res.passScore === 'number') ? res.passScore
+        : ((window.CERT_PACK && window.CERT_PACK.meta && window.CERT_PACK.meta.examPassScore) || 720),
+      weakArea: weak ? weak.label : 'your weakest area',
+      reviewCards: (typeof pp.seededCount === 'number') ? pp.seededCount : 0,
+      calibScore: score,
+      moveFrom: score,
+      moveTo: score,
+      session: res ? res.session : null
+    };
+    try { if (typeof window.showPage === 'function') window.showPage('setup'); } catch (_) {}
+    goScoreReveal();
+  }
+
+  function onMovementDone(res) {
+    var pp = (res && res.passPlan) ? res.passPlan : {};
+    var to = (typeof pp.predicted === 'number') ? pp.predicted : (real ? real.score : PH.score);
+    if (!real) real = { pass: (window.EXAM_PASS_SCORE || 720), weakArea: 'your weakest area', calibScore: to };
+    real.moveFrom = real.calibScore;
+    real.moveTo = to;
+    real.score = to;
+    if (typeof pp.seededCount === 'number') real.reviewCards = (real.reviewCards || 0) + pp.seededCount;
+    real.session = res ? res.session : real.session;
+    try { if (typeof window.showPage === 'function') window.showPage('setup'); } catch (_) {}
+    goMovement();
   }
 
   function goHabit() { show(); render(screenHabit()); }
@@ -181,20 +239,23 @@
     } else if (action === 'confirm-cert') {
       goDiagnosticIntro();
     } else if (action === 'start-diagnostic') {
-      // TODO(next pass): launch the SHORT first-run calibration (~12-15Q) — reuse
-      // the diagnostic engine with a reduced count + no confirm — then feed the
-      // real readiness into score-reveal. For now show score-reveal w/ placeholder.
-      try { console.info('[onb] first-run: start calibration for', state.certId); } catch (_) {}
-      goScoreReveal();
+      try { console.info('[onb] first-run: start calibration for', state.certId, mockMode ? '(mock)' : ''); } catch (_) {}
+      if (typeof window.startDiagnostic !== 'function') { goScoreReveal(); return; }  // engine absent → design-review fallback
+      close();  // reveal the diagnostic-quiz page beneath the overlay
+      window.startDiagnostic({ count: 15, skipConfirm: true, onboarding: 'calibration', mock: mockMode, onComplete: onCalibrationDone });
     } else if (action === 'skip-diagnostic') {
       try { console.info('[onb] first-run: skipped diagnostic for', state.certId); } catch (_) {}
       handToHome();
     } else if (action === 'to-movement') {
-      goMovement();
+      if (!real || typeof window.startDiagnostic !== 'function') { goMovement(); return; }  // fallback if engine/real absent
+      try { console.info('[onb] first-run: movement practice for', state.certId); } catch (_) {}
+      close();
+      window.startDiagnostic({ count: 5, skipConfirm: true, onboarding: 'movement', mock: mockMode, priorSession: real.session, onComplete: onMovementDone });
     } else if (action === 'to-habit') {
       goHabit();
     } else if (action === 'finish-firstrun') {
-      // TODO(next pass): set metadata.activated[certId] via cloud-store.
+      // Activation is already set: the calibration wrote the per-cert readiness
+      // snapshot, which is the lobby router's activation signal. Just reveal home.
       try { console.info('[onb] first-run: complete for', state.certId); } catch (_) {}
       handToHome();
     }

--- a/lib/onboarding-firstrun.js
+++ b/lib/onboarding-firstrun.js
@@ -1,0 +1,129 @@
+// lib/onboarding-firstrun.js — Onboarding first-run spine (Phase 1).
+//
+// Renders the activation sequence (cert pick -> diagnostic intro -> diagnostic
+// -> score reveal -> +5 movement -> habit hook) into #onb-firstrun, lifted from
+// the approved mockup (mockups/onboarding-first-run-concept.html), forged-bronze.
+//
+// Launched by the lobby router's 'first-run' decision via window.onbFirstRun.start().
+// GUARDED: only ever invoked when onboarding-boot is enabled (?onb=1), so it is
+// inert by default. The deep engine wiring (real diagnostic / readiness / SR) is
+// layered in incrementally; this increment ships the cert-pick + diagnostic-intro
+// screens and the sequence shell.
+//
+// Sec-P7: no inline on* handlers. One delegated click listener reads data-fr-action.
+
+(function () {
+  'use strict';
+
+  // The 8 certs (static metadata; stable). Matches the cert packs + landing My Certs.
+  var CERTS = [
+    { id: 'netplus',     name: 'Network+',           vendor: 'CompTIA · N10-009',  mark: 'N+'  },
+    { id: 'secplus',     name: 'Security+',          vendor: 'CompTIA · SY0-701',  mark: 'S+'  },
+    { id: 'aplus-core1', name: 'A+ Core 1',          vendor: 'CompTIA · 220-1101', mark: 'A+'  },
+    { id: 'aplus-core2', name: 'A+ Core 2',          vendor: 'CompTIA · 220-1102', mark: 'A+'  },
+    { id: 'az900',       name: 'AZ-900',             vendor: 'Microsoft Azure Fundamentals',     mark: 'AZ'  },
+    { id: 'ai900',       name: 'AI-900',             vendor: 'Microsoft Azure AI Fundamentals',  mark: 'AI'  },
+    { id: 'sc900',       name: 'SC-900',             vendor: 'Microsoft Security Fundamentals',  mark: 'SC'  },
+    { id: 'clfc02',      name: 'Cloud Practitioner', vendor: 'AWS · CLF-C02',      mark: 'CLF' }
+  ];
+
+  var host = null;
+  var state = { certId: null, tier: 'free' };
+
+  function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+  function container() { return host || (host = document.getElementById('onb-firstrun')); }
+  function certById(id) { for (var i = 0; i < CERTS.length; i++) if (CERTS[i].id === id) return CERTS[i]; return null; }
+
+  function show() { var h = container(); if (h) h.hidden = false; }
+  function close() { var h = container(); if (h) { h.hidden = true; h.innerHTML = ''; } }
+
+  // ── Screens ────────────────────────────────────────────────────────────────
+  function screenCertPick() {
+    var sel = state.certId || (window.CURRENT_CERT || 'netplus');
+    state.certId = sel;
+    var rows = CERTS.map(function (c) {
+      var on = c.id === sel ? ' fr-sel' : '';
+      return '<button type="button" class="fr-cert' + on + '" data-fr-action="pick-cert" data-fr-cert="' + c.id + '">'
+        + '<span class="fr-mark">' + esc(c.mark) + '</span>'
+        + '<span class="fr-cmeta"><span class="fr-cname">' + esc(c.name) + '</span><span class="fr-cvendor">' + esc(c.vendor) + '</span></span>'
+        + '<span class="fr-check" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></span>'
+        + '</button>';
+    }).join('');
+    var selName = (certById(sel) || {}).name || 'this exam';
+    return ''
+      + '<div class="fr-screen" data-fr-screen="cert-pick">'
+      + '  <p class="fr-kicker">Step 1 of 3</p>'
+      + '  <h2 class="fr-title">Which exam are you studying for?</h2>'
+      + '  <p class="fr-body">Pick one to get your readiness score. On the free plan you focus on a single exam at a time.</p>'
+      + '  <div class="fr-cert-list">' + rows + '</div>'
+      + '  <div class="fr-foot">'
+      + '    <button type="button" class="fr-btn fr-btn-primary" data-fr-action="confirm-cert">Continue with ' + esc(selName) + '</button>'
+      + '    <p class="fr-micro">8 exams available. Switching between them is a Pro feature.</p>'
+      + '  </div>'
+      + '</div>';
+  }
+
+  function screenDiagnosticIntro() {
+    return ''
+      + '<div class="fr-screen" data-fr-screen="diagnostic-intro">'
+      + '  <p class="fr-kicker">Step 2 of 3</p>'
+      + '  <h2 class="fr-title">Let’s see where you stand.</h2>'
+      + '  <p class="fr-body">Answer about 15 questions so we can calibrate your readiness. No studying needed. Anything you miss becomes your first review set.</p>'
+      + '  <div class="fr-reassure">'
+      + '    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l7 3v5c0 4.4-3 7.6-7 9-4-1.4-7-4.6-7-9V6l7-3z"/><path d="M9 12l2 2 4-4"/></svg>'
+      + '    <span><b>This is calibration, not a test.</b> There is nothing to fail here. A low score just means more room to climb.</span>'
+      + '  </div>'
+      + '  <div class="fr-foot">'
+      + '    <button type="button" class="fr-btn fr-btn-primary" data-fr-action="start-diagnostic">Start the 15-question check</button>'
+      + '    <button type="button" class="fr-btn fr-btn-ghost" data-fr-action="skip-diagnostic">Skip for now</button>'
+      + '    <p class="fr-micro">Takes about 4 minutes, and it does not use your daily questions. You can take it later from your home.</p>'
+      + '  </div>'
+      + '</div>';
+  }
+
+  function render(html) { var h = container(); if (h) { h.innerHTML = html; h.scrollTop = 0; } }
+
+  function goCertPick() { show(); render(screenCertPick()); }
+  function goDiagnosticIntro() { show(); render(screenDiagnosticIntro()); }
+
+  // Hand off to the existing home (engine wiring for the real diagnostic comes
+  // in the next increment). Reveals the cert-app underneath.
+  function handToHome() { close(); }
+
+  // ── Delegated actions ────────────────────────────────────────────────────────
+  function onClick(e) {
+    var t = e.target && e.target.closest ? e.target.closest('[data-fr-action]') : null;
+    if (!t) return;
+    var action = t.getAttribute('data-fr-action');
+    if (action === 'pick-cert') {
+      state.certId = t.getAttribute('data-fr-cert');
+      goCertPick();                       // re-render with new selection + button label
+    } else if (action === 'confirm-cert') {
+      goDiagnosticIntro();
+    } else if (action === 'start-diagnostic') {
+      // TODO(next increment): launch the existing diagnostic engine for state.certId.
+      try { console.info('[onb] first-run: start diagnostic for', state.certId); } catch (_) {}
+      handToHome();
+    } else if (action === 'skip-diagnostic') {
+      try { console.info('[onb] first-run: skipped diagnostic for', state.certId); } catch (_) {}
+      handToHome();
+    }
+  }
+
+  // ── Public API ───────────────────────────────────────────────────────────────
+  window.onbFirstRun = {
+    start: function (decision) {
+      decision = decision || {};
+      state.certId = decision.certId || window.CURRENT_CERT || null;
+      state.tier = decision.tier || 'free';
+      var h = container();
+      if (h && !h._frWired) { h.addEventListener('click', onClick); h._frWired = true; }
+      // If the cert is already known (free locked cert / Pro switching to a known
+      // cert), skip the picker and open at the diagnostic intro.
+      if (state.certId && decision.reason === 'not-activated') goDiagnosticIntro();
+      else goCertPick();
+    },
+    close: close,
+    _state: function () { return { certId: state.certId, tier: state.tier, visible: container() && !container().hidden }; }
+  };
+})();

--- a/lib/onboarding-firstrun.js
+++ b/lib/onboarding-firstrun.js
@@ -209,8 +209,9 @@
       var h = container();
       if (h && !h._frWired) { h.addEventListener('click', onClick); h._frWired = true; }
       // If the cert is already known (free locked cert / Pro switching to a known
-      // cert), skip the picker and open at the diagnostic intro.
-      if (state.certId && decision.reason === 'not-activated') goDiagnosticIntro();
+      // but un-activated cert via the switcher), skip the picker and open at the
+      // diagnostic intro for that cert.
+      if (state.certId && (decision.reason === 'not-activated' || decision.reason === 'switch-not-activated')) goDiagnosticIntro();
       else goCertPick();
     },
     close: close,

--- a/lib/onboarding-firstrun.js
+++ b/lib/onboarding-firstrun.js
@@ -37,6 +37,26 @@
   function show() { var h = container(); if (h) h.hidden = false; }
   function close() { var h = container(); if (h) { h.hidden = true; h.innerHTML = ''; } }
 
+  // Placeholder readiness until the short-calibration engine is wired (next pass).
+  // Decision (founder, 2026-06-07): first-run uses a SHORT calibration (~12-15Q),
+  // reusing the diagnostic engine with a reduced count + no confirm; the full 20-Q
+  // Baseline Diagnostic stays separate. These numbers become real once that lands.
+  var PH = { score: 465, pass: 720, weakArea: 'Subnetting', moveTo: 482, reviewCards: 5 };
+  function pct(s) { return ((s - 100) / 800 * 100) + '%'; }
+  var REDUCE = false; try { REDUCE = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (_) {}
+
+  // count-up with a setTimeout fallback + done-guard (robust if rAF is throttled).
+  function animateNum(elm, from, to, ms, onDone) {
+    if (!elm) { if (onDone) onDone(); return; }
+    elm.textContent = from;
+    if (REDUCE) { elm.textContent = to; if (onDone) onDone(); return; }
+    var start = null, done = false;
+    function finish() { if (done) return; done = true; elm.textContent = to; if (onDone) onDone(); }
+    function step(t) { if (done) return; if (start === null) start = t; var p = Math.min((t - start) / ms, 1); elm.textContent = Math.round(from + (to - from) * (1 - Math.pow(1 - p, 3))); if (p < 1) requestAnimationFrame(step); else finish(); }
+    requestAnimationFrame(step);
+    setTimeout(finish, ms + 250);
+  }
+
   // ── Screens ────────────────────────────────────────────────────────────────
   function screenCertPick() {
     var sel = state.certId || (window.CURRENT_CERT || 'netplus');
@@ -81,10 +101,70 @@
       + '</div>';
   }
 
+  function screenScoreReveal() {
+    var certName = (certById(state.certId) || {}).name || 'your';
+    var gap = PH.pass - PH.score;
+    return ''
+      + '<div class="fr-screen fr-screen-center" data-fr-screen="score-reveal">'
+      + '  <p class="fr-kicker fr-kicker-dim">Your readiness today</p>'
+      + '  <div class="fr-readiness"><span class="fr-num" id="fr-reveal-num">0</span><span class="fr-outof">out of 900</span></div>'
+      + '  <div class="fr-bar-wrap"><div class="fr-bar-track"><div class="fr-bar-fill" id="fr-reveal-bar"></div><div class="fr-bar-tick"></div></div><div class="fr-bar-legend"><span>100</span><span class="fr-pass">Pass ' + PH.pass + '</span><span>900</span></div></div>'
+      + '  <p class="fr-gap">You are <b>' + gap + ' points</b> from the ' + esc(certName) + ' pass mark.</p>'
+      + '  <p class="fr-honest">This estimates where you stand today, based on your diagnostic. It is not a prediction or a pass guarantee. It moves as you study.</p>'
+      + '  <div class="fr-foot"><button type="button" class="fr-btn fr-btn-primary" data-fr-action="to-movement">Start closing the gap</button></div>'
+      + '</div>';
+  }
+
+  function screenMovement() {
+    var delta = PH.moveTo - PH.score;
+    return ''
+      + '<div class="fr-screen fr-screen-center" data-fr-screen="movement">'
+      + '  <p class="fr-kicker">Your weakest area</p>'
+      + '  <div class="fr-chip-wrap"><span class="fr-chip"><span class="fr-dot"></span>' + esc(PH.weakArea) + ' · 5 answered</span></div>'
+      + '  <div class="fr-readiness"><span class="fr-num" id="fr-move-num">' + PH.score + '</span><span class="fr-outof">out of 900</span><span class="fr-delta" id="fr-move-delta"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg>+' + delta + ' today</span></div>'
+      + '  <div class="fr-bar-wrap"><div class="fr-bar-track"><div class="fr-bar-fill" id="fr-move-bar"></div><div class="fr-bar-tick"></div></div><div class="fr-bar-legend"><span>100</span><span class="fr-pass">Pass ' + PH.pass + '</span><span>900</span></div></div>'
+      + '  <p class="fr-honest">You just moved your readiness. A few questions, ' + delta + ' points. That is the whole loop: study a little, watch the number climb.</p>'
+      + '  <div class="fr-foot"><button type="button" class="fr-btn fr-btn-primary" data-fr-action="to-habit">Set up my daily habit</button></div>'
+      + '</div>';
+  }
+
+  function screenHabit() {
+    return ''
+      + '<div class="fr-screen" data-fr-screen="habit">'
+      + '  <p class="fr-kicker">You’re set up</p>'
+      + '  <h2 class="fr-title">A few minutes a day is how it sticks.</h2>'
+      + '  <p class="fr-body">Your diagnostic seeded your first review cards. Spaced practice is what moves the number, so we’ll line up a small set each day.</p>'
+      + '  <div class="fr-card-focal"><div class="fr-rev"><div class="fr-rev-ring"><span>' + PH.reviewCards + '</span></div><div><div class="fr-rev-title">Daily Review ready tomorrow</div><div class="fr-rev-sub">' + PH.reviewCards + ' cards from what you missed today</div></div></div></div>'
+      + '  <div class="fr-streak"><span>Streak started.</span><b>Day 1</b></div>'
+      + '  <div class="fr-foot"><button type="button" class="fr-btn fr-btn-primary" data-fr-action="finish-firstrun">Go to my home</button></div>'
+      + '</div>';
+  }
+
   function render(html) { var h = container(); if (h) { h.innerHTML = html; h.scrollTop = 0; } }
 
   function goCertPick() { show(); render(screenCertPick()); }
   function goDiagnosticIntro() { show(); render(screenDiagnosticIntro()); }
+
+  function goScoreReveal() {
+    show(); render(screenScoreReveal());
+    var bar = document.getElementById('fr-reveal-bar');
+    if (bar) { bar.style.transition = 'none'; bar.style.width = '0'; void bar.offsetWidth; bar.style.transition = ''; bar.style.width = pct(PH.score); }
+    animateNum(document.getElementById('fr-reveal-num'), 0, PH.score, 1100);
+  }
+
+  function goMovement() {
+    show(); render(screenMovement());
+    var bar = document.getElementById('fr-move-bar');
+    var delta = document.getElementById('fr-move-delta');
+    var num = document.getElementById('fr-move-num');
+    if (bar) { bar.style.transition = 'none'; bar.style.width = pct(PH.score); void bar.offsetWidth; }
+    setTimeout(function () {
+      if (bar) { bar.style.transition = ''; bar.style.width = pct(PH.moveTo); }
+      animateNum(num, PH.score, PH.moveTo, 900, function () { if (delta) delta.classList.add('show'); });
+    }, 420);
+  }
+
+  function goHabit() { show(); render(screenHabit()); }
 
   // Hand off to the existing home (engine wiring for the real diagnostic comes
   // in the next increment). Reveals the cert-app underneath.
@@ -101,11 +181,21 @@
     } else if (action === 'confirm-cert') {
       goDiagnosticIntro();
     } else if (action === 'start-diagnostic') {
-      // TODO(next increment): launch the existing diagnostic engine for state.certId.
-      try { console.info('[onb] first-run: start diagnostic for', state.certId); } catch (_) {}
-      handToHome();
+      // TODO(next pass): launch the SHORT first-run calibration (~12-15Q) — reuse
+      // the diagnostic engine with a reduced count + no confirm — then feed the
+      // real readiness into score-reveal. For now show score-reveal w/ placeholder.
+      try { console.info('[onb] first-run: start calibration for', state.certId); } catch (_) {}
+      goScoreReveal();
     } else if (action === 'skip-diagnostic') {
       try { console.info('[onb] first-run: skipped diagnostic for', state.certId); } catch (_) {}
+      handToHome();
+    } else if (action === 'to-movement') {
+      goMovement();
+    } else if (action === 'to-habit') {
+      goHabit();
+    } else if (action === 'finish-firstrun') {
+      // TODO(next pass): set metadata.activated[certId] via cloud-store.
+      try { console.info('[onb] first-run: complete for', state.certId); } catch (_) {}
       handToHome();
     }
   }

--- a/lib/onboarding-home.js
+++ b/lib/onboarding-home.js
@@ -1,0 +1,310 @@
+// lib/onboarding-home.js — Onboarding tier chrome (Phase 2): home bar + cert switcher.
+//
+// The post-activation home surfaces lifted from mockups/onboarding-batch2-concept.html:
+//   • Free home — quota meter (Daily Review due · New practice X/15) + "Add an exam · Pro".
+//   • Pro home  — a cert switcher pill that opens the "Your exams" sheet (per-cert
+//     readiness, Take-diagnostic for an exam not started yet).
+//   • Wires the upgrade-sheet triggers (daily cap / add a cert) onto STUBBED tier +
+//     quota state. Entitlements are saas-gated (#136), so this is display + a soft
+//     daily counter only — no hard enforcement, no Stripe.
+//
+// GUARDED — OFF BY DEFAULT. Inert unless the onboarding flag is on (localStorage
+// 'onb_router', set by ?onb=1). Tier is a preview stub: ?onbtier=pro|free (persisted)
+// lets a preview exercise both homes; default follows the router stub ('free').
+//
+// It injects ONE element — .onb-home-bar — as the first child of the home bento
+// (main.board inside #page-setup). It never rewrites the existing home. Mount /
+// unmount is driven by wrapping window.showPage, patched at DOMContentLoaded AFTER
+// app.js has defined it; app.js itself stays untouched (keeps this off the files
+// that overlap the in-flight mobile-fit2 branch).
+//
+// Sec-P7: no inline on* handlers. Delegated clicks read data-home-action.
+
+(function () {
+  'use strict';
+
+  // ── guard + stubbed tier ────────────────────────────────────────────────────
+  function guardOn() {
+    try {
+      var s = location.search || '';
+      if (s.indexOf('onbtier=pro') !== -1) localStorage.setItem('onb_tier', 'pro');
+      if (s.indexOf('onbtier=free') !== -1) localStorage.removeItem('onb_tier');
+      return localStorage.getItem('onb_router') === '1';
+    } catch (_) { return false; }
+  }
+  function tier() {
+    try { if (localStorage.getItem('onb_tier') === 'pro') return 'pro'; } catch (_) {}
+    return 'free';
+  }
+
+  var ENABLED = guardOn();
+  var REDUCE = false;
+  try { REDUCE = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (_) {}
+
+  // The 8 certs (static metadata; mirrors onboarding-firstrun.js + the cert packs).
+  var CERTS = [
+    { id: 'netplus',     name: 'Network+',           vendor: 'N10-009',  mark: 'N+'  },
+    { id: 'secplus',     name: 'Security+',          vendor: 'SY0-701',  mark: 'S+'  },
+    { id: 'aplus-core1', name: 'A+ Core 1',          vendor: '220-1101', mark: 'A+'  },
+    { id: 'aplus-core2', name: 'A+ Core 2',          vendor: '220-1102', mark: 'A+'  },
+    { id: 'az900',       name: 'AZ-900',             vendor: 'Azure Fundamentals',    mark: 'AZ'  },
+    { id: 'ai900',       name: 'AI-900',             vendor: 'Azure AI Fundamentals', mark: 'AI'  },
+    { id: 'sc900',       name: 'SC-900',             vendor: 'Security Fundamentals',  mark: 'SC'  },
+    { id: 'clfc02',      name: 'Cloud Practitioner', vendor: 'CLF-C02',  mark: 'CLF' }
+  ];
+
+  var NEW_Q_CAP = 15;   // free daily new-question cap (display only; #136 enforces)
+  var REVIEW_CAP = 5;   // free daily review cap
+
+  function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+  function certById(id) { for (var i = 0; i < CERTS.length; i++) if (CERTS[i].id === id) return CERTS[i]; return null; }
+  function currentCertId() { return (window.CURRENT_CERT) || (state.certId) || 'netplus'; }
+
+  var state = { certId: null };
+  var enteredOnce = false;   // entrance animation plays only the first time the bar appears
+
+  // ── real-ish data reads (cheap, read-only) ───────────────────────────────────
+  // Per-cert readiness score from the shipped snapshot store; null if not scored.
+  function readinessFor(certId) {
+    try {
+      var raw = localStorage.getItem('nplus_readiness_snapshots');
+      if (!raw) return null;
+      var snaps = JSON.parse(raw) || {};
+      var s = snaps[certId];
+      if (s && typeof s.score === 'number') return Math.round(s.score);
+      if (typeof s === 'number') return Math.round(s);
+    } catch (_) {}
+    return null;
+  }
+  function isActivated(certId) { return readinessFor(certId) != null; }
+  function dueCount() {
+    try { if (typeof window.getSrDueCount === 'function') return window.getSrDueCount() | 0; } catch (_) {}
+    return 0;
+  }
+  // Stubbed soft counter for new questions answered today (#136 owns the real one).
+  function todayKey() { try { return (new Date()).toISOString().slice(0, 10); } catch (_) { return 'x'; } }
+  function newUsed() {
+    try { return Math.max(0, parseInt(localStorage.getItem('onb_q_new_' + todayKey()) || '0', 10) || 0); } catch (_) { return 0; }
+  }
+  function setNewUsed(n) {
+    try { localStorage.setItem('onb_q_new_' + todayKey(), String(Math.max(0, n | 0))); } catch (_) {}
+  }
+  function hoursToReset() {
+    try {
+      var now = new Date();
+      var end = new Date(now); end.setHours(24, 0, 0, 0);
+      return Math.max(1, Math.ceil((end - now) / 3600000));
+    } catch (_) { return 6; }
+  }
+
+  // ── the home bar ──────────────────────────────────────────────────────────────
+  function svgChevron() { return '<svg class="onb-hb-chev" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>'; }
+
+  function switcherPill() {
+    var c = certById(currentCertId()) || CERTS[0];
+    return '<button type="button" class="onb-hb-switcher" data-home-action="open-switcher" aria-haspopup="dialog">'
+      + '<span class="onb-hb-mark">' + esc(c.mark) + '</span>'
+      + '<span class="onb-hb-ct"><span class="onb-hb-name">' + esc(c.name) + '</span><span class="onb-hb-code">' + esc(c.vendor) + '</span></span>'
+      + svgChevron()
+      + '</button>';
+  }
+
+  function quotaRows(t) {
+    var due = dueCount();
+    var reviewVal = t === 'pro'
+      ? (due + ' due')
+      : (due > REVIEW_CAP ? (REVIEW_CAP + ' of ' + REVIEW_CAP + ' today') : (due + (due === 1 ? ' card due' : ' cards due')));
+    var newRow;
+    if (t === 'pro') {
+      newRow = '<div class="onb-hb-row"><span class="onb-hb-rn">New practice</span><span class="onb-hb-rv onb-hb-rv-free">Unlimited</span></div>';
+    } else {
+      var used = Math.min(newUsed(), NEW_Q_CAP);
+      var capped = used >= NEW_Q_CAP;
+      var pctw = Math.round(used / NEW_Q_CAP * 100);
+      var rv = capped
+        ? '<button type="button" class="onb-hb-capbtn" data-home-action="cap-hit">Resets in ' + hoursToReset() + 'h</button>'
+        : (used + ' / ' + NEW_Q_CAP + ' today');
+      newRow = '<div class="onb-hb-row">'
+        + '<span class="onb-hb-rn">New practice</span><span class="onb-hb-rv">' + rv + '</span>'
+        + '</div>'
+        + '<div class="onb-hb-meter" aria-hidden="true"><span style="width:' + pctw + '%"></span></div>';
+    }
+    return '<div class="onb-hb-row"><span class="onb-hb-rn">Daily Review</span><span class="onb-hb-rv">' + esc(reviewVal) + '</span></div>' + newRow;
+  }
+
+  function barHtml() {
+    var t = tier();
+    var top = t === 'pro'
+      ? '<div class="onb-hb-top">' + switcherPill() + '<span class="onb-hb-plan onb-hb-plan-pro">Pro</span></div>'
+      : '<div class="onb-hb-top"><div class="onb-hb-cert"><span class="onb-hb-mark">' + esc((certById(currentCertId()) || CERTS[0]).mark) + '</span>'
+        + '<span class="onb-hb-ct"><span class="onb-hb-name">' + esc((certById(currentCertId()) || CERTS[0]).name) + '</span><span class="onb-hb-code">' + esc((certById(currentCertId()) || CERTS[0]).vendor) + '</span></span></div>'
+        + '<span class="onb-hb-plan">Free</span></div>';
+    var addCert = t === 'free'
+      ? '<button type="button" class="onb-hb-add" data-home-action="add-cert"><span class="onb-hb-plus" aria-hidden="true">+</span><span>Add an exam</span><span class="onb-hb-protag">Pro</span></button>'
+      : '';
+    return '<div class="onb-home-bar" data-onb-tier="' + t + '">'
+      + top
+      + '<div class="onb-hb-quota">' + quotaRows(t) + '</div>'
+      + addCert
+      + '</div>';
+  }
+
+  function mountTarget() {
+    var setup = document.getElementById('page-setup');
+    if (!setup) return null;
+    return setup.querySelector('main.board') || setup;
+  }
+
+  function unmount() {
+    var ex = document.getElementById('onb-home-bar-host');
+    if (ex && ex.parentNode) ex.parentNode.removeChild(ex);
+  }
+
+  function mount() {
+    if (!ENABLED) return;
+    var target = mountTarget();
+    if (!target) return;
+    unmount();
+    var wrap = document.createElement('div');
+    wrap.id = 'onb-home-bar-host';
+    wrap.innerHTML = barHtml();
+    if (!enteredOnce) {
+      var bar = wrap.querySelector('.onb-home-bar');
+      if (bar) bar.classList.add('onb-hb-enter');
+      enteredOnce = true;
+    }
+    wrap.addEventListener('click', onBarClick);
+    target.insertBefore(wrap, target.firstChild);
+  }
+
+  function sync() { if (document.getElementById('onb-home-bar-host')) mount(); }
+
+  function onBarClick(e) {
+    var t = e.target && e.target.closest ? e.target.closest('[data-home-action]') : null;
+    if (!t) return;
+    var action = t.getAttribute('data-home-action');
+    if (action === 'open-switcher') { openSwitcher(); }
+    else if (action === 'add-cert') { if (window.onbUpgrade) window.onbUpgrade.show('add-cert'); }
+    else if (action === 'cap-hit') { if (window.onbUpgrade) window.onbUpgrade.show('cap'); }
+  }
+
+  // ── "Your exams" switcher sheet (reuses the #onb-overlay sheet mechanism) ─────
+  function overlay() { return document.getElementById('onb-overlay'); }
+
+  function switcherSheetHtml() {
+    var cur = currentCertId();
+    var rows = CERTS.map(function (c) {
+      var score = readinessFor(c.id);
+      var on = c.id === cur ? ' onb-sw-sel' : '';
+      var right = score != null
+        ? '<span class="onb-sw-score"><span class="onb-sw-v">' + score + '</span><span class="onb-sw-l">/ 900</span></span>'
+        : '<span class="onb-sw-start">Take diagnostic</span>';
+      var sub = score != null ? esc(c.vendor) : 'Not started yet';
+      return '<button type="button" class="onb-sw-row' + on + '" data-home-action="pick-cert" data-home-cert="' + c.id + '">'
+        + '<span class="onb-sw-mark">' + esc(c.mark) + '</span>'
+        + '<span class="onb-sw-meta"><span class="onb-sw-cn">' + esc(c.name) + '</span><span class="onb-sw-cs">' + sub + '</span></span>'
+        + right
+        + '</button>';
+    }).join('');
+    return '<div class="onb-ov-scrim" data-home-action="dismiss"></div>'
+      + '<div class="onb-sheet" role="dialog" aria-modal="true" aria-label="Your exams"><div class="onb-grab" aria-hidden="true"></div>'
+      + '<h2 class="onb-sh-title">Your exams</h2>'
+      + '<div class="onb-sw-list">' + rows + '</div>'
+      + '<button type="button" class="onb-sw-add" data-home-action="add-cert"><span class="onb-sw-plus" aria-hidden="true">+</span><span>Add an exam</span></button>'
+      + '<button type="button" class="onb-sw-link" data-home-action="see-all">See all your exams and progress</button>'
+      + '</div>';
+  }
+
+  function openSheet(html) {
+    var h = overlay();
+    if (!h) return;
+    if (!h._homeWired) { h.addEventListener('click', onSheetClick); h._homeWired = true; }
+    h.innerHTML = html;
+    h.hidden = false;
+    if (!REDUCE) { void h.offsetWidth; h.classList.add('onb-ov-in'); }
+  }
+  function closeSheet() {
+    var h = overlay();
+    if (!h || h.hidden) return;
+    h.classList.add('onb-ov-out');
+    var done = function () { h.hidden = true; h.classList.remove('onb-ov-out', 'onb-ov-in'); h.innerHTML = ''; };
+    if (REDUCE) { done(); return; }
+    setTimeout(done, 340);
+  }
+
+  function openSwitcher() {
+    if (tier() !== 'pro') { if (window.onbUpgrade) window.onbUpgrade.show('add-cert'); return; }
+    openSheet(switcherSheetHtml());
+  }
+
+  function onSheetClick(e) {
+    var t = e.target && e.target.closest ? e.target.closest('[data-home-action]') : null;
+    if (!t) return;
+    var action = t.getAttribute('data-home-action');
+    if (action === 'dismiss') { closeSheet(); return; }
+    if (action === 'add-cert') { closeSheet(); if (window.onbUpgrade) setTimeout(function () { window.onbUpgrade.show('add-cert'); }, REDUCE ? 0 : 200); return; }
+    if (action === 'see-all') { closeSheet(); try { if (typeof window.showMyCerts === 'function') window.showMyCerts(); } catch (_) {} return; }
+    if (action === 'pick-cert') {
+      var certId = t.getAttribute('data-home-cert');
+      closeSheet();
+      var R = window.certanvilRouter;
+      var decision = R && R.routeOnSwitch ? R.routeOnSwitch({ metadata: { tier: tier() } }, certId) : { kind: isActivated(certId) ? 'cert-home' : 'first-run', certId: certId };
+      try { console.info('[onb] switch ->', decision.kind, certId); } catch (_) {}
+      if (decision.kind === 'first-run') {
+        setTimeout(function () { try { if (window.onbFirstRun) window.onbFirstRun.start(decision); } catch (_) {} }, REDUCE ? 0 : 200);
+      } else {
+        // Activated: this is where a real cert-switch would re-render the home for
+        // the chosen cert (writes metadata.lastActiveCertId — gated #136). For now
+        // record the intent + re-sync the bar so the pill reflects the choice.
+        state.certId = certId;
+        try { localStorage.setItem('onb_last_active_cert', certId); } catch (_) {}
+        sync();
+      }
+    }
+  }
+
+  // ── mount wiring: wrap showPage so the bar tracks the home page ───────────────
+  // app.js defines showPage inside its OWN DOMContentLoaded handler, which runs
+  // after this module's (script order), so showPage may not exist on the first
+  // try — retry briefly until it does, then wrap + mount if home is already up.
+  function wireShowPage() {
+    if (typeof window.showPage !== 'function' || window.showPage._onbHomeWrapped) return;
+    var orig = window.showPage;
+    window.showPage = function (p) {
+      var r = orig.apply(this, arguments);
+      try { if (p === 'setup') mount(); else unmount(); } catch (_) {}
+      return r;
+    };
+    window.showPage._onbHomeWrapped = true;
+  }
+
+  function patch(tries) {
+    if (!ENABLED) return;
+    tries = tries || 0;
+    if (typeof window.showPage !== 'function' && tries < 60) {
+      setTimeout(function () { patch(tries + 1); }, 50);
+      return;
+    }
+    wireShowPage();
+    // If the home is already the active page at patch time, mount immediately.
+    try {
+      var setup = document.getElementById('page-setup');
+      if (setup && setup.classList.contains('active')) mount();
+    } catch (_) {}
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', function () { patch(0); });
+  else patch(0);
+
+  // ── public API (dev/preview helpers) ─────────────────────────────────────────
+  window.onbHome = {
+    sync: sync,
+    mount: mount,
+    unmount: unmount,
+    openSwitcher: openSwitcher,
+    capHit: function () { if (window.onbUpgrade) window.onbUpgrade.show('cap'); },
+    // preview helper: simulate exhausting today's free new-question cap.
+    simulateCap: function () { setNewUsed(NEW_Q_CAP); sync(); if (window.onbUpgrade) window.onbUpgrade.show('cap'); },
+    _state: function () { return { tier: tier(), cert: currentCertId(), due: dueCount(), newUsed: newUsed() }; }
+  };
+})();

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,0 +1,110 @@
+// lib/router.js — Onboarding "lobby" router (Option B entry point).
+//
+// PURE decision logic: given auth + profile + the detected cert, decide where a
+// launch should land. This module is INERT — it has no side effects, performs no
+// cloud writes, and is not yet wired into the boot/auth sequence. Wiring it into
+// app.js boot (~:2001) + auth-state.js (getSession ~:569 / handleSignedIn ~:510)
+// is a separate, live-verified Phase 0 step.
+//
+// Spec: docs/planning/ONBOARDING_ACTIVATION_DECISIONS.md §6 (routing) + §6b
+// (on-ramp, not a rebuild). Decision tree:
+//   logged out                         -> marketing landing (strangers only)
+//   logged in, no cert                 -> first-run (cert pick)
+//   logged in, cert not activated      -> first-run (diagnostic for that cert)
+//   logged in, cert activated          -> that cert's home (existing #page-setup)
+//
+// Tier is STUBBED (saas-gated #136): getTier() returns 'free' unless an explicit
+// metadata.tier === 'pro' is set (lets previews/tests exercise the Pro path).
+
+(function (global) {
+  'use strict';
+
+  // Accept either a full profile ({ metadata: {...} }) or a raw metadata object.
+  function metaOf(profile) {
+    if (!profile) return {};
+    return profile.metadata || profile;
+  }
+
+  // --- activation (per-cert) -------------------------------------------------
+  // A cert is "activated" once the user has a readiness score for it. Stored as
+  // metadata.activated.<certId> (new; same shape as the shipped
+  // metadata.sr.<certId> cert-keying). Derived defensively: explicit flag OR an
+  // existing per-cert readiness snapshot (so users already scored pre-launch
+  // are not forced back through first-run).
+  function isActivated(profile, certId) {
+    if (!certId) return false;
+    var meta = metaOf(profile);
+    try {
+      if (meta.activated && meta.activated[certId]) return true;
+      var snaps = meta.readiness_snapshots || meta.readinessSnapshots;
+      if (snaps && snaps[certId] != null) return true;
+    } catch (_) {}
+    return false;
+  }
+
+  // --- tier (STUB — saas-gated #136) ----------------------------------------
+  function getTier(profile) {
+    var meta = metaOf(profile);
+    return meta.tier === 'pro' ? 'pro' : 'free';
+  }
+
+  function firstOwnedCert(meta) {
+    try {
+      var cr = meta.cert_results || meta.certResults;
+      if (cr) { for (var k in cr) { if (Object.prototype.hasOwnProperty.call(cr, k)) return k; } }
+    } catch (_) {}
+    return null;
+  }
+
+  // --- current cert ----------------------------------------------------------
+  // Free owns exactly one locked cert; Pro resumes its last-active cert. Falls
+  // back to the subdomain-detected cert, then to the first owned cert.
+  function currentCert(tier, profile, detectedCert) {
+    var meta = metaOf(profile);
+    if (tier === 'free') {
+      return meta.freeCertId || detectedCert || firstOwnedCert(meta) || null;
+    }
+    return meta.lastActiveCertId || detectedCert || firstOwnedCert(meta) || null;
+  }
+
+  // --- the decision ----------------------------------------------------------
+  // ctx = { isLoggedIn: bool, profile: object, detectedCert: string }
+  // returns { kind: 'landing'|'first-run'|'cert-home', certId, tier, reason }
+  function routeOnLaunch(ctx) {
+    ctx = ctx || {};
+    if (!ctx.isLoggedIn) {
+      return { kind: 'landing', certId: null, tier: null, reason: 'logged-out' };
+    }
+    var tier = getTier(ctx.profile);
+    var certId = currentCert(tier, ctx.profile, ctx.detectedCert);
+    if (!certId) {
+      return { kind: 'first-run', certId: null, tier: tier, reason: 'no-cert' };
+    }
+    if (!isActivated(ctx.profile, certId)) {
+      return { kind: 'first-run', certId: certId, tier: tier, reason: 'not-activated' };
+    }
+    return { kind: 'cert-home', certId: certId, tier: tier, reason: 'activated' };
+  }
+
+  // Pro switching to a cert never diagnosed re-enters first-run FOR that cert.
+  // (Used by the cert switcher; pure helper, the switcher wires the navigation.)
+  function routeOnSwitch(profile, certId) {
+    var tier = getTier(profile);
+    if (!certId) return { kind: 'first-run', certId: null, tier: tier, reason: 'switch-no-cert' };
+    if (!isActivated(profile, certId)) {
+      return { kind: 'first-run', certId: certId, tier: tier, reason: 'switch-not-activated' };
+    }
+    return { kind: 'cert-home', certId: certId, tier: tier, reason: 'switch-activated' };
+  }
+
+  var api = {
+    routeOnLaunch: routeOnLaunch,
+    routeOnSwitch: routeOnSwitch,
+    isActivated: isActivated,
+    getTier: getTier,
+    currentCert: currentCert
+  };
+
+  if (typeof module !== 'undefined' && module.exports) { module.exports = api; }
+  if (global) { global.certanvilRouter = api; }
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/mockups/onboarding-batch2-concept.html
+++ b/mockups/onboarding-batch2-concept.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Onboarding batch 2 (switcher · upgrades · coachmark)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: oklch(0.16 0.009 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.185 0.009 275);
+    --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.78 0.010 275); --muted: oklch(0.60 0.013 275);
+    --border: oklch(0.30 0.008 275); --border-soft: oklch(0.26 0.008 275);
+    --accent: oklch(0.80 0.155 64); --accent-bright: oklch(0.86 0.140 70); --accent-deep: oklch(0.70 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.74 0.150 152); --warn: oklch(0.80 0.130 75);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+    --scrim: oklch(0.10 0.01 275 / 0.55);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+    --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-bright: oklch(0.80 0.155 64); --accent-deep: oklch(0.42 0.150 52);
+    --on-accent: oklch(0.985 0.010 85); --pass: oklch(0.52 0.13 150); --warn: oklch(0.62 0.14 70);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+    --scrim: oklch(0.30 0.02 280 / 0.42);
+  }
+  :root { --text: var(--ink); --text-mid: var(--ink-soft); --text-dim: var(--muted); --ease: cubic-bezier(0.16,1,0.3,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink); font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 28px 20px 60px; transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 760px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 6px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 22px; letter-spacing: -0.01em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 4px 0 0; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright); background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+  .theme-toggle:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 800px; border-radius: 46px; padding: 12px; background: linear-gradient(160deg, #20232b, #0e0f13); position: relative; box-shadow: 0 30px 80px -28px rgba(0,0,0,0.55), 0 0 0 1.5px rgba(255,255,255,0.06) inset; flex: 0 0 auto; }
+  .phone-screen { position: relative; width: 366px; height: 776px; border-radius: 36px; overflow: hidden; background: var(--bg); color: var(--text); transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 116px; height: 26px; background: #0e0f13; border-radius: 0 0 16px 16px; z-index: 40; }
+  .statusbar { position: absolute; top: 0; left: 0; right: 0; height: 44px; display: flex; align-items: center; justify-content: space-between; padding: 0 22px; font-size: 12.5px; font-weight: 650; color: var(--text); z-index: 30; }
+  .statusbar .sb-right { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-bars { width: 17px; height: 11px; border: 1.4px solid var(--text); border-radius: 3px; position: relative; opacity: .9; }
+  .sb-bars::after { content: ""; position: absolute; inset: 1.6px; right: 5px; background: var(--text); border-radius: 1px; }
+
+  .screens { position: absolute; inset: 44px 0 0; overflow: hidden; }
+  .screen { position: absolute; inset: 0; background: var(--bg); z-index: 1; opacity: 0; visibility: hidden; transform: translateY(8px); }
+  .screen.active { opacity: 1; visibility: visible; transform: none; z-index: 2; transition: opacity .42s var(--ease), transform .42s var(--ease); }
+  .pad { height: 100%; overflow-y: auto; padding: 8px 22px 26px; }
+  .pad::-webkit-scrollbar { width: 0; }
+
+  /* home chrome */
+  .home-top { display: flex; align-items: center; justify-content: space-between; padding: 2px 0 14px; }
+  .switcher { display: inline-flex; align-items: center; gap: 9px; padding: 6px 10px 6px 6px; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); cursor: pointer; transition: transform .15s var(--ease), border-color .18s var(--ease); }
+  .switcher:active { transform: scale(0.98); }
+  .switcher:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .lettermark { flex: 0 0 auto; width: 34px; height: 34px; border-radius: 9px; display: grid; place-items: center; font: 800 11px/1 Inter, sans-serif; color: var(--accent); background: color-mix(in oklab, var(--accent) 12%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border)); }
+  .lettermark.big { width: 42px; height: 42px; border-radius: 11px; font-size: 13px; }
+  .switcher .ct { display: block; font-weight: 700; font-size: 14px; line-height: 1.1; color: var(--text); }
+  .switcher .cv { display: block; font-size: 11px; color: var(--text-dim); margin-top: 1px; }
+  .chev { width: 16px; height: 16px; stroke: var(--text-dim); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; margin-left: 1px; }
+  .acct { width: 30px; height: 30px; border-radius: 50%; background: color-mix(in oklab, var(--accent) 16%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)); display: grid; place-items: center; font-weight: 800; font-size: 12px; color: var(--accent); }
+
+  .card { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 18px; box-shadow: 0 1px 0 color-mix(in oklab, var(--text) 4%, transparent), 0 16px 36px -22px color-mix(in oklab, var(--text) 20%, transparent); }
+  .kicker { font-size: 10.5px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin: 0 0 8px; }
+  .ready-mini { display: flex; align-items: baseline; gap: 9px; }
+  .ready-mini .n { font-family: Fraunces, serif; font-weight: 600; font-size: 40px; line-height: 1; letter-spacing: -0.02em; color: var(--text); font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; }
+  .ready-mini .of { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+  .bar-wrap { margin: 14px 0 0; }
+  .bar-track { position: relative; height: 9px; border-radius: 999px; background: var(--surface-2); border: 1px solid var(--border-soft); }
+  .bar-fill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 999px; background: linear-gradient(90deg, var(--accent-deep), var(--accent)); }
+  .bar-tick { position: absolute; top: -7px; bottom: -7px; width: 2px; background: var(--text-mid); left: 80%; border-radius: 2px; }
+  .bar-legend { display: flex; justify-content: space-between; margin-top: 9px; font-size: 11px; color: var(--text-dim); }
+  .bar-legend .pass { color: var(--text-mid); font-weight: 700; }
+
+  .plan-title { font-size: 11px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin: 20px 0 11px; }
+  .row2 { display: flex; align-items: center; justify-content: space-between; padding: 12px 0; }
+  .row2 + .row2 { border-top: 1px solid var(--border-soft); }
+  .row2 .rn { font-size: 13.5px; font-weight: 650; color: var(--text); }
+  .row2 .rv { font-size: 12.5px; color: var(--text-dim); }
+  .row2 .rv.free { color: var(--accent); font-weight: 650; }
+
+  .stack { display: grid; gap: 12px; }
+  .mt18 { margin-top: 18px; }
+  .btn { display: block; width: 100%; text-align: center; font: 700 15px/1 Inter, sans-serif; border-radius: 13px; padding: 16px 18px; cursor: pointer; border: 1px solid transparent; transition: transform .15s var(--ease), filter .2s; }
+  .btn:active { transform: scale(0.978); }
+  .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .btn-primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent-deep); }
+  @media (hover:hover){ .btn-primary:hover { filter: brightness(1.04); } }
+  .btn-ghost { background: transparent; color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); }
+
+  /* ── overlay (scrim + sheet / coachmark) ── */
+  .overlay { position: absolute; inset: 0; z-index: 5; }
+  .scrim { position: absolute; inset: 0; background: var(--scrim); }
+  .sheet { position: absolute; left: 0; right: 0; bottom: 0; background: var(--surface); border-radius: 22px 22px 0 0; border-top: 1px solid var(--border); padding: 10px 22px 26px; box-shadow: 0 -18px 50px -20px color-mix(in oklab, var(--text) 30%, transparent); }
+  .grabber { width: 38px; height: 4px; border-radius: 999px; background: var(--border); margin: 4px auto 16px; }
+  .sheet-title { font-family: Fraunces, serif; font-weight: 600; font-size: 21px; line-height: 1.15; letter-spacing: -0.01em; color: var(--text); margin: 0 0 8px; }
+  .sheet-body { font-size: 14px; line-height: 1.5; color: var(--text-mid); margin: 0 0 16px; }
+
+  /* switcher sheet rows */
+  .cert-row { display: flex; align-items: center; gap: 13px; padding: 12px 12px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); cursor: pointer; margin-bottom: 8px; transition: border-color .18s var(--ease), background .18s var(--ease), transform .15s var(--ease); }
+  .cert-row:active { transform: scale(0.992); }
+  .cert-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .cert-row.sel { border-color: var(--accent); background: color-mix(in oklab, var(--accent) 8%, var(--surface)); }
+  .cert-row .meta { flex: 1 1 auto; min-width: 0; }
+  .cert-row .cn { display: block; font-weight: 650; font-size: 14px; line-height: 1.15; color: var(--text); }
+  .cert-row .cs { display: block; font-size: 12px; color: var(--text-dim); margin-top: 2px; }
+  .rscore { flex: 0 0 auto; text-align: right; }
+  .rscore .v { font-family: Fraunces, serif; font-weight: 600; font-size: 19px; color: var(--text); font-variant-numeric: lining-nums tabular-nums; }
+  .rscore .l { font-size: 10px; color: var(--text-dim); letter-spacing: 0.05em; }
+  .start-tag { flex: 0 0 auto; font: 700 11.5px/1 Inter, sans-serif; color: var(--accent); }
+  .check { flex: 0 0 auto; width: 18px; height: 18px; stroke: var(--accent); fill: none; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+  .add-cert { display: flex; align-items: center; gap: 11px; padding: 12px 14px; border-radius: 13px; border: 1px dashed color-mix(in oklab, var(--accent) 34%, var(--border)); background: transparent; cursor: pointer; transition: border-color .18s var(--ease), background .18s var(--ease), transform .15s var(--ease); width: 100%; }
+  .add-cert:active { transform: scale(0.99); }
+  .add-cert .plus { width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center; color: var(--accent); background: color-mix(in oklab, var(--accent) 10%, transparent); font-weight: 700; }
+  .add-cert .t { flex: 1 1 auto; text-align: left; font-size: 13.5px; font-weight: 600; color: var(--text-mid); }
+  .sheet-link { display: block; width: 100%; text-align: center; background: none; border: none; color: var(--accent); font: 600 13px/1 Inter, sans-serif; padding: 14px 0 4px; cursor: pointer; }
+
+  /* coachmark */
+  .coach-anchor { position: absolute; top: 8px; left: 22px; z-index: 7; }
+  .coach-anchor .switcher { box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 55%, transparent), 0 0 0 6px color-mix(in oklab, var(--accent) 18%, transparent); }
+  .coach-pop { position: absolute; top: 64px; left: 22px; right: 40px; z-index: 7; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 15px 16px; box-shadow: 0 18px 40px -16px color-mix(in oklab, var(--text) 34%, transparent); }
+  .coach-pop::before { content: ""; position: absolute; top: -7px; left: 30px; width: 13px; height: 13px; background: var(--surface); border-left: 1px solid var(--border); border-top: 1px solid var(--border); transform: rotate(45deg); }
+  .coach-pop .ct { font-weight: 700; font-size: 14px; color: var(--text); margin-bottom: 5px; }
+  .coach-pop .cb { font-size: 13px; line-height: 1.45; color: var(--text-mid); margin-bottom: 14px; }
+  .coach-actions { display: flex; align-items: center; justify-content: space-between; }
+  .coach-skip { background: none; border: none; color: var(--text-dim); font: 600 12.5px/1 Inter, sans-serif; cursor: pointer; padding: 6px 0; }
+  .coach-got { background: var(--accent); color: var(--on-accent); border: 1px solid var(--accent-deep); border-radius: 10px; font: 700 13px/1 Inter, sans-serif; padding: 9px 16px; cursor: pointer; }
+  .coach-got:active { transform: scale(0.97); }
+
+  /* upgrade sheet */
+  .price-row { display: flex; gap: 10px; margin: 4px 0 16px; }
+  .price { flex: 1 1 0; border: 1px solid var(--border); border-radius: 13px; padding: 13px 14px; cursor: pointer; transition: border-color .18s var(--ease), background .18s var(--ease), transform .15s var(--ease); }
+  .price:active { transform: scale(0.985); }
+  .price:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .price.sel { border-color: var(--accent); background: color-mix(in oklab, var(--accent) 7%, var(--surface)); }
+  .price .pl { font-size: 11.5px; color: var(--text-dim); font-weight: 650; }
+  .price .pv { font-family: Fraunces, serif; font-weight: 600; font-size: 22px; color: var(--text); margin-top: 4px; font-variant-numeric: lining-nums; }
+  .price .pp { font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+  .price .save { display: inline-block; margin-top: 7px; font: 700 10px/1 Inter, sans-serif; letter-spacing: 0.04em; text-transform: uppercase; color: var(--pass); background: color-mix(in oklab, var(--pass) 12%, transparent); border-radius: 999px; padding: 4px 8px; }
+  .feat { display: flex; align-items: flex-start; gap: 10px; padding: 7px 0; }
+  .feat svg { flex: 0 0 auto; width: 18px; height: 18px; stroke: var(--accent); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; margin-top: 1px; }
+  .feat span { font-size: 13.5px; color: var(--text-mid); line-height: 1.4; }
+  .feat b { color: var(--text); font-weight: 650; }
+  .fineprint { text-align: center; font-size: 11.5px; color: var(--text-dim); margin: 12px 0 0; }
+
+  /* entrance (emil pass): sheet slides up from its edge, scrim fades, coachmark pops from its anchor */
+  .scrim { opacity: 0; }
+  .sheet { transform: translateY(100%); }
+  .coach-anchor { opacity: 0; }
+  .coach-pop { opacity: 0; transform: translateY(-6px) scale(0.97); }
+  .screen.active .scrim { opacity: 1; transition: opacity .3s var(--ease); }
+  .screen.active .sheet { transform: translateY(0); transition: transform .44s var(--ease); }
+  .screen.active .coach-anchor { opacity: 1; transition: opacity .3s var(--ease) .05s; }
+  .screen.active .coach-pop { opacity: 1; transform: none; transition: opacity .34s var(--ease) .12s, transform .42s cubic-bezier(0.34, 1.4, 0.64, 1) .12s; }
+  .reset-note { display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--text-dim); margin: 0 0 16px; }
+  .reset-note svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* controls below phone */
+  .controls { display: flex; align-items: center; gap: 16px; margin-top: 22px; }
+  .nav-btn { display: inline-flex; align-items: center; gap: 7px; font: 650 13px/1 Inter, sans-serif; color: var(--page-ink); background: transparent; border: 1px solid color-mix(in oklab, var(--page-ink) 22%, transparent); border-radius: 999px; padding: 10px 16px; cursor: pointer; transition: transform .15s var(--ease); }
+  .nav-btn:active { transform: scale(0.97); }
+  .nav-btn[disabled] { opacity: .4; pointer-events: none; }
+  .nav-btn:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
+  .nav-btn svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .dots { display: flex; gap: 8px; flex: 1 1 auto; justify-content: center; }
+  .dots button { width: 9px; height: 9px; border-radius: 50%; border: none; padding: 0; background: color-mix(in oklab, var(--page-ink) 24%, transparent); cursor: pointer; transition: transform .2s var(--ease), background .2s; }
+  .dots button.on { background: var(--accent-bright); transform: scale(1.25); }
+  .dots button:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
+  .screen-name { text-align: center; margin-top: 14px; font-size: 13px; color: var(--page-dim); }
+  .screen-name b { color: var(--page-ink); font-weight: 650; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .screen { transform: none; }
+    .screen.active { transition: opacity .2s ease; }
+    .sheet { transform: none; }
+    .screen.active .sheet { transition: opacity .2s ease; }
+    .coach-pop { transform: none; }
+    .screen.active .coach-pop { transition: opacity .2s ease; }
+  }
+  @media (max-width: 430px) { .phone { transform: scale(0.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+<div class="stage">
+  <div class="stage-head">
+    <div>
+      <p class="stage-eyebrow">Concept mockup · batch 2 · not prod</p>
+      <h1 class="stage-title">Switcher · upgrades · coachmark</h1>
+      <p class="stage-sub">The Pro multi-cert surfaces and the post-aha upgrade moments. Click through the 5 screens; toggle for dark.</p>
+    </div>
+    <button id="themeBtn" class="theme-toggle" type="button" aria-pressed="false"></button>
+  </div>
+
+  <div class="phone-wrap">
+    <div class="phone">
+      <div class="phone-screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="sb-right"><span>5G</span><span class="sb-bars"></span></span></div>
+        <div class="screens">
+
+          <!-- S1 · PRO HOME -->
+          <section class="screen" data-screen="0">
+            <div class="pad">
+              <div class="home-top">
+                <button class="switcher" type="button"><span class="lettermark">N+</span><span><span class="ct">Network+</span><span class="cv">N10-009</span></span><svg class="chev" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6"/></svg></button>
+                <div class="acct">SO</div>
+              </div>
+              <div class="card">
+                <p class="kicker">Readiness</p>
+                <div class="ready-mini"><span class="n">482</span><span class="of">/ 900</span></div>
+                <div class="bar-wrap"><div class="bar-track"><div class="bar-fill" style="width:53.6%"></div><div class="bar-tick"></div></div><div class="bar-legend"><span>238 to pass</span><span class="pass">Pass 720</span></div></div>
+              </div>
+              <p class="plan-title">Today's plan</p>
+              <div class="card" style="padding:6px 18px">
+                <div class="row2"><span class="rn">Daily Review</span><span class="rv">8 cards due</span></div>
+                <div class="row2"><span class="rn">New practice</span><span class="rv free">Unlimited</span></div>
+              </div>
+              <div class="stack mt18">
+                <button class="btn btn-primary">Start Daily Review</button>
+                <button class="btn btn-ghost">Practice new questions</button>
+              </div>
+            </div>
+          </section>
+
+          <!-- S2 · SWITCHER OPEN -->
+          <section class="screen" data-screen="1">
+            <div class="pad" aria-hidden="true">
+              <div class="home-top"><button class="switcher" type="button"><span class="lettermark">N+</span><span><span class="ct">Network+</span><span class="cv">N10-009</span></span><svg class="chev" viewBox="0 0 24 24"><path d="M6 15l6-6 6 6"/></svg></button><div class="acct">SO</div></div>
+              <div class="card"><p class="kicker">Readiness</p><div class="ready-mini"><span class="n">482</span><span class="of">/ 900</span></div></div>
+            </div>
+            <div class="overlay">
+              <div class="scrim"></div>
+              <div class="sheet">
+                <div class="grabber"></div>
+                <h2 class="sheet-title">Your exams</h2>
+                <div class="cert-row sel"><span class="lettermark big">N+</span><span class="meta"><span class="cn">Network+</span><span class="cs">N10-009</span></span><span class="rscore"><span class="v">482</span><span class="l">/ 900</span></span></div>
+                <div class="cert-row"><span class="lettermark big">S+</span><span class="meta"><span class="cn">Security+</span><span class="cs">SY0-701</span></span><span class="rscore"><span class="v">510</span><span class="l">/ 900</span></span></div>
+                <div class="cert-row"><span class="lettermark big">AZ</span><span class="meta"><span class="cn">AZ-900</span><span class="cs">Not started yet</span></span><span class="start-tag">Take diagnostic</span></div>
+                <button class="add-cert" type="button"><span class="plus">+</span><span class="t">Add an exam</span></button>
+                <button class="sheet-link" type="button">See all your exams and progress</button>
+              </div>
+            </div>
+          </section>
+
+          <!-- S3 · COACHMARK -->
+          <section class="screen" data-screen="2">
+            <div class="pad" aria-hidden="true">
+              <div class="home-top"><div class="switcher" style="visibility:hidden"><span class="lettermark">N+</span><span><span class="ct">Network+</span></span></div><div class="acct">SO</div></div>
+              <div class="card"><p class="kicker">Readiness</p><div class="ready-mini"><span class="n">482</span><span class="of">/ 900</span></div><div class="bar-wrap"><div class="bar-track"><div class="bar-fill" style="width:53.6%"></div><div class="bar-tick"></div></div><div class="bar-legend"><span>238 to pass</span><span class="pass">Pass 720</span></div></div></div>
+              <p class="plan-title">Today's plan</p>
+              <div class="card" style="padding:6px 18px"><div class="row2"><span class="rn">Daily Review</span><span class="rv">8 cards due</span></div><div class="row2"><span class="rn">New practice</span><span class="rv free">Unlimited</span></div></div>
+            </div>
+            <div class="overlay">
+              <div class="scrim"></div>
+              <div class="coach-anchor"><button class="switcher" type="button"><span class="lettermark">N+</span><span><span class="ct">Network+</span><span class="cv">N10-009</span></span><svg class="chev" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6"/></svg></button></div>
+              <div class="coach-pop">
+                <div class="ct">Switch between your exams here</div>
+                <div class="cb">We save your place in each one, including its readiness score and review deck.</div>
+                <div class="coach-actions"><button class="coach-skip" type="button">Don't show tips</button><button class="coach-got" type="button">Got it</button></div>
+              </div>
+            </div>
+          </section>
+
+          <!-- S4 · UPGRADE: DAILY CAP -->
+          <section class="screen" data-screen="3">
+            <div class="pad" aria-hidden="true">
+              <div class="home-top"><div class="switcher"><span class="lettermark">N+</span><span><span class="ct">Network+</span><span class="cv">N10-009</span></span></div><div class="acct">SO</div></div>
+              <div class="card"><p class="kicker">Readiness</p><div class="ready-mini"><span class="n">482</span><span class="of">/ 900</span></div></div>
+            </div>
+            <div class="overlay">
+              <div class="scrim"></div>
+              <div class="sheet">
+                <div class="grabber"></div>
+                <h2 class="sheet-title">That's today's 15 new questions.</h2>
+                <p class="sheet-body">Your Daily Review is still open, and your 15 new questions reset tomorrow. Pro lifts the daily cap so you can keep going.</p>
+                <div class="reset-note"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>New questions reset in 6 hours</div>
+                <div class="stack">
+                  <button class="btn btn-primary">See Pro</button>
+                  <button class="btn btn-ghost">Keep reviewing</button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <!-- S5 · UPGRADE: ADD A SECOND EXAM -->
+          <section class="screen" data-screen="4">
+            <div class="pad" aria-hidden="true">
+              <div class="home-top"><div class="switcher"><span class="lettermark">N+</span><span><span class="ct">Network+</span></span></div><div class="acct">SO</div></div>
+            </div>
+            <div class="overlay">
+              <div class="scrim"></div>
+              <div class="sheet">
+                <div class="grabber"></div>
+                <h2 class="sheet-title">Study more than one exam</h2>
+                <p class="sheet-body">Pro opens up every exam, lets you switch between them, and removes the daily question cap.</p>
+                <div class="feat"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg><span><b>All 8 exams</b>, each with its own readiness score</span></div>
+                <div class="feat"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg><span><b>Switch anytime</b>, your place in each is saved</span></div>
+                <div class="feat"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg><span><b>No daily cap</b> on new questions</span></div>
+                <div class="price-row">
+                  <div class="price"><div class="pl">Monthly</div><div class="pv">$9.99</div><div class="pp">per month</div></div>
+                  <div class="price sel"><div class="pl">Yearly</div><div class="pv">$89</div><div class="pp">per year</div><span class="save">Save 25%</span></div>
+                </div>
+                <div class="stack">
+                  <button class="btn btn-primary">Go Pro</button>
+                  <button class="btn btn-ghost">Not now</button>
+                </div>
+                <p class="fineprint">Cancel anytime. We never promise a passing grade.</p>
+              </div>
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="controls" style="width:390px">
+      <button class="nav-btn" id="prevBtn"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg>Back</button>
+      <div class="dots" id="dots"></div>
+      <button class="nav-btn" id="nextBtn">Next<svg viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg></button>
+    </div>
+    <p class="screen-name" id="screenName"></p>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var NAMES = ["Pro home (with switcher)","Cert switcher open (per-exam activation)","Coachmark (navigation hint)","Upgrade: daily cap reached","Upgrade: add a second exam"];
+    var screens = Array.prototype.slice.call(document.querySelectorAll('.screen'));
+    var dotsWrap = document.getElementById('dots');
+    var prevBtn = document.getElementById('prevBtn'), nextBtn = document.getElementById('nextBtn'), nameEl = document.getElementById('screenName');
+    var i = 0;
+    screens.forEach(function (s, idx) { var b = document.createElement('button'); b.addEventListener('click', function () { go(idx); }); dotsWrap.appendChild(b); });
+    var dots = Array.prototype.slice.call(dotsWrap.children);
+    function go(idx) {
+      i = Math.max(0, Math.min(screens.length - 1, idx));
+      screens.forEach(function (s, n) { s.classList.toggle('active', n === i); });
+      dots.forEach(function (d, n) { d.classList.toggle('on', n === i); });
+      prevBtn.disabled = (i === 0); nextBtn.disabled = (i === screens.length - 1);
+      nameEl.innerHTML = 'Screen ' + (i + 1) + ' of ' + screens.length + ' · <b>' + NAMES[i] + '</b>';
+    }
+    prevBtn.addEventListener('click', function () { go(i - 1); });
+    nextBtn.addEventListener('click', function () { go(i + 1); });
+    document.addEventListener('keydown', function (e) { if (e.key === 'ArrowRight') go(i + 1); if (e.key === 'ArrowLeft') go(i - 1); });
+
+    var SUN = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4.2"/><path d="M12 2v2.4M12 19.6V22M2 12h2.4M19.6 12H22M4.9 4.9l1.7 1.7M17.4 17.4l1.7 1.7M19.1 4.9l-1.7 1.7M6.6 17.4l-1.7 1.7"/></svg>';
+    var MOON = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>';
+    var btn = document.getElementById('themeBtn');
+    function syncBtn() { var light = document.documentElement.getAttribute('data-theme') === 'light'; btn.innerHTML = (light ? MOON : SUN) + '<span>' + (light ? 'Dark' : 'Light') + '</span>'; btn.setAttribute('aria-pressed', String(!light)); btn.setAttribute('aria-label', light ? 'Switch to dark mode' : 'Switch to light mode'); }
+    btn.addEventListener('click', function () { document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); syncBtn(); });
+    syncBtn(); go(0);
+  })();
+</script>
+</body>
+</html>

--- a/mockups/onboarding-first-run-concept.html
+++ b/mockups/onboarding-first-run-concept.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · First-run activation concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (design/brand/BRAND.md). Dark in :root, light in [data-theme=light]. Light is primary. ── */
+  :root {
+    --bg: oklch(0.16 0.009 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.185 0.009 275);
+    --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.78 0.010 275); --muted: oklch(0.60 0.013 275);
+    --border: oklch(0.30 0.008 275); --border-soft: oklch(0.26 0.008 275);
+    --accent: oklch(0.80 0.155 64); --accent-bright: oklch(0.86 0.140 70); --accent-deep: oklch(0.70 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.74 0.150 152); --warn: oklch(0.80 0.130 75);
+    /* page-chrome (outside the phone) */
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+    --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-bright: oklch(0.80 0.155 64); --accent-deep: oklch(0.42 0.150 52);
+    --on-accent: oklch(0.985 0.010 85); --pass: oklch(0.52 0.13 150); --warn: oklch(0.62 0.14 70);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --text: var(--ink); --text-mid: var(--ink-soft); --text-dim: var(--muted); --ease: cubic-bezier(0.16,1,0.3,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body {
+    margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    padding: 28px 20px 60px; transition: background .35s var(--ease), color .35s var(--ease);
+  }
+  .stage { max-width: 760px; margin: 0 auto; }
+
+  /* page header */
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 6px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 22px; letter-spacing: -0.01em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 4px 0 0; }
+  .theme-toggle {
+    flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif;
+    color: var(--accent-bright); background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim));
+    border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s;
+  }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* ── Phone frame ── */
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone {
+    width: 390px; height: 800px; border-radius: 46px; padding: 12px;
+    background: linear-gradient(160deg, #20232b, #0e0f13); position: relative;
+    box-shadow: 0 30px 80px -28px rgba(0,0,0,0.55), 0 0 0 1.5px rgba(255,255,255,0.06) inset;
+    flex: 0 0 auto;
+  }
+  .phone-screen {
+    position: relative; width: 366px; height: 776px; border-radius: 36px; overflow: hidden;
+    background: var(--bg); color: var(--text); transition: background .35s var(--ease), color .35s var(--ease);
+  }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 116px; height: 26px; background: #0e0f13; border-radius: 0 0 16px 16px; z-index: 40; }
+  .statusbar { position: absolute; top: 0; left: 0; right: 0; height: 44px; display: flex; align-items: center; justify-content: space-between; padding: 0 22px; font-size: 12.5px; font-weight: 650; color: var(--text); z-index: 30; }
+  .statusbar .sb-right { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-bars { width: 17px; height: 11px; border: 1.4px solid var(--text); border-radius: 3px; position: relative; opacity: .9; }
+  .sb-bars::after { content: ""; position: absolute; inset: 1.6px; right: 5px; background: var(--text); border-radius: 1px; }
+
+  /* screen scroll area */
+  .screens { position: absolute; inset: 44px 0 0; overflow: hidden; }
+  /* inactive screens hide instantly (no transition); only the incoming active screen fades in, so two layers never blend */
+  .screen { position: absolute; inset: 0; padding: 8px 22px 26px; overflow-y: auto; background: var(--bg); z-index: 1; opacity: 0; visibility: hidden; transform: translateY(8px); }
+  .screen.active { opacity: 1; visibility: visible; transform: none; z-index: 2; transition: opacity .42s var(--ease), transform .42s var(--ease); }
+  .screen::-webkit-scrollbar { width: 0; }
+
+  /* shared bits */
+  .kicker { font-size: 10.5px; font-weight: 800; letter-spacing: 0.13em; text-transform: uppercase; color: var(--accent); margin: 0 0 10px; }
+  .kicker.neutral { color: var(--text-dim); }
+  h2.s-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 27px; line-height: 1.1; letter-spacing: -0.02em; margin: 0 0 10px; color: var(--text); }
+  .s-body { font-size: 14.5px; line-height: 1.5; color: var(--text-mid); margin: 0 0 18px; }
+  .s-foot { position: sticky; bottom: 0; padding-top: 12px; background: linear-gradient(to top, var(--bg) 72%, transparent); }
+
+  .btn { display: block; width: 100%; text-align: center; font: 700 15px/1 Inter, sans-serif; border-radius: 13px; padding: 16px 18px; cursor: pointer; border: 1px solid transparent; transition: transform .15s var(--ease), filter .2s; }
+  .btn:active { transform: scale(0.978); }
+  .btn-primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent-deep); }
+  @media (hover:hover){ .btn-primary:hover { filter: brightness(1.04); } }
+  .btn-ghost { background: transparent; color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); margin-top: 9px; }
+  .btn[disabled] { opacity: .45; pointer-events: none; }
+  .micro { text-align: center; font-size: 12px; color: var(--text-dim); margin: 11px 0 0; }
+  .btn:focus-visible, .nav-btn:focus-visible, .add-cert:focus-visible, .theme-toggle:focus-visible, .dots button:focus-visible, .cert-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* monogram */
+  .mono { width: 60px; height: 60px; }
+  .mono path { stroke: var(--accent); fill: none; }
+
+  /* ── S1 lobby ── */
+  .lobby { height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 22px; }
+  .lobby .wordmark { font-family: Fraunces, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; color: var(--text); }
+  .skeleton { width: 210px; display: grid; gap: 10px; }
+  .sk-line { height: 11px; border-radius: 999px; background: linear-gradient(90deg, var(--surface-2) 0%, color-mix(in oklab, var(--accent) 16%, var(--surface-2)) 50%, var(--surface-2) 100%); background-size: 200% 100%; animation: shimmer 1.4s var(--ease) infinite; }
+  .sk-line.short { width: 62%; margin: 0 auto; }
+  @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  .lobby .note { font-size: 12.5px; color: var(--text-dim); }
+
+  /* ── cert picker ── */
+  .cert-list { display: grid; gap: 8px; margin: 2px 0 10px; }
+  .cert-row { display: flex; align-items: center; gap: 13px; padding: 13px 14px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); cursor: pointer; transition: border-color .18s var(--ease), background .18s var(--ease); }
+  .cert-row:active { transform: scale(0.992); }
+  .cert-row.sel { border-color: var(--accent); background: color-mix(in oklab, var(--accent) 8%, var(--surface)); }
+  .lettermark { flex: 0 0 auto; width: 42px; height: 42px; border-radius: 11px; display: grid; place-items: center; font: 800 13px/1 Inter, sans-serif; letter-spacing: 0.01em; color: var(--accent); background: color-mix(in oklab, var(--accent) 12%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border)); }
+  .cert-row.sel .lettermark { color: var(--on-accent); background: var(--accent); border-color: var(--accent-deep); }
+  .cert-meta { flex: 1 1 auto; min-width: 0; }
+  .cert-name { font-weight: 650; font-size: 14.5px; color: var(--text); }
+  .cert-vendor { font-size: 12px; color: var(--text-dim); margin-top: 2px; }
+  .cert-check { flex: 0 0 auto; width: 20px; height: 20px; opacity: 0; }
+  .cert-row.sel .cert-check { opacity: 1; }
+  .cert-check svg { width: 20px; height: 20px; stroke: var(--accent); fill: none; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* reassurance row */
+  .reassure { display: flex; align-items: center; gap: 10px; padding: 13px 15px; border-radius: 13px; background: color-mix(in oklab, var(--accent) 7%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 16%, var(--border)); margin-bottom: 18px; }
+  .reassure svg { flex: 0 0 auto; width: 19px; height: 19px; stroke: var(--accent); fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .reassure span { font-size: 13px; color: var(--text-mid); line-height: 1.4; }
+  .reassure b { color: var(--text); font-weight: 650; }
+
+  /* ── readiness instrument ── */
+  .readiness { text-align: center; margin: 8px 0 6px; }
+  .readiness .label { font-size: 11px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
+  .readiness .num { display: block; font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: clamp(76px, 24vw, 96px); line-height: 1; letter-spacing: -0.03em; color: var(--text); font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; margin-top: 6px; }
+  .readiness .outof { font-size: 12px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; color: var(--text-dim); margin-top: 2px; }
+  .delta { display: inline-flex; align-items: center; gap: 5px; margin-top: 12px; padding: 6px 12px; border-radius: 999px; font-size: 13px; font-weight: 700; color: var(--pass); background: color-mix(in oklab, var(--pass) 12%, transparent); border: 1px solid color-mix(in oklab, var(--pass) 26%, transparent); opacity: 0; transform: translateY(4px) scale(0.92); transition: opacity .32s var(--ease), transform .42s cubic-bezier(0.34, 1.4, 0.64, 1); }
+  .delta.show { opacity: 1; transform: none; }
+  .delta svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+
+  .bar-wrap { margin: 20px 2px 6px; }
+  .bar-track { position: relative; height: 9px; border-radius: 999px; background: var(--surface-2); border: 1px solid var(--border-soft); overflow: visible; }
+  .bar-fill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 999px; background: linear-gradient(90deg, var(--accent-deep), var(--accent)); width: 0; transition: width 1s var(--ease); }
+  .bar-tick { position: absolute; top: -7px; bottom: -7px; width: 2px; background: var(--text-mid); left: 80%; border-radius: 2px; }
+  .bar-legend { display: flex; justify-content: space-between; margin-top: 9px; font-size: 11px; color: var(--text-dim); }
+  .bar-legend .pass { color: var(--text-mid); font-weight: 700; }
+  .honest { font-size: 12.5px; line-height: 1.5; color: var(--text-dim); margin: 16px 2px 0; }
+
+  .gap-stat { text-align: center; font-size: 14px; color: var(--text-mid); margin: 16px 0 0; }
+  .gap-stat b { color: var(--text); font-weight: 700; }
+
+  /* weak chip */
+  .chip { display: inline-flex; align-items: center; gap: 7px; padding: 7px 13px; border-radius: 999px; background: color-mix(in oklab, var(--accent) 11%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border)); font-size: 12.5px; font-weight: 650; color: var(--accent); }
+  .chip .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+  .center { text-align: center; }
+
+  /* habit card */
+  .card { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 18px; box-shadow: 0 1px 0 color-mix(in oklab, var(--text) 4%, transparent), 0 16px 36px -22px color-mix(in oklab, var(--text) 20%, transparent); }
+  .card.focal { background: var(--accent); color: var(--on-accent); border-color: var(--accent-deep); }
+  .review-card { display: flex; align-items: center; gap: 14px; }
+  .review-ring { flex: 0 0 auto; width: 54px; height: 54px; border-radius: 14px; display: grid; place-items: center; background: color-mix(in oklab, var(--on-accent) 16%, transparent); border: 1px solid color-mix(in oklab, var(--on-accent) 26%, transparent); }
+  .review-ring .n { font-family: Fraunces, serif; font-weight: 600; font-size: 24px; color: var(--on-accent); font-variant-numeric: lining-nums; }
+  .review-card .rc-title { font-weight: 700; font-size: 15px; color: var(--on-accent); }
+  .review-card .rc-sub { font-size: 12.5px; color: color-mix(in oklab, var(--on-accent) 78%, transparent); margin-top: 2px; }
+  .streak { display: inline-flex; align-items: center; gap: 7px; margin-top: 14px; font-size: 12.5px; color: var(--text-dim); }
+  .streak b { color: var(--text); }
+
+  /* ── free home ── */
+  .home-top { display: flex; align-items: center; justify-content: space-between; padding: 2px 0 14px; }
+  .home-cert { display: flex; align-items: center; gap: 10px; }
+  .home-cert .lettermark { width: 34px; height: 34px; border-radius: 9px; font-size: 11px; }
+  .home-cert .ct { font-weight: 700; font-size: 14px; color: var(--text); }
+  .home-cert .cv { font-size: 11px; color: var(--text-dim); margin-top: 1px; }
+  .acct { width: 30px; height: 30px; border-radius: 50%; background: color-mix(in oklab, var(--accent) 16%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)); display: grid; place-items: center; font-weight: 800; font-size: 12px; color: var(--accent); }
+
+  .ready-mini { display: flex; align-items: baseline; gap: 9px; }
+  .ready-mini .n { font-family: Fraunces, serif; font-weight: 600; font-size: 40px; line-height: 1; letter-spacing: -0.02em; color: var(--text); font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; }
+  .ready-mini .of { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+
+  .plan-title { font-size: 11px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin: 4px 0 11px; }
+  .meter { margin-bottom: 14px; }
+  .meter:last-child { margin-bottom: 0; }
+  .meter-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 8px; }
+  .meter-name { font-size: 13.5px; font-weight: 650; color: var(--text); }
+  .meter-count { font-size: 12px; color: var(--text-dim); }
+  .pips { display: flex; gap: 5px; }
+  .pip { flex: 1 1 0; height: 7px; border-radius: 999px; background: var(--surface-2); border: 1px solid var(--border-soft); }
+  .pip.on { background: var(--accent); border-color: var(--accent-deep); }
+  .thinbar { height: 7px; border-radius: 999px; background: var(--surface-2); border: 1px solid var(--border-soft); overflow: hidden; }
+  .thinbar i { display: block; height: 100%; width: 100%; background: linear-gradient(90deg, var(--accent-deep), var(--accent)); }
+
+  .add-cert { display: flex; align-items: center; gap: 11px; padding: 13px 15px; border-radius: 13px; border: 1px dashed color-mix(in oklab, var(--accent) 34%, var(--border)); background: transparent; cursor: pointer; margin-top: 4px; transition: border-color .18s var(--ease), background .18s var(--ease), transform .15s var(--ease); }
+  .add-cert:active { transform: scale(0.985); }
+  @media (hover:hover){ .add-cert:hover { background: color-mix(in oklab, var(--accent) 5%, transparent); border-color: color-mix(in oklab, var(--accent) 50%, var(--border)); } }
+  .add-cert .plus { flex: 0 0 auto; width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center; color: var(--accent); background: color-mix(in oklab, var(--accent) 10%, transparent); font-weight: 700; }
+  .add-cert .ac-txt { flex: 1 1 auto; font-size: 13.5px; font-weight: 600; color: var(--text-mid); }
+  .pro-tag { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: var(--on-accent); background: var(--accent); border-radius: 999px; padding: 4px 8px; }
+
+  .stack { display: grid; gap: 12px; }
+  .mt18 { margin-top: 18px; } .mt14 { margin-top: 14px; } .mt10 { margin-top: 10px; }
+
+  /* ── controls below phone ── */
+  .controls { display: flex; align-items: center; gap: 16px; margin-top: 22px; }
+  .nav-btn { display: inline-flex; align-items: center; gap: 7px; font: 650 13px/1 Inter, sans-serif; color: var(--page-ink); background: transparent; border: 1px solid color-mix(in oklab, var(--page-ink) 22%, transparent); border-radius: 999px; padding: 10px 16px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .nav-btn:active { transform: scale(0.97); }
+  .nav-btn[disabled] { opacity: .4; pointer-events: none; }
+  .nav-btn svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .dots { display: flex; gap: 8px; flex: 1 1 auto; justify-content: center; }
+  .dots button { width: 9px; height: 9px; border-radius: 50%; border: none; padding: 0; background: color-mix(in oklab, var(--page-ink) 24%, transparent); cursor: pointer; transition: transform .2s var(--ease), background .2s; }
+  .dots button.on { background: var(--accent-bright); transform: scale(1.25); }
+  .screen-name { text-align: center; margin-top: 14px; font-size: 13px; color: var(--page-dim); }
+  .screen-name b { color: var(--page-ink); font-weight: 650; }
+
+  /* reduced motion: keep gentle opacity fades (comprehension), drop transform motion + the shimmer loop */
+  @media (prefers-reduced-motion: reduce) {
+    .sk-line { animation: none; background: var(--surface-2); }
+    .screen { transform: none; }
+    .screen.active { transition: opacity .2s ease; }
+    .bar-fill { transition: none; }
+    .delta { transform: none; transition: opacity .2s ease; }
+    .delta.show { transform: none; }
+  }
+  @media (max-width: 430px) { .phone { transform: scale(0.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+<div class="stage">
+  <div class="stage-head">
+    <div>
+      <p class="stage-eyebrow">Concept mockup · not prod · review before lifting</p>
+      <h1 class="stage-title">First-run activation flow</h1>
+      <p class="stage-sub">The new surfaces that do not exist yet. Click through the 7 screens. Light is primary; toggle for dark.</p>
+    </div>
+    <button id="themeBtn" class="theme-toggle" type="button" aria-pressed="false"></button>
+  </div>
+
+  <div class="phone-wrap">
+    <div class="phone">
+      <div class="phone-screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="sb-right"><span>5G</span><span class="sb-bars"></span></span></div>
+
+        <div class="screens">
+
+          <!-- S1 · LOBBY RESOLVE -->
+          <section class="screen" data-screen="0">
+            <div class="lobby">
+              <svg class="mono" viewBox="0 0 48 48" aria-hidden="true">
+                <path d="M31 14a11 11 0 1 0 0 20" stroke-width="3.6" stroke-linecap="round"/>
+                <path d="M30 33 L37 14" stroke-width="2.6" stroke-linecap="round" opacity="0.55"/>
+                <path d="M21 33 L28 14 M22.5 27 h6.4" stroke-width="3.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <div class="wordmark">CertAnvil</div>
+              <div class="skeleton">
+                <div class="sk-line"></div>
+                <div class="sk-line short"></div>
+              </div>
+              <div class="note">Getting things ready</div>
+            </div>
+          </section>
+
+          <!-- S2 · CERT PICKER -->
+          <section class="screen" data-screen="1">
+            <p class="kicker">Step 1 of 3</p>
+            <h2 class="s-title">Which exam are you studying for?</h2>
+            <p class="s-body">Pick one to get your readiness score. On the free plan you focus on a single exam at a time.</p>
+            <div class="cert-list">
+              <div class="cert-row sel"><div class="lettermark">N+</div><div class="cert-meta"><div class="cert-name">Network+</div><div class="cert-vendor">CompTIA · N10-009</div></div><span class="cert-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></span></div>
+              <div class="cert-row"><div class="lettermark">S+</div><div class="cert-meta"><div class="cert-name">Security+</div><div class="cert-vendor">CompTIA · SY0-701</div></div><span class="cert-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></span></div>
+              <div class="cert-row"><div class="lettermark">A+</div><div class="cert-meta"><div class="cert-name">A+ Core 1</div><div class="cert-vendor">CompTIA · 220-1101</div></div><span class="cert-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></span></div>
+              <div class="cert-row"><div class="lettermark">AZ</div><div class="cert-meta"><div class="cert-name">AZ-900</div><div class="cert-vendor">Microsoft Azure Fundamentals</div></div><span class="cert-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></span></div>
+              <div class="cert-row"><div class="lettermark">CLF</div><div class="cert-meta"><div class="cert-name">Cloud Practitioner</div><div class="cert-vendor">AWS · CLF-C02</div></div><span class="cert-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></span></div>
+            </div>
+            <div class="s-foot">
+              <button class="btn btn-primary">Continue with Network+</button>
+              <p class="micro">8 exams available. Switching between them is a Pro feature.</p>
+            </div>
+          </section>
+
+          <!-- S3 · DIAGNOSTIC INTRO -->
+          <section class="screen" data-screen="2">
+            <p class="kicker">Step 2 of 3</p>
+            <h2 class="s-title">Let's see where you stand.</h2>
+            <p class="s-body">Answer about 15 questions so we can calibrate your readiness. No studying needed. Anything you miss becomes your first review set.</p>
+            <div class="reassure">
+              <svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 4.4-3 7.6-7 9-4-1.4-7-4.6-7-9V6l7-3z"/><path d="M9 12l2 2 4-4"/></svg>
+              <span><b>This is calibration, not a test.</b> There is nothing to fail here. A low score just means more room to climb.</span>
+            </div>
+            <div class="s-foot">
+              <button class="btn btn-primary">Start the 15-question check</button>
+              <button class="btn btn-ghost">Skip for now</button>
+              <p class="micro">Takes about 4 minutes, and it does not use your daily questions. You can take it later from your home.</p>
+            </div>
+          </section>
+
+          <!-- S4 · SCORE REVEAL -->
+          <section class="screen" data-screen="3">
+            <p class="kicker neutral">Your readiness today</p>
+            <div class="readiness">
+              <span class="num" id="revealNum">0</span>
+              <div class="outof">out of 900</div>
+            </div>
+            <div class="bar-wrap">
+              <div class="bar-track"><div class="bar-fill" id="revealBar"></div><div class="bar-tick"></div></div>
+              <div class="bar-legend"><span>100</span><span class="pass">Pass 720</span><span>900</span></div>
+            </div>
+            <p class="gap-stat">You are <b>255 points</b> from the Network+ pass mark.</p>
+            <p class="honest">This estimates where you stand today, based on your diagnostic. It is not a prediction or a pass guarantee. It moves as you study.</p>
+            <div class="s-foot">
+              <button class="btn btn-primary">Start closing the gap</button>
+            </div>
+          </section>
+
+          <!-- S5 · MOVEMENT (the aha) -->
+          <section class="screen" data-screen="4">
+            <p class="kicker">Your weakest area</p>
+            <div class="center" style="margin-bottom:18px"><span class="chip"><span class="dot"></span>Subnetting · 5 answered</span></div>
+            <div class="readiness">
+              <span class="num" id="moveNum">465</span>
+              <div class="outof">out of 900</div>
+              <div class="delta" id="moveDelta"><svg viewBox="0 0 24 24"><path d="M12 19V5M5 12l7-7 7 7"/></svg><span>+17 today</span></div>
+            </div>
+            <div class="bar-wrap">
+              <div class="bar-track"><div class="bar-fill" id="moveBar"></div><div class="bar-tick"></div></div>
+              <div class="bar-legend"><span>100</span><span class="pass">Pass 720</span><span>900</span></div>
+            </div>
+            <p class="honest">You just moved your readiness. Five questions, seventeen points. That is the whole loop: study a little, watch the number climb.</p>
+            <div class="s-foot">
+              <button class="btn btn-primary">Set up my daily habit</button>
+            </div>
+          </section>
+
+          <!-- S6 · HABIT HOOK -->
+          <section class="screen" data-screen="5">
+            <p class="kicker">You're set up</p>
+            <h2 class="s-title">A few minutes a day is how it sticks.</h2>
+            <p class="s-body">Your diagnostic seeded your first review cards. Spaced practice is what moves the number, so we'll line up a small set each day.</p>
+            <div class="card focal">
+              <div class="review-card">
+                <div class="review-ring"><span class="n">5</span></div>
+                <div><div class="rc-title">Daily Review ready tomorrow</div><div class="rc-sub">5 cards from what you missed today</div></div>
+              </div>
+            </div>
+            <div class="streak"><span>Streak started.</span><b>Day 1</b></div>
+            <div class="s-foot">
+              <button class="btn btn-primary">Go to my home</button>
+            </div>
+          </section>
+
+          <!-- S7 · FREE HOME + QUOTA -->
+          <section class="screen" data-screen="6">
+            <div class="home-top">
+              <div class="home-cert"><div class="lettermark">N+</div><div><div class="ct">Network+</div><div class="cv">N10-009</div></div></div>
+              <div class="acct">SO</div>
+            </div>
+            <div class="card">
+              <p class="kicker neutral" style="margin:0 0 8px">Readiness</p>
+              <div class="ready-mini"><span class="n">482</span><span class="of">/ 900</span></div>
+              <div class="bar-wrap" style="margin:14px 0 0">
+                <div class="bar-track"><div class="bar-fill" style="width:53.6%"></div><div class="bar-tick"></div></div>
+                <div class="bar-legend"><span>238 to pass</span><span class="pass">Pass 720</span></div>
+              </div>
+            </div>
+
+            <p class="plan-title" style="margin-top:20px">Today's plan</p>
+            <div class="card">
+              <div class="meter">
+                <div class="meter-head"><span class="meter-name">Daily Review</span><span class="meter-count">5 cards ready</span></div>
+                <div class="pips"><i class="pip on"></i><i class="pip on"></i><i class="pip on"></i><i class="pip on"></i><i class="pip on"></i></div>
+              </div>
+              <div class="meter">
+                <div class="meter-head"><span class="meter-name">New practice</span><span class="meter-count">15 left today</span></div>
+                <div class="thinbar"><i style="width:100%"></i></div>
+              </div>
+            </div>
+
+            <div class="stack mt18">
+              <button class="btn btn-primary">Start Daily Review</button>
+              <button class="btn btn-ghost">Practice new questions</button>
+            </div>
+
+            <button class="add-cert mt18" type="button">
+              <span class="plus">+</span>
+              <span class="ac-txt">Studying for more than one exam?</span>
+              <span class="pro-tag">Pro</span>
+            </button>
+          </section>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="controls" style="width:390px">
+      <button class="nav-btn" id="prevBtn"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg>Back</button>
+      <div class="dots" id="dots"></div>
+      <button class="nav-btn" id="nextBtn">Next<svg viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg></button>
+    </div>
+    <p class="screen-name" id="screenName"></p>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var NAMES = ["Lobby resolve (no flash of landing)","First-run cert picker","Diagnostic intro (calibration framing)","Readiness score reveal","The +5 movement (the aha)","Habit hook","Free home with quota meter"];
+    var screens = Array.prototype.slice.call(document.querySelectorAll('.screen'));
+    var dotsWrap = document.getElementById('dots');
+    var prevBtn = document.getElementById('prevBtn');
+    var nextBtn = document.getElementById('nextBtn');
+    var nameEl = document.getElementById('screenName');
+    var i = 0, reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    screens.forEach(function (s, idx) {
+      var b = document.createElement('button');
+      b.addEventListener('click', function () { go(idx); });
+      dotsWrap.appendChild(b);
+    });
+    var dots = Array.prototype.slice.call(dotsWrap.children);
+
+    function pct(score) { return ((score - 100) / 800 * 100) + '%'; }
+
+    // count-up with a setTimeout fallback so the final value is correct even if rAF is throttled
+    function animateNum(el, from, to, ms, onDone) {
+      el.textContent = from;
+      if (reduce) { el.textContent = to; if (onDone) onDone(); return; }
+      var start = null, done = false;
+      function finish() { if (done) return; done = true; el.textContent = to; if (onDone) onDone(); }
+      function step(t) {
+        if (done) return;
+        if (start === null) start = t;
+        var p = Math.min((t - start) / ms, 1);
+        el.textContent = Math.round(from + (to - from) * (1 - Math.pow(1 - p, 3)));
+        if (p < 1) requestAnimationFrame(step); else finish();
+      }
+      requestAnimationFrame(step);
+      setTimeout(finish, ms + 250);
+    }
+
+    function onEnter(idx) {
+      if (idx === 3) {
+        var bar = document.getElementById('revealBar');
+        bar.style.transition = 'none'; bar.style.width = '0'; void bar.offsetWidth;  // reflow
+        bar.style.transition = ''; bar.style.width = pct(465);                        // CSS transition animates the fill
+        animateNum(document.getElementById('revealNum'), 0, 465, 1100);
+      }
+      if (idx === 4) {
+        var mbar = document.getElementById('moveBar');
+        var delta = document.getElementById('moveDelta');
+        var num = document.getElementById('moveNum');
+        num.textContent = '465';
+        delta.classList.remove('show');
+        mbar.style.transition = 'none'; mbar.style.width = pct(465); void mbar.offsetWidth;
+        setTimeout(function () {
+          mbar.style.transition = ''; mbar.style.width = pct(482);
+          animateNum(num, 465, 482, 900, function () { delta.classList.add('show'); });
+        }, 420);
+      }
+    }
+
+    function go(idx) {
+      i = Math.max(0, Math.min(screens.length - 1, idx));
+      screens.forEach(function (s, n) { s.classList.toggle('active', n === i); });
+      dots.forEach(function (d, n) { d.classList.toggle('on', n === i); });
+      prevBtn.disabled = (i === 0);
+      nextBtn.disabled = (i === screens.length - 1);
+      nameEl.innerHTML = 'Screen ' + (i + 1) + ' of ' + screens.length + ' · <b>' + NAMES[i] + '</b>';
+      onEnter(i);
+    }
+
+    prevBtn.addEventListener('click', function () { go(i - 1); });
+    nextBtn.addEventListener('click', function () { go(i + 1); });
+    document.addEventListener('keydown', function (e) { if (e.key === 'ArrowRight') go(i + 1); if (e.key === 'ArrowLeft') go(i - 1); });
+
+    // theme toggle
+    var SUN = '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4.2"/><path d="M12 2v2.4M12 19.6V22M2 12h2.4M19.6 12H22M4.9 4.9l1.7 1.7M17.4 17.4l1.7 1.7M19.1 4.9l-1.7 1.7M6.6 17.4l-1.7 1.7"/></svg>';
+    var MOON = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>';
+    var btn = document.getElementById('themeBtn');
+    function syncBtn() {
+      var light = document.documentElement.getAttribute('data-theme') === 'light';
+      btn.innerHTML = (light ? MOON : SUN) + '<span>' + (light ? 'Dark' : 'Light') + '</span>';
+      btn.setAttribute('aria-pressed', String(!light));
+      btn.setAttribute('aria-label', light ? 'Switch to dark mode' : 'Switch to light mode');
+    }
+    btn.addEventListener('click', function () {
+      document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light');
+      syncBtn();
+    });
+
+    syncBtn();
+    go(0);
+  })();
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.29.1",
+  "version": "7.30.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.29.1
+   Network+ AI Quiz — styles.css  v7.30.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.29.1 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.29.1';
+// Service Worker v7.30.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.30.0';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## What this is

The onboarding / activation / first-run-routing build, lifting the approved mockups + LOCKED strategy onto production. **Everything is guarded behind `?onb=1`** (localStorage `onb_router`; `?onb=0` to disable) — off by default, zero impact on current users, safe at every commit.

Strategy + plan + mockups are committed on the branch:
- `docs/planning/ONBOARDING_ACTIVATION_DECISIONS.md` (LOCKED strategy)
- `docs/planning/ONBOARDING_ROUTING_BUILD_PLAN.md` (screen → file → engine map)
- `mockups/onboarding-first-run-concept.html` + `mockups/onboarding-batch2-concept.html` (approved)

## What's in it

- **Phase 0 — lobby router + boot skeleton.** `lib/router.js` (pure decision tree, 11/11 unit tests) + `#onb-resolve` skeleton + guarded wiring (`lib/onboarding-boot.js`, 3-line hook in `auth-state.js`). Routes logged-out → landing, activated → cert-home, fresh → first-run.
- **Phase 1 — first-run spine.** `lib/onboarding-firstrun.js`: cert pick → diagnostic intro (+Skip) → score reveal → +5 movement → habit hook. **Readiness is placeholder** until the engine wiring lands (see below).
- **Phase 2 (1/2) — upgrade sheets.** `lib/onboarding-chrome.js`: `onbUpgrade.show('cap'|'add-cert')` slide-up sheets ($9.99/$89, honest framing, dismissible).
- **Phase 2 (2/2) — home integration (this session).** `lib/onboarding-home.js`: free-home quota meter + Pro switcher pill + "Your exams" sheet (per-cert real readiness, Take-diagnostic → first-run), upgrade-sheet triggers wired to the stubbed quota. Injects one `.onb-home-bar` into the home bento by wrapping `showPage` — **app.js untouched**.
- All CSS is scoped (`.onb-resolve` / `.onb-fr` / `.onb-ov` / `.onb-home-bar`) in `dg-system.css`, mapped to real dg tokens.

## Gated lane

Touches `auth-state.js` → **gated lane**. This PR exists to auto-spin the **Vercel preview + Supabase branch DB**, which is the unblock for the remaining work.

## Still TODO (needs this preview)

1. **Phase 1 engine wiring** — the short calibration (~12-15Q): reuse the diagnostic engine with reduced count + no confirm, feed REAL readiness into score-reveal/movement, set `metadata.activated[certId]` on finish. **Needs a live env** (AI question-gen + auth) — that's why this preview is needed.
2. **Coachmark** — light nav hint on the switcher (`metadata.tours.<surfaceId>`).

Tier + quota stay **STUBBED** (saas-gated #136): `?onbtier=pro|free` preview override, soft daily counter only, no hard enforcement, no Stripe.

## Verification

- **UAT 4074/4074.** Sec-P7 inline-handler ratchet still passes (delegated `data-*` clicks, zero inline `on*`).
- Phase 2 home verified end-to-end via local preview in **both themes**: free + pro homes, both upgrade sheets, switcher (activated scores + Take-diagnostic), take-diagnostic → first-run handoff.
- Build discipline per founder hard-rule: `/onboarding` lens + `/design-taste-frontend` → `/emil-design-eng` → `/humanizer` on the new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)