### PR TITLE
feat(sandbox): installable iOS onboarding sandbox (live lock + first-run + design mockups)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-onboarding-sandbox-plan.md
+++ b/docs/superpowers/plans/2026-06-07-onboarding-sandbox-plan.md
@@ -1,0 +1,320 @@
+# Onboarding Sandbox — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A single installable phone-framed page (`mockups/onboarding-sandbox.html`) that lets the founder tap through the live cert-lock wall + live first-run flow + the six design mockups on their iPhone 13 Pro Max, no accounts or flags.
+
+**Architecture:** One self-contained static HTML file under `mockups/` (deploy-served). It loads the *real shipped* `../dg-system.css` + `../lib/{router,cert-lock,onboarding-firstrun}.js`, drives them with stub data, and iframes the static design mockups. Installable-app meta tags + safe-area CSS make Add-to-Home-Screen launch full-screen.
+
+**Tech Stack:** Vanilla HTML/CSS/JS, the project's `dg-system.css` forged-bronze tokens, the live onboarding modules.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-onboarding-sandbox-design.md`. **Lane:** FAST (static `mockups/` only). No version bump. No UAT (UAT covers app source, not `mockups/` demos — verification is the browser walk).
+
+**Grounded facts (verified):**
+- First-run container: `<div id="onb-firstrun" class="onb-fr" hidden></div>`; `show()` just sets `hidden=false`; launched via `window.onbFirstRun.start(decision)`.
+- Only global needing a stub: `window.showPage` (no-op). `CERT_PACK`/`EXAM_PASS_SCORE`/`cloudStore`/`startDiagnostic` are all guarded or intentionally absent (no-engine fallback → jumps to reveal screens with placeholder data).
+- Cert-lock: `window._certLock.check({isLoggedIn,profile})` reads `window.CURRENT_CERT` + `profile.metadata.freeCertId`; renders `#cl-wall`.
+- 7 design mockups live on `origin/worktree-onboarding-admin-tier` (not on `main`).
+- Cert ids: `netplus, secplus, az900, ai900, aplus-core1, aplus-core2, sc900, clfc02`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `mockups/onboarding-{native-welcome,signup-signin,upgrade-sheet,free-capped-home,pro-welcome,my-certs-pro,rollout-flow}.html` | **Bring from old branch** | The 6 design screens (+rollout map) the sandbox iframes. |
+| `mockups/onboarding-sandbox.html` | **Create** | The whole sandbox: app-shell meta, menu, theme toggle, live cert-lock control, live first-run launcher, mockup iframes. |
+
+---
+
+## Task 1: Bring the 7 design mockups into the branch
+
+**Files:** 7 `mockups/onboarding-*.html` (from `origin/worktree-onboarding-admin-tier`).
+
+- [ ] **Step 1: Check them out**
+
+```bash
+cd "/Users/simioremosu/Desktop/Dev Projects/networkplus-quiz/.claude/worktrees/onboarding-admin-tier"
+git fetch origin --quiet
+git checkout origin/worktree-onboarding-admin-tier -- \
+  mockups/onboarding-native-welcome.html \
+  mockups/onboarding-signup-signin.html \
+  mockups/onboarding-upgrade-sheet.html \
+  mockups/onboarding-free-capped-home.html \
+  mockups/onboarding-pro-welcome.html \
+  mockups/onboarding-my-certs-pro.html \
+  mockups/onboarding-rollout-flow.html
+```
+
+- [ ] **Step 2: Verify all 7 present**
+
+Run: `ls mockups/onboarding-{native-welcome,signup-signin,upgrade-sheet,free-capped-home,pro-welcome,my-certs-pro,rollout-flow}.html`
+Expected: all 7 listed, no "No such file".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mockups/onboarding-native-welcome.html mockups/onboarding-signup-signin.html mockups/onboarding-upgrade-sheet.html mockups/onboarding-free-capped-home.html mockups/onboarding-pro-welcome.html mockups/onboarding-my-certs-pro.html mockups/onboarding-rollout-flow.html
+git commit -m "docs(mockups): bring the 7 onboarding design mockups onto main (for the sandbox)"
+```
+
+---
+
+## Task 2: Create the sandbox page (full file)
+
+**Files:** Create `mockups/onboarding-sandbox.html`.
+
+- [ ] **Step 1: Write the complete file**
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>CertAnvil Lab</title>
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex, nofollow">
+<!-- Installable app shell (iPhone 13 Pro Max: 428x926, notch + home-indicator safe areas) -->
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="CertAnvil Lab">
+<meta name="theme-color" content="#1a1714">
+<!-- monogram touch icon (forged-bronze tile) -->
+<link rel="apple-touch-icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Crect width='180' height='180' rx='40' fill='%231a1714'/%3E%3Cg fill='none' stroke='%23c98a3c' stroke-width='12' stroke-linecap='round'%3E%3Cpath d='M104 38 C76 26, 34 42, 30 70 C26 98, 44 116, 78 118'/%3E%3Cline x1='58' y1='150' x2='126' y2='32' stroke='%238a8a8a'/%3E%3Cpath d='M82 156 L116 86 L150 156 M95 130 L137 130'/%3E%3C/g%3E%3C/svg%3E">
+<link rel="stylesheet" href="../dg-system.css?v=sandbox">
+<style>
+  :root { color-scheme: light dark; }
+  html, body { margin: 0; height: 100%; background: var(--bg, #111); }
+  body { font-family: Inter, system-ui, sans-serif; color: var(--text, #eee); }
+  /* phone frame: full-bleed on device, centered 428-wide column on desktop */
+  .sbx-frame {
+    position: relative; width: 100%; max-width: 428px; min-height: 100dvh;
+    margin: 0 auto; background: var(--bg); overflow: hidden;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    box-sizing: border-box;
+  }
+  @media (min-width: 480px) { .sbx-frame { min-height: 926px; max-height: 96vh; margin-top: 2vh; border-radius: 44px; box-shadow: 0 30px 90px rgba(0,0,0,.4); border: 1px solid var(--border, #333); overflow-y: auto; } }
+  .sbx-bar { display:flex; align-items:center; justify-content:space-between; padding:16px 18px 10px; }
+  .sbx-brand { display:flex; align-items:center; gap:9px; font-family:'Fraunces',Georgia,serif; font-weight:600; font-size:18px; color:var(--text); }
+  .sbx-brand svg { width:26px; height:26px; }
+  .sbx-theme { font:600 13px Inter,sans-serif; color:var(--accent); background:transparent; border:1px solid color-mix(in oklab,var(--accent) 30%,var(--border)); border-radius:999px; padding:7px 13px; cursor:pointer; }
+  .sbx-intro { padding:4px 18px 14px; color:var(--text-dim); font-size:13.5px; line-height:1.5; }
+  .sbx-group { padding:10px 18px 4px; font:700 11px Inter,sans-serif; letter-spacing:.08em; text-transform:uppercase; color:var(--text-dim); }
+  .sbx-cards { display:flex; flex-direction:column; gap:9px; padding:4px 14px 18px; }
+  .sbx-card { display:flex; align-items:center; gap:12px; width:100%; text-align:left; background:var(--surface); border:1px solid var(--border); border-radius:15px; padding:15px 16px; cursor:pointer; color:var(--text); font:inherit; transition:transform .15s cubic-bezier(0.16,1,0.3,1); }
+  .sbx-card:active { transform:scale(0.985); }
+  .sbx-tag { margin-left:auto; font:600 10px Inter,sans-serif; padding:3px 8px; border-radius:999px; }
+  .sbx-tag.live { color:#1c7a47; background:color-mix(in oklab,#1c7a47 16%,transparent); }
+  .sbx-tag.design { color:var(--text-dim); background:color-mix(in oklab,var(--text) 10%,transparent); }
+  .sbx-card-t { font-weight:600; font-size:15px; }
+  .sbx-card-s { font-size:12.5px; color:var(--text-dim); margin-top:2px; }
+  /* panels (full-frame overlays) */
+  .sbx-panel { position:absolute; inset:0; background:var(--bg); display:none; flex-direction:column; z-index:50; }
+  .sbx-panel.open { display:flex; }
+  .sbx-panel-bar { display:flex; align-items:center; gap:10px; padding:calc(env(safe-area-inset-top) + 12px) 16px 12px; border-bottom:1px solid var(--border); }
+  .sbx-back { font:600 14px Inter,sans-serif; color:var(--accent); background:none; border:none; cursor:pointer; padding:6px 4px; }
+  .sbx-panel-title { font-weight:600; font-size:14px; color:var(--text); }
+  .sbx-panel-body { flex:1; overflow-y:auto; -webkit-overflow-scrolling:touch; }
+  .sbx-panel-body iframe { width:100%; height:100%; border:0; display:block; }
+  /* cert-lock control */
+  .sbx-ctl { padding:22px 18px; display:flex; flex-direction:column; gap:14px; }
+  .sbx-ctl label { font:600 12px Inter,sans-serif; color:var(--text-dim); display:block; margin-bottom:6px; }
+  .sbx-ctl select { width:100%; font:500 15px Inter,sans-serif; color:var(--text); background:var(--surface); border:1px solid var(--border); border-radius:11px; padding:13px 12px; }
+  .sbx-ctl .sbx-go { background:var(--accent); color:var(--bg); border:none; border-radius:13px; padding:15px; font:700 15px Inter,sans-serif; cursor:pointer; }
+  .sbx-ctl .sbx-hint { font-size:12.5px; color:var(--text-dim); line-height:1.5; }
+  #onb-firstrun.onb-fr[hidden] { display:none; }
+</style>
+</head>
+<body>
+<div class="sbx-frame" id="sbx-menu-frame">
+  <div class="sbx-bar">
+    <div class="sbx-brand">
+      <svg viewBox="0 0 100 100" fill="none" aria-hidden="true">
+        <path d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" class="sb-brand-c" stroke-width="7" stroke-linecap="round"/>
+        <line x1="30" y1="84" x2="70" y2="16" class="sb-brand-slash" stroke-width="5" stroke-linecap="round"/>
+        <path d="M46 88 L64 50 L82 88 M53 74 L75 74" class="sb-brand-a" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      CertAnvil Lab
+    </div>
+    <button class="sbx-theme" id="sbx-theme">Dark</button>
+  </div>
+  <p class="sbx-intro">A sandbox to walk the onboarding flow. Green items are the real shipped code; tan items are the approved design mockups. Nothing here touches a real account.</p>
+
+  <div class="sbx-group">Live &amp; interactive</div>
+  <div class="sbx-cards">
+    <button class="sbx-card" data-act="certlock"><span><span class="sbx-card-t">Cert-lock wall</span><span class="sbx-card-s">The free-tier lock. Pick a cert pairing.</span></span><span class="sbx-tag live">live</span></button>
+    <button class="sbx-card" data-act="firstrun"><span><span class="sbx-card-t">First-run flow</span><span class="sbx-card-s">Lobby, diagnostic, the +movement aha, home.</span></span><span class="sbx-tag live">live</span></button>
+  </div>
+
+  <div class="sbx-group">Design mockups</div>
+  <div class="sbx-cards" id="sbx-mock-cards"><!-- filled by JS --></div>
+
+  <div class="sbx-group">The real app</div>
+  <div class="sbx-cards">
+    <button class="sbx-card" data-act="realapp"><span><span class="sbx-card-t">Open the live app</span><span class="sbx-card-s">The actual home chrome, with ?onb=1.</span></span><span class="sbx-tag design">link</span></button>
+  </div>
+
+  <!-- cert-lock control panel -->
+  <div class="sbx-panel" id="sbx-panel-certlock">
+    <div class="sbx-panel-bar"><button class="sbx-back" data-back>&larr; Menu</button><span class="sbx-panel-title">Cert-lock wall (live)</span></div>
+    <div class="sbx-panel-body">
+      <div class="sbx-ctl">
+        <div><label for="sbx-owned">Free user is locked to</label><select id="sbx-owned"></select></div>
+        <div><label for="sbx-visiting">and is now visiting</label><select id="sbx-visiting"></select></div>
+        <button class="sbx-go" id="sbx-show-wall">Show the wall</button>
+        <p class="sbx-hint">Pick two different certs to see the lock. Pick the same cert (their owned one) to confirm no wall appears. This calls the real <code>_certLock.check</code>.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- first-run panel (the module renders into #onb-firstrun) -->
+  <div class="sbx-panel" id="sbx-panel-firstrun">
+    <div class="sbx-panel-bar"><button class="sbx-back" data-back data-fr-close>&larr; Menu</button><span class="sbx-panel-title">First-run flow (live, placeholder data)</span></div>
+    <div class="sbx-panel-body"><div id="onb-firstrun" class="onb-fr" hidden></div></div>
+  </div>
+
+  <!-- mockup iframe panel -->
+  <div class="sbx-panel" id="sbx-panel-mock">
+    <div class="sbx-panel-bar"><button class="sbx-back" data-back>&larr; Menu</button><span class="sbx-panel-title" id="sbx-mock-title">Design</span><span class="sbx-tag design" style="margin-left:auto">design</span></div>
+    <div class="sbx-panel-body"><iframe id="sbx-mock-frame" title="design mockup"></iframe></div>
+  </div>
+</div>
+
+<!-- real shipped modules (order: router -> cert-lock -> firstrun) -->
+<script src="../lib/router.js"></script>
+<script src="../lib/cert-lock.js"></script>
+<script>window.showPage = function () {};  /* no-op stub: firstrun calls window.showPage('setup'); the sandbox has no app pages */</script>
+<script src="../lib/onboarding-firstrun.js"></script>
+<script>
+(function () {
+  'use strict';
+  var CERTS = [
+    ['netplus','Network+'],['secplus','Security+'],['az900','Azure AZ-900'],['ai900','Azure AI-900'],
+    ['aplus-core1','A+ Core 1'],['aplus-core2','A+ Core 2'],['sc900','Security SC-900'],['clfc02','AWS CLF-C02']
+  ];
+  var MOCKS = [
+    ['onboarding-native-welcome.html','Welcome','First screen on launch.'],
+    ['onboarding-signup-signin.html','Sign up / Sign in','Account step.'],
+    ['onboarding-upgrade-sheet.html','Pro upgrade sheet','The payment moment.'],
+    ['onboarding-free-capped-home.html','Done for today','After declining Pro.'],
+    ['onboarding-pro-welcome.html',"You're Pro",'Post-purchase celebration.'],
+    ['onboarding-my-certs-pro.html','My Certs (Pro)','Every exam unlocked.'],
+    ['onboarding-rollout-flow.html','Rollout flow map','Reference: the whole flow.']
+  ];
+  function $(id){ return document.getElementById(id); }
+
+  // theme toggle
+  var themeBtn = $('sbx-theme');
+  function applyTheme(t){ document.documentElement.setAttribute('data-theme', t); try{ localStorage.setItem('sbx_theme', t); }catch(_){} themeBtn.textContent = t === 'light' ? 'Light' : 'Dark'; }
+  themeBtn.addEventListener('click', function(){ var cur = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light'; applyTheme(cur); });
+  try { applyTheme(localStorage.getItem('sbx_theme') || 'light'); } catch(_) { applyTheme('light'); }
+
+  // populate cert dropdowns
+  function fill(sel, def){ CERTS.forEach(function(c){ var o=document.createElement('option'); o.value=c[0]; o.textContent=c[1]; if(c[0]===def)o.selected=true; sel.appendChild(o); }); }
+  fill($('sbx-owned'),'netplus'); fill($('sbx-visiting'),'secplus');
+
+  // mockup cards
+  var wrap = $('sbx-mock-cards');
+  MOCKS.forEach(function(m){
+    var b=document.createElement('button'); b.className='sbx-card'; b.setAttribute('data-mock', m[0]); b.setAttribute('data-mock-title', m[1]);
+    b.innerHTML='<span><span class="sbx-card-t">'+m[1]+'</span><span class="sbx-card-s">'+m[2]+'</span></span><span class="sbx-tag design">design</span>';
+    wrap.appendChild(b);
+  });
+
+  function openPanel(id){ var p=$(id); if(p) p.classList.add('open'); }
+  function closePanels(){ ['sbx-panel-certlock','sbx-panel-firstrun','sbx-panel-mock'].forEach(function(id){ $(id).classList.remove('open'); }); }
+
+  // delegated clicks
+  document.addEventListener('click', function(e){
+    var card = e.target.closest('[data-act]');
+    if (card){
+      var act = card.getAttribute('data-act');
+      if (act==='certlock') openPanel('sbx-panel-certlock');
+      else if (act==='firstrun') startFirstRun();
+      else if (act==='realapp') window.open('/?onb=1','_blank');
+      return;
+    }
+    var mock = e.target.closest('[data-mock]');
+    if (mock){ $('sbx-mock-frame').src = mock.getAttribute('data-mock'); $('sbx-mock-title').textContent = mock.getAttribute('data-mock-title'); openPanel('sbx-panel-mock'); return; }
+    if (e.target.closest('[data-back]')){ if (e.target.closest('[data-fr-close]') && window.onbFirstRun && window.onbFirstRun.close) { try{ window.onbFirstRun.close(); }catch(_){} } var f=$('sbx-mock-frame'); if(f) f.removeAttribute('src'); closePanels(); }
+  });
+
+  // cert-lock: drive the real module
+  $('sbx-show-wall').addEventListener('click', function(){
+    var owned=$('sbx-owned').value, visiting=$('sbx-visiting').value;
+    var ex=document.getElementById('cl-wall'); if(ex) ex.remove(); document.documentElement.classList.remove('cl-locked');
+    window.CURRENT_CERT = visiting;
+    try { window._certLock.check({ isLoggedIn:true, profile:{ role:'user', metadata:{ freeCertId: owned } } }); } catch(_){}
+    if (!document.getElementById('cl-wall')) { alert(owned===visiting ? 'No wall: this is their owned cert (correct).' : 'No wall rendered.'); }
+  });
+
+  // first-run: stub already set (window.showPage); start in mock mode
+  function startFirstRun(){
+    try { localStorage.setItem('onb_mock','1'); } catch(_){}
+    openPanel('sbx-panel-firstrun');
+    try { if (window.onbFirstRun && window.onbFirstRun.start) window.onbFirstRun.start({ certId:null, tier:'free', reason:'no-cert' }); } catch(_){}
+  }
+})();
+</script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Lint the HTML (no broken script paths / unclosed tags)**
+
+Run: `grep -c 'sbx-frame\|onb-firstrun\|_certLock' mockups/onboarding-sandbox.html`
+Expected: ≥ 3 (sanity that the key hooks are present).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mockups/onboarding-sandbox.html
+git commit -m "feat(sandbox): installable iOS onboarding sandbox (live lock + first-run + design mockups)"
+```
+
+---
+
+## Task 3: Live-verify at iPhone 13 Pro Max size
+
+**Files:** none.
+
+- [ ] **Step 1: Serve + open at 428x926.** Use the worktree preview (or `python3 -m http.server 3131`). Resize the preview viewport to 428x926. Navigate to `mockups/onboarding-sandbox.html`.
+- [ ] **Step 2: Walk each bucket (console must stay clean):**
+  - Theme toggle flips light/dark; the menu + live wall recolor.
+  - Cert-lock: owned=Network+, visiting=Security+ → Show wall → real `#cl-wall` appears ("Security+ is part of Pro", Back to Network+). Owned=visiting → alert "owned cert (correct)", no wall.
+  - First-run: Start → walk lobby → pick a cert → diagnostic intro → (no-engine fallback) score reveal → +movement → habit → home. Back to Menu closes it.
+  - Each design card opens its mockup in the iframe; Back returns.
+  - "Open the live app" opens `/?onb=1` in a new tab.
+- [ ] **Step 3: Screenshot** the menu (both themes) + the live wall + a first-run screen for the record.
+- [ ] **Step 4: Confirm app-shell meta present**
+
+Run: `grep -c 'apple-mobile-web-app-capable\|viewport-fit=cover\|apple-touch-icon' mockups/onboarding-sandbox.html`
+Expected: `3`.
+
+---
+
+## Task 4: Ship (fast lane) + send the link
+
+**Files:** none (push only).
+
+- [ ] **Step 1: Push to main** (fast lane — static mockups only, no gated files, no version bump):
+
+```bash
+git push origin feat/onboarding-sandbox:main
+```
+(Pushes the current branch to remote `main`. Confirm branch first with `git branch --show-current`.)
+
+- [ ] **Step 2: Confirm CI/deploy** — `gh run list --branch main --limit 2`; wait for "CI/CD — Test & Deploy" success.
+- [ ] **Step 3: Smoke prod** — fetch `https://networkplus.certanvil.com/mockups/onboarding-sandbox.html` (via the code path, curl is sandboxed) and confirm it returns the sandbox HTML (contains `CertAnvil Lab` + `onb-firstrun`).
+- [ ] **Step 4: Send the founder the URL:** `https://networkplus.certanvil.com/mockups/onboarding-sandbox.html` with the "Add to Home Screen" note.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** installable shell + safe areas (Task 2 meta + CSS) ✓; loads real shipped files (Task 2 script srcs) ✓; live cert-lock with cert pickers (Task 2 control + handler) ✓; live first-run via no-engine fallback + `showPage` stub (Task 2) ✓; 6 design mockups + rollout map iframed (Task 2 MOCKS) ✓; open-real-app button ✓; theme toggle ✓; unlinked + noindex ✓; bring 7 mockups to main (Task 1) ✓; fast lane, no bump (Task 4) ✓; 428x926 verify (Task 3) ✓.
+- **Placeholder scan:** none — full file provided. The touch icon is an inline SVG data-URI (no external asset needed). The first-run app.js-coupling risk is handled by the `showPage` no-op stub + the verified no-engine fallback; if a leg still misbehaves, Task 3 catches it and the fix is another small stub.
+- **Name consistency:** `#onb-firstrun.onb-fr`, `window.onbFirstRun.start/close`, `window._certLock.check`, `window.CURRENT_CERT`, `#cl-wall`, `data-act`/`data-mock`/`data-back`, `sbx-*` — consistent throughout.
+- **Risk:** zero impact on the real app (separate unlinked static file; loads but does not mutate app state; writes only `onb_mock`/`sbx_theme` to the sandbox origin's localStorage, never `nplus_*`).

--- a/docs/superpowers/specs/2026-06-07-onboarding-sandbox-design.md
+++ b/docs/superpowers/specs/2026-06-07-onboarding-sandbox-design.md
@@ -1,0 +1,83 @@
+# Onboarding Sandbox — Design Spec (2026-06-07)
+
+**Goal:** Give the founder an installable, phone-framed playground to see and interact with the full onboarding flow + the new free-tier cert lock on their iPhone — today, without waiting for the App Store and without juggling real accounts/state.
+
+**Why:** Everything is currently only visible via screenshots or by setting up real free accounts + `?onb=1` flags on prod. The founder wants to *physically tap through* the flow on their device (iPhone 13 Pro Max).
+
+---
+
+## Locked decisions (founder, 2026-06-07)
+
+1. **Hybrid composition:** the cert-lock wall and first-run flow are *truly live and interactive*; the other six screens show the *approved static design mockups*, clearly labelled "design"; plus a button into the real app.
+2. **Installable mini-app:** lives at a single URL the founder Adds to Home Screen; launches full-screen (standalone), feels native.
+3. **Target device:** iPhone 13 Pro Max (428×926 logical, notch + home-indicator safe areas).
+4. **Fast lane:** static `mockups/` page + docs only. No gated files, no version bump.
+
+---
+
+## Architecture
+
+### Location & delivery
+- Single self-contained file: **`mockups/onboarding-sandbox.html`**. `/mockups/` is deploy-served (per `vercel.json`), so it goes live at `https://networkplus.certanvil.com/mockups/onboarding-sandbox.html` on push to `main`.
+- **Unlinked + `<meta name="robots" content="noindex">`** — no real user stumbles in; not in any nav or sitemap.
+- **Loads the real shipped files** via parent-relative paths: `../dg-system.css`, `../lib/router.js`, `../lib/cert-lock.js`, `../lib/onboarding-firstrun.js`. So the live pieces are always exactly prod, never a drifting copy.
+
+### Installable-app shell (iPhone 13 Pro Max)
+- `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">` — enables safe-area insets.
+- `<meta name="apple-mobile-web-app-capable" content="yes">` + `<meta name="mobile-web-app-capable" content="yes">` — full-screen standalone on Add to Home Screen.
+- `<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">` + `<meta name="apple-mobile-web-app-title" content="CertAnvil Lab">`.
+- `<link rel="apple-touch-icon" ...>` — the CertAnvil monogram on a forged-bronze tile, so the home-screen icon looks right.
+- All chrome respects `env(safe-area-inset-top/bottom/left/right)` so content clears the notch and home indicator.
+- Layout targets a 428pt-wide column. On desktop it renders as a centered phone-framed column; on the real phone (standalone) it's full-bleed within the safe area.
+
+### Composition (three buckets)
+**🟢 Live & interactive**
+- **Cert-lock wall** — a small control: "Locked to [dropdown of 8 certs] · Visiting [dropdown of 8 certs]" → "Show the wall" calls the real `window._certLock.check({ isLoggedIn:true, profile:{ role:'user', metadata:{ freeCertId:<locked> } } })` after setting `window.CURRENT_CERT = <visiting>`. The real wall renders. "Reset" removes it. (If locked === visiting, show a hint that this is the owned-cert case = no wall.)
+- **First-run flow** — "Start first-run" sets `onb_mock` and calls `window.onbFirstRun.start({ certId:null, tier:'free', reason:'no-cert' })`. The founder walks lobby → pick cert → diagnostic intro → score reveal → +movement → habit → home. Runs via the module's built-in **no-engine fallback** (when `window.startDiagnostic` is absent, it jumps straight to the reveal screens with placeholder readiness), so no API key / app.js / cert pack needed.
+
+**🎨 Design mockups (embedded, labelled "design")**
+- welcome (`onboarding-native-welcome.html`), sign-up (`onboarding-signup-signin.html`), Pro upgrade sheet (`onboarding-upgrade-sheet.html`), done-for-today (`onboarding-free-capped-home.html`), You're Pro (`onboarding-pro-welcome.html`), My Certs (`onboarding-my-certs-pro.html`). Each opens in an in-page `<iframe>` filling the phone frame, with a "design mockup" tag + back button.
+- (Optional extra: the rollout-flow map `onboarding-rollout-flow.html` under a "Reference" heading.)
+
+**🔗 The real thing**
+- A button that opens `/?onb=1` (the live app) in a new tab for the genuine home chrome.
+
+### Menu / control UX
+- The sandbox "home" is a phone-framed menu: a CertAnvil header, a global **light/dark toggle** (applies `data-theme` to drive the live pieces' tokens), then tappable cards grouped under the three buckets above with the 🟢/🎨/🔗 affordances.
+- Every screen has a persistent "← Menu" affordance (respecting the top safe-area inset).
+- Forged-bronze, Fraunces + Inter, matches `dg-system.css`. Reduced-motion gated. Zero em-dashes in any visible copy.
+
+### Data flow
+- Cert-lock: menu dropdowns → `window.CURRENT_CERT` + `_certLock.check(stub profile)` → real wall in the DOM. No persistence (sandbox never writes `nplus_*` to a real profile; it operates on stub objects only).
+- First-run: menu → `onb_mock` flag (sandbox-local) + `onbFirstRun.start(decision)` → renders into its container. Placeholder data only.
+- Mockups: menu → set `iframe.src` → static file.
+
+---
+
+## Prerequisite: bring 7 mockups into `main`
+The session-1 design mockups exist only on `worktree-onboarding-admin-tier` (never merged). Bring these into `main` (pure static docs, zero risk) before/with the sandbox:
+`onboarding-native-welcome.html`, `onboarding-signup-signin.html`, `onboarding-upgrade-sheet.html`, `onboarding-free-capped-home.html`, `onboarding-pro-welcome.html`, `onboarding-my-certs-pro.html`, `onboarding-rollout-flow.html`.
+(`onboarding-batch2-concept.html` and `onboarding-first-run-concept.html` are already on `main`.)
+
+## Error handling / graceful degradation
+- Every live call is wrapped so a failure shows a small inline "couldn't load the live module" note instead of a blank screen — the rest of the sandbox keeps working.
+- **Risk (known):** `onbFirstRun.start` may reference app.js globals beyond the no-engine fallback (e.g. `window.showPage`, `window.CERT_PACK`). Mitigation: provide minimal no-op stubs for any such globals the module touches; the build verifies the full first-run walk on a real device/preview. If a leg can't run standalone, that leg degrades to a labelled note and the rest still works. Determined during implementation.
+- Sandbox writes nothing to real cloud/profile state; all profile objects are local stubs.
+
+## Out of scope
+- Building the six design-only screens as live interactive code (that's the deferred onboarding work).
+- The live home chrome inside the sandbox (covered by the "open the real app" button).
+- Auth, payments, real diagnostics.
+
+## Surfaces touched + lane
+- NEW: `mockups/onboarding-sandbox.html`. Bring over: 7 `mockups/onboarding-*.html` files. Touch-icon asset if not reusable from existing brand assets.
+- **FAST LANE** — static `mockups/` + docs only, no gated files. Commit → `main` → deploy. No version bump (new unlinked page, not a precached shell asset).
+
+## Testing
+- Local: serve the worktree, open the sandbox at a 428×926 viewport (preview resize), walk each bucket: cert-lock wall renders for a wrong-cert pick and not for owned; first-run walks end to end on placeholder data; each mockup loads in its frame; theme toggle flips light/dark on the live pieces.
+- Console clean (no errors) across the walk.
+- Confirm the standalone meta tags are present (so Add to Home Screen launches full-screen).
+- Real-device confirmation is the founder's Add-to-Home-Screen pass once the link is sent.
+
+## Success criteria
+The founder opens one URL on their iPhone 13 Pro Max, Adds to Home Screen, launches a full-screen app, and can tap through: the real cert-lock wall (any cert pairing), the real first-run flow end to end, and all six design screens — in light or dark — without any accounts, flags, or setup.

--- a/mockups/onboarding-free-capped-home.html
+++ b/mockups/onboarding-free-capped-home.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Done for today (after declining Pro)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .home { flex: 1; padding: 10px 20px 24px; overflow-y: auto; }
+  .home::-webkit-scrollbar { width: 0; }
+
+  /* free home bar (capped state) */
+  .hb { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 14px 15px; margin-top: 8px; }
+  .hb-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px; }
+  .hb-cert { display: inline-flex; align-items: center; gap: 9px; min-width: 0; }
+  .hb-mark { flex: 0 0 auto; width: 34px; height: 34px; border-radius: 9px; background: color-mix(in oklab, var(--accent) 14%, var(--surface-2)); color: var(--accent-deep); display: grid; place-items: center; font: 800 13px/1 Inter, sans-serif; }
+  .hb-name { font: 650 15px/1.1 Inter, sans-serif; color: var(--ink); }
+  .hb-code { font: 600 11.5px/1 'Roboto Mono', monospace; color: var(--muted); margin-top: 3px; }
+  .hb-plan { flex: 0 0 auto; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 5px 9px; }
+  .hb-quota { border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); padding-top: 4px; }
+  .hb-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 0; }
+  .hb-row + .hb-row { border-top: 1px solid color-mix(in oklab, var(--border) 55%, transparent); }
+  .hb-rn { font-size: 13.5px; color: var(--ink-soft); }
+  .hb-rv { font: 600 13px/1 Inter, sans-serif; color: var(--ink); }
+  .hb-reset { display: inline-flex; align-items: center; gap: 6px; font: 700 11.5px/1 Inter, sans-serif; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 11%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border)); border-radius: 999px; padding: 6px 10px; }
+  .hb-reset svg { width: 12px; height: 12px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* done-for-today moment */
+  .done { text-align: center; margin: 24px 4px 6px; }
+  .done .kick { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--pass); margin-bottom: 9px; display: inline-flex; align-items: center; gap: 7px; }
+  .done .kick svg { width: 14px; height: 14px; stroke: var(--pass); fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .done h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 25px; line-height: 1.1; letter-spacing: -0.015em; margin: 0 0 9px; color: var(--ink); }
+  .done p { font-size: 13.5px; line-height: 1.5; color: var(--ink-soft); margin: 0 auto; max-width: 34ch; }
+
+  /* the still-free next action */
+  .review { margin-top: 20px; border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border)); border-radius: 16px; background: color-mix(in oklab, var(--accent) 6%, var(--surface)); padding: 16px; }
+  .review-head { display: flex; align-items: center; gap: 12px; margin-bottom: 13px; }
+  .review-ring { flex: 0 0 auto; width: 44px; height: 44px; border-radius: 999px; display: grid; place-items: center; background: var(--surface); border: 2px solid color-mix(in oklab, var(--accent) 45%, var(--border)); font-family: Fraunces, serif; font-weight: 600; font-size: 18px; color: var(--accent-deep); font-variant-numeric: lining-nums; font-feature-settings: "lnum"; }
+  .review-t { font: 650 15px/1.1 Inter, sans-serif; color: var(--ink); }
+  .review-s { font-size: 12.5px; color: var(--ink-soft); margin-top: 3px; }
+  .btn-primary { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+  /* soft, re-openable Pro line (not a sheet) */
+  .pro-soft { margin-top: 14px; display: flex; align-items: center; gap: 12px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 13px 15px; }
+  .pro-soft .pt { flex: 1 1 auto; min-width: 0; }
+  .pro-soft .pt b { font: 650 13.5px/1.2 Inter, sans-serif; color: var(--ink); }
+  .pro-soft .pt span { display: block; font-size: 12px; color: var(--muted); margin-top: 2px; }
+  .pro-soft .see { flex: 0 0 auto; background: none; border: 1px solid color-mix(in oklab, var(--accent) 40%, var(--border)); border-radius: 999px; padding: 8px 13px; cursor: pointer; font: 650 12.5px/1 Inter, sans-serif; color: var(--accent-bright); transition: background .2s; }
+  @media (hover:hover) and (pointer:fine) { .pro-soft .see:hover { background: color-mix(in oklab, var(--accent) 9%, transparent); } }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(10px); animation: rise .5s var(--ease) forwards; }
+    .hb { animation-delay: .04s; } .done { animation-delay: .12s; } .review { animation-delay: .2s; } .pro-soft { animation-delay: .28s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">After declining Pro</p>
+        <h1 class="stage-title">Done for today</h1>
+        <p class="stage-sub">Where a free user lands after closing the Pro sheet. Not a wall: Daily Review is still free, the cap resets tomorrow, and Pro stays a quiet option.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="home">
+            <div class="hb reveal">
+              <div class="hb-top">
+                <div class="hb-cert"><span class="hb-mark">N+</span><span><span class="hb-name">Network+</span><div class="hb-code">N10-009</div></span></div>
+                <span class="hb-plan">Free</span>
+              </div>
+              <div class="hb-quota">
+                <div class="hb-row"><span class="hb-rn">Daily Review</span><span class="hb-rv">5 cards due</span></div>
+                <div class="hb-row"><span class="hb-rn">New practice</span><span class="hb-reset"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 2"></path></svg>15 of 15 · resets in 5h</span></div>
+              </div>
+            </div>
+
+            <div class="done reveal">
+              <span class="kick"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>Done for today</span>
+              <h2>That's today's 15 done.</h2>
+              <p>Your streak is safe. Daily Review still moves your readiness, and 15 fresh questions unlock in about 5 hours.</p>
+            </div>
+
+            <div class="review reveal">
+              <div class="review-head">
+                <div class="review-ring">5</div>
+                <div><div class="review-t">Daily Review</div><div class="review-s">5 cards from what you've missed, about 3 minutes. Still free today.</div></div>
+              </div>
+              <button class="btn-primary" type="button">Start review</button>
+            </div>
+
+            <div class="pro-soft reveal">
+              <div class="pt"><b>Hitting the cap a lot?</b><span>Pro removes the daily limit.</span></div>
+              <button class="see" type="button">See Pro</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">The Pro sheet stays one tap away (See Pro), never forced.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-my-certs-pro.html
+++ b/mockups/onboarding-my-certs-pro.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · My Certs (Pro)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 12px; }
+  .hdr .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); }
+  .hdr .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+  .hdr .pro-tag { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); background: color-mix(in oklab, var(--accent) 13%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); border-radius: 999px; padding: 6px 9px; }
+
+  .body { flex: 1; overflow-y: auto; padding: 4px 22px 24px; }
+  .body::-webkit-scrollbar { width: 0; }
+  .sect { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin: 14px 2px 10px; }
+
+  .mark { flex: 0 0 auto; width: 40px; height: 40px; border-radius: 11px; background: color-mix(in oklab, var(--accent) 13%, var(--surface-2)); color: var(--accent-deep); display: grid; place-items: center; font: 800 13px/1 Inter, sans-serif; }
+  .nm { font: 650 15px/1.1 Inter, sans-serif; color: var(--ink); }
+  .cd { font: 600 11.5px/1 'Roboto Mono', monospace; color: var(--muted); margin-top: 3px; }
+
+  /* active cert (rich) */
+  .active-card { border: 1px solid color-mix(in oklab, var(--accent) 34%, var(--border)); border-radius: 16px; background: color-mix(in oklab, var(--accent) 6%, var(--surface)); padding: 15px 16px; }
+  .ac-top { display: flex; align-items: center; gap: 12px; }
+  .ac-badge { margin-left: auto; font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--pass); background: color-mix(in oklab, var(--pass) 13%, transparent); border: 1px solid color-mix(in oklab, var(--pass) 34%, transparent); border-radius: 999px; padding: 5px 8px; }
+  .ac-score { display: flex; align-items: baseline; gap: 7px; margin: 14px 0 6px; }
+  .ac-num { font: 600 30px/1 Fraunces, serif; color: var(--ink); font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; }
+  .ac-of { font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+  .bar { height: 7px; border-radius: 999px; background: var(--track); position: relative; overflow: hidden; margin-bottom: 5px; }
+  .bar > span { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 999px; background: var(--accent); }
+  .bar .tick { position: absolute; top: -2px; bottom: -2px; width: 2px; background: color-mix(in oklab, var(--ink) 45%, var(--track)); }
+  .bar-legend { display: flex; justify-content: space-between; font: 600 10.5px/1 Inter, sans-serif; color: var(--muted); }
+  .bar-legend .p { color: var(--accent-deep); }
+  .btn-primary { width: 100%; border: none; border-radius: 12px; padding: 13px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 14.5px/1 Inter, sans-serif; margin-top: 14px;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+  /* ready-to-start rows */
+  .cert-row { display: flex; align-items: center; gap: 12px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 11px 13px; margin-bottom: 10px; cursor: pointer; transition: border-color .18s, transform .12s var(--ease); }
+  .cert-row:active { transform: scale(0.99); }
+  @media (hover:hover) and (pointer:fine) { .cert-row:hover { border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); } }
+  .cert-row .meta { flex: 1 1 auto; min-width: 0; }
+  .cert-row .state { flex: 0 0 auto; font: 700 12px/1 Inter, sans-serif; color: var(--accent-bright); display: inline-flex; align-items: center; gap: 6px; }
+  .cert-row .state svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+  .scored .state { color: var(--ink-soft); }
+  .scored .state b { font-family: Fraunces, serif; font-weight: 600; font-size: 15px; color: var(--ink); font-variant-numeric: lining-nums; font-feature-settings: "lnum"; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(9px); animation: rise .5s var(--ease) forwards; }
+    .reveal:nth-child(1){animation-delay:.04s}.reveal:nth-child(2){animation-delay:.08s}.reveal:nth-child(3){animation-delay:.12s}
+    .reveal:nth-child(4){animation-delay:.16s}.reveal:nth-child(5){animation-delay:.20s}.reveal:nth-child(6){animation-delay:.24s}
+    .reveal:nth-child(7){animation-delay:.28s}.reveal:nth-child(8){animation-delay:.32s}.reveal:nth-child(9){animation-delay:.36s}.reveal:nth-child(10){animation-delay:.40s}
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Pro · my certs</p>
+        <h1 class="stage-title">Your exams (Pro)</h1>
+        <p class="stage-sub">Where "See all your exams" lands. The payoff of Pro: the cert you started keeps its score, and every other IT exam is unlocked and ready.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="hdr">
+            <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+            <h1>Your exams</h1>
+            <span class="pro-tag">Pro</span>
+          </div>
+
+          <div class="body">
+            <div class="sect reveal">Studying now</div>
+            <div class="active-card reveal">
+              <div class="ac-top">
+                <span class="mark">N+</span>
+                <span><span class="nm">Network+</span><div class="cd">N10-009</div></span>
+                <span class="ac-badge">Active</span>
+              </div>
+              <div class="ac-score"><span class="ac-num">465</span><span class="ac-of">/ 900 readiness</span></div>
+              <div class="bar"><span style="width:51.6%"></span><span class="tick" style="left:80%"></span></div>
+              <div class="bar-legend"><span>100</span><span class="p">Pass 720</span><span>900</span></div>
+              <button class="btn-primary" type="button">Continue Network+</button>
+            </div>
+
+            <div class="sect reveal">Unlocked, ready to start</div>
+            <div class="cert-row reveal"><span class="mark">S+</span><div class="meta"><div class="nm">Security+</div><div class="cd">SY0-701</div></div><span class="state">Start <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"></path></svg></span></div>
+            <div class="cert-row reveal"><span class="mark">A+</span><div class="meta"><div class="nm">A+ Core 1</div><div class="cd">220-1101</div></div><span class="state">Start <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"></path></svg></span></div>
+            <div class="cert-row reveal"><span class="mark">A+</span><div class="meta"><div class="nm">A+ Core 2</div><div class="cd">220-1102</div></div><span class="state">Start <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"></path></svg></span></div>
+            <div class="cert-row reveal"><span class="mark">AZ</span><div class="meta"><div class="nm">Azure Fundamentals</div><div class="cd">AZ-900</div></div><span class="state">Start <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"></path></svg></span></div>
+            <div class="cert-row reveal"><span class="mark">AI</span><div class="meta"><div class="nm">Azure AI Fundamentals</div><div class="cd">AI-900</div></div><span class="state">Start <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"></path></svg></span></div>
+            <div class="cert-row reveal"><span class="mark">SC</span><div class="meta"><div class="nm">Security Fundamentals</div><div class="cd">SC-900</div></div><span class="state">Start <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"></path></svg></span></div>
+            <div class="cert-row reveal"><span class="mark">CLF</span><div class="meta"><div class="nm">Cloud Practitioner</div><div class="cd">CLF-C02</div></div><span class="state">Start <svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"></path></svg></span></div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">More exams are added over time; they show up here automatically.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-native-welcome.html
+++ b/mockups/onboarding-native-welcome.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Native welcome concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css). Dark in :root, light in [data-theme=light]; light is primary. ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.245 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.32 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.985 0.006 85); --surface: oklch(0.965 0.008 84); --surface-2: oklch(0.93 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.86 0.008 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-back: cubic-bezier(0.34,1.4,0.64,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body {
+    margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    padding: 30px 20px 64px; transition: background .35s var(--ease), color .35s var(--ease);
+  }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 44ch; line-height: 1.5; }
+  .head-controls { display: flex; flex-direction: column; gap: 8px; flex: 0 0 auto; align-items: flex-end; }
+  .chip-btn { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; white-space: nowrap; }
+  .chip-btn svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .chip-btn:active { transform: scale(0.97); }
+  @media (hover:hover) and (pointer:fine) { .chip-btn:hover { background: color-mix(in oklab, var(--accent-bright) 10%, transparent); } }
+
+  /* ── phone ── */
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11);
+    box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative;
+    background: var(--bg); color: var(--ink); display: flex; flex-direction: column;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; stroke: var(--ink); fill: var(--ink); }
+
+  /* welcome layout */
+  .welcome { flex: 1; display: flex; flex-direction: column; padding: 8px 28px 30px; position: relative; }
+  .ambient { position: absolute; inset: 0; pointer-events: none; z-index: 0;
+    background: radial-gradient(120% 60% at 50% 30%, color-mix(in oklab, var(--accent) 22%, transparent), transparent 60%); opacity: 0; transition: opacity .8s var(--ease); }
+  .welcome.lit .ambient { opacity: 1; }
+
+  .brand { display: flex; align-items: center; gap: 9px; justify-content: center; margin-top: 18px; position: relative; z-index: 1; }
+  .brand-mark { width: 32px; height: 32px; color: var(--accent); display: inline-flex; }
+  .brand-mark svg { width: 100%; height: 100%; }
+  .brand-name { font: 700 17px/1 Inter, sans-serif; letter-spacing: -0.01em; color: var(--ink); }
+
+  /* the hero gauge */
+  .hero { flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; margin: 22px 0 6px; position: relative; z-index: 1; }
+  .gauge { position: relative; width: 232px; height: 232px; }
+  .gauge svg { width: 100%; height: 100%; transform: rotate(-90deg); }
+  .g-track { fill: none; stroke: var(--track); stroke-width: 15; stroke-linecap: round; }
+  .g-fill { fill: none; stroke: var(--accent); stroke-width: 15; stroke-linecap: round;
+    stroke-dasharray: 691.15; stroke-dashoffset: 691.15; transition: stroke .45s var(--ease); }
+  .g-tick { stroke: color-mix(in oklab, var(--ink) 55%, var(--track)); stroke-width: 3; stroke-linecap: round; }
+  .hero.passed .g-fill { stroke: var(--pass); }
+  .g-glow { position: absolute; inset: 14px; border-radius: 50%; pointer-events: none; opacity: 0;
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--pass) 55%, transparent); }
+  .hero.passed .g-glow { animation: glowpulse .9s var(--ease) forwards; }
+  @keyframes glowpulse { 0%{opacity:.9; box-shadow:0 0 0 0 color-mix(in oklab,var(--pass) 50%,transparent);} 100%{opacity:0; box-shadow:0 0 0 26px color-mix(in oklab,var(--pass) 0%,transparent);} }
+
+  /* confetti burst fired once when the score crosses into pass range */
+  .confetti { position: absolute; left: 50%; top: 50%; width: 0; height: 0; z-index: 5; pointer-events: none; }
+  .confetto { position: absolute; left: 0; top: 0; width: 8px; height: 11px; border-radius: 2px; opacity: 0; will-change: transform, opacity;
+    animation: confetti var(--dur, 1.3s) cubic-bezier(0.2,0.7,0.35,1) var(--delay, 0s) forwards; }
+  @keyframes confetti {
+    0% { transform: translate(0,0) rotate(0); opacity: 0; }
+    10% { opacity: 1; }
+    100% { transform: translate(var(--dx), var(--dy)) rotate(var(--rot)); opacity: 0; }
+  }
+  @media (prefers-reduced-motion: reduce) { .confetti { display: none; } }
+
+  .g-center { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0; }
+  .g-num { font: 600 56px/1 Fraunces, Georgia, serif; letter-spacing: -0.02em; color: var(--ink); font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; transition: color .45s var(--ease); }
+  .hero.passed .g-num { color: var(--pass); }
+  .g-of { font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); margin-top: 9px; }
+  .g-pass { margin-top: 14px; font: 700 10px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); }
+  .g-ready { margin-top: 9px; display: inline-flex; align-items: center; gap: 6px; font: 700 11px/1 Inter, sans-serif; letter-spacing: 0.04em;
+    color: var(--pass); background: color-mix(in oklab, var(--pass) 13%, transparent); border: 1px solid color-mix(in oklab, var(--pass) 34%, transparent);
+    border-radius: 999px; padding: 6px 11px; opacity: 0; transform: scale(0.9); }
+  .g-ready svg { width: 13px; height: 13px; stroke: var(--pass); fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .hero.passed .g-ready { animation: pop .42s var(--ease-back) forwards; }
+  @keyframes pop { to { opacity: 1; transform: none; } }
+
+  /* copy + CTA */
+  .copy { text-align: center; margin-top: auto; position: relative; z-index: 1; }
+  .copy h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 28px; line-height: 1.08; letter-spacing: -0.015em; margin: 0 0 10px; color: var(--ink); }
+  .copy p { font-size: 14px; line-height: 1.5; color: var(--ink-soft); margin: 0 auto; max-width: 30ch; }
+
+  .cta { margin-top: 22px; position: relative; z-index: 1; }
+  .btn-primary { width: 100%; border: none; border-radius: 15px; padding: 16px; cursor: pointer;
+    background: var(--accent); color: var(--on-accent); font: 700 15.5px/1 Inter, sans-serif; letter-spacing: -0.005em;
+    box-shadow: 0 12px 26px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+  .cta-sub { text-align: center; font-size: 11.5px; color: var(--muted); margin-top: 11px; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .cta-sub svg { width: 13px; height: 13px; fill: currentColor; }
+  .btn-link { display: block; width: 100%; margin-top: 16px; background: none; border: none; cursor: pointer;
+    font: 600 13.5px/1 Inter, sans-serif; color: var(--ink-soft); padding: 4px; }
+  .btn-link b { color: var(--accent-bright); font-weight: 700; }
+
+  /* entrance: content rises in after the gauge has told its story */
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(12px); }
+    .welcome.run .reveal { animation: rise .55s var(--ease) forwards; }
+    .welcome.run .brand { animation-delay: .05s; }
+    .welcome.run .copy { animation-delay: 1.15s; }
+    .welcome.run .cta { animation-delay: 1.32s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">App Store · first launch</p>
+        <h1 class="stage-title">Native welcome</h1>
+        <p class="stage-sub">The first screen on iPhone after download. Account-first, and the motion shows the product's promise: a readiness score climbing past the pass line.</p>
+      </div>
+      <div class="head-controls">
+        <button class="chip-btn" id="themeToggle" type="button" aria-label="Toggle light and dark">
+          <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+          <span id="themeLabel">Dark</span>
+        </button>
+        <button class="chip-btn" id="replayBtn" type="button">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12a9 9 0 1 0 3-6.7"></path><path d="M3 4v4h4"></path></svg>
+          Replay
+        </button>
+      </div>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="welcome" id="welcome">
+            <div class="ambient"></div>
+
+            <div class="brand reveal">
+              <span class="brand-mark" aria-hidden="true">
+                <svg viewBox="0 0 100 100" fill="none">
+                  <path class="ca-c" d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+                  <line class="ca-slash" x1="30" y1="84" x2="70" y2="16" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+                  <path class="ca-a" d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+              <span class="brand-name">CertAnvil</span>
+            </div>
+
+            <div class="hero" id="hero">
+              <div class="gauge">
+                <svg viewBox="0 0 232 232" aria-hidden="true">
+                  <circle class="g-track" cx="116" cy="116" r="110"></circle>
+                  <circle class="g-fill" id="gFill" cx="116" cy="116" r="110"></circle>
+                  <g transform="rotate(198 116 116)"><line class="g-tick" x1="116" y1="2" x2="116" y2="15"></line></g>
+                </svg>
+                <div class="g-glow"></div>
+                <div class="g-center">
+                  <div class="g-num" id="gNum">350</div>
+                  <div class="g-of">out of 900</div>
+                  <div class="g-ready"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>Pass range</div>
+                </div>
+                <div class="confetti" id="confetti"></div>
+              </div>
+              <div class="g-pass">Pass mark 720</div>
+            </div>
+
+            <div class="copy reveal">
+              <h1>Know when you're ready</h1>
+              <p>Real exam questions and a readiness score that climbs as you study, so exam day is never a guess.</p>
+            </div>
+
+            <div class="cta reveal">
+              <button class="btn-primary" type="button">Get started</button>
+              <div class="cta-sub">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16.4 12.6c0-2 1.6-3 1.7-3.05-0.93-1.36-2.38-1.55-2.9-1.57-1.23-0.12-2.4 0.72-3.03 0.72-0.62 0-1.59-0.7-2.62-0.68-1.35 0.02-2.6 0.78-3.29 1.99-1.4 2.43-0.36 6.02 1.0 7.99 0.67 0.96 1.46 2.05 2.5 2.0 1.0-0.04 1.38-0.65 2.6-0.65 1.21 0 1.56 0.65 2.62 0.63 1.08-0.02 1.77-0.98 2.43-1.95 0.77-1.11 1.08-2.19 1.1-2.25-0.02-0.01-2.11-0.81-2.13-3.22zM14.5 6.6c0.55-0.67 0.92-1.6 0.82-2.53-0.79 0.03-1.76 0.53-2.33 1.2-0.51 0.59-0.96 1.54-0.84 2.45 0.88 0.07 1.79-0.45 2.35-1.12z"/></svg>
+                Sign in with Apple or email
+              </div>
+              <button class="btn-link" type="button">Already have an account? <b>Sign in</b></button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Tap Replay to watch the welcome again.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paintTheme(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paintTheme(); });
+      paintTheme();
+
+      var welcome = document.getElementById('welcome'), hero = document.getElementById('hero');
+      var num = document.getElementById('gNum'), fill = document.getElementById('gFill');
+      var C = 2 * Math.PI * 110;                 // ring circumference (~691.15)
+      var START = 350, END = 735, MAX = 900, PASS = 720, DUR = 1500;
+      var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      var raf = null;
+
+      function setRing(v){ fill.style.strokeDashoffset = (C * (1 - v / MAX)).toFixed(2); }
+
+      var confetti = document.getElementById('confetti'), firedConfetti = false;
+      function burst(){
+        if (reduce || !confetti) return;
+        confetti.innerHTML = '';
+        var palette = ['var(--accent-bright)', 'var(--accent)', 'var(--pass)', 'var(--accent-deep)'];
+        for (var i = 0; i < 42; i++){
+          var p = document.createElement('span'); p.className = 'confetto';
+          var ang = Math.random() * Math.PI * 2, dist = 50 + Math.random() * 120;
+          p.style.setProperty('--dx', Math.round(Math.cos(ang) * dist) + 'px');
+          p.style.setProperty('--dy', Math.round(70 + Math.random() * 280) + 'px');
+          p.style.setProperty('--rot', Math.round(Math.random() * 720 - 360) + 'deg');
+          p.style.setProperty('--dur', (1.0 + Math.random() * 0.8).toFixed(2) + 's');
+          p.style.setProperty('--delay', (Math.random() * 0.12).toFixed(2) + 's');
+          p.style.background = palette[i % palette.length];
+          var w = 6 + Math.random() * 5; p.style.width = Math.round(w) + 'px'; p.style.height = Math.round(w * 1.5) + 'px';
+          confetti.appendChild(p);
+        }
+        setTimeout(function(){ if (confetti) confetti.innerHTML = ''; }, 2400);
+      }
+
+      function finalState(){
+        if (raf) cancelAnimationFrame(raf);
+        num.textContent = END; setRing(END); hero.classList.add('passed'); welcome.classList.add('lit', 'run');
+      }
+
+      function play(){
+        if (reduce) { finalState(); return; }
+        welcome.classList.remove('run'); hero.classList.remove('passed');
+        firedConfetti = false;
+        num.textContent = START; setRing(START);
+        void welcome.offsetWidth;                 // reflow so the reveal + transitions restart
+        welcome.classList.add('lit', 'run');
+        // ease-out on both the number and the ring sweep, kept in sync
+        fill.style.transition = 'none';
+        var t0 = null;
+        function tick(ts){
+          if (t0 === null) t0 = ts;
+          var p = Math.min((ts - t0) / DUR, 1);
+          var e = 1 - Math.pow(1 - p, 3);         // easeOutCubic
+          var v = START + (END - START) * e;
+          num.textContent = Math.round(v);
+          setRing(v);
+          if (v >= PASS) { hero.classList.add('passed'); if (!firedConfetti) { firedConfetti = true; burst(); } }
+          if (p < 1) { raf = requestAnimationFrame(tick); } else { num.textContent = END; setRing(END); }
+        }
+        raf = requestAnimationFrame(tick);
+      }
+
+      document.getElementById('replayBtn').addEventListener('click', play);
+      // kick off shortly after load so the entrance reads as intentional
+      setTimeout(play, 280);
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-pro-welcome.html
+++ b/mockups/onboarding-pro-welcome.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · You're Pro (post-purchase)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.985 0.006 85); --surface: oklch(0.965 0.008 84); --surface-2: oklch(0.93 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.66 0.150 60); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-back: cubic-bezier(0.34,1.5,0.64,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 46ch; line-height: 1.5; }
+  .head-controls { display: flex; flex-direction: column; gap: 8px; align-items: flex-end; flex: 0 0 auto; }
+  .chip-btn { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; white-space: nowrap; }
+  .chip-btn svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .chip-btn:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .pro { flex: 1; display: flex; flex-direction: column; align-items: center; padding: 8px 30px 30px; position: relative; }
+  .ambient { position: absolute; inset: 0; pointer-events: none; z-index: 0;
+    background: radial-gradient(110% 50% at 50% 26%, color-mix(in oklab, var(--accent) 24%, transparent), transparent 62%); opacity: 0; transition: opacity .8s var(--ease); }
+  .pro.lit .ambient { opacity: 1; }
+  .confetti { position: absolute; left: 50%; top: 30%; width: 0; height: 0; z-index: 4; pointer-events: none; }
+  .confetto { position: absolute; left: 0; top: 0; width: 8px; height: 12px; border-radius: 2px; opacity: 0; will-change: transform, opacity;
+    animation: confetti var(--dur,1.3s) cubic-bezier(0.2,0.7,0.35,1) var(--delay,0s) forwards; }
+  @keyframes confetti { 0%{transform:translate(0,0) rotate(0);opacity:0;} 10%{opacity:1;} 100%{transform:translate(var(--dx),var(--dy)) rotate(var(--rot));opacity:0;} }
+  @media (prefers-reduced-motion: reduce) { .confetti { display: none; } }
+
+  /* the PRO emblem */
+  .emblem { position: relative; z-index: 1; margin-top: 70px; display: flex; flex-direction: column; align-items: center; }
+  .emblem-mark { width: 78px; height: 78px; border-radius: 22px; background: linear-gradient(160deg, var(--accent-bright), var(--accent-deep)); color: var(--on-accent); display: grid; place-items: center;
+    box-shadow: 0 18px 40px -16px color-mix(in oklab, var(--accent) 65%, transparent); opacity: 0; transform: scale(0.7); }
+  .emblem-mark svg { width: 46px; height: 46px; }
+  .pro.run .emblem-mark { animation: emblemPop .55s var(--ease-back) .1s forwards; }
+  @keyframes emblemPop { to { opacity: 1; transform: none; } }
+  .pro-pill { margin-top: 14px; font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); background: color-mix(in oklab, var(--accent) 13%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 34%, transparent); border-radius: 999px; padding: 7px 13px; opacity: 0; transform: scale(0.9); }
+  .pro.run .pro-pill { animation: emblemPop .42s var(--ease-back) .42s forwards; }
+
+  .pro-copy { text-align: center; margin-top: 22px; position: relative; z-index: 1; }
+  .pro-copy h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 34px; line-height: 1.04; letter-spacing: -0.02em; margin: 0 0 12px; color: var(--ink); }
+  .pro-copy p { font-size: 14.5px; line-height: 1.5; color: var(--ink-soft); margin: 0 auto; max-width: 28ch; }
+
+  .unlocked { margin: 24px 0 0; width: 100%; max-width: 300px; display: grid; gap: 10px; position: relative; z-index: 1; }
+  .ul-row { display: flex; align-items: center; gap: 11px; font-size: 13.5px; color: var(--ink); }
+  .ul-ic { flex: 0 0 auto; width: 24px; height: 24px; border-radius: 999px; background: color-mix(in oklab, var(--accent) 14%, transparent); display: grid; place-items: center; }
+  .ul-ic svg { width: 14px; height: 14px; stroke: var(--accent-deep); fill: none; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; }
+
+  .cta { margin-top: auto; width: 100%; position: relative; z-index: 1; }
+  .btn-primary { width: 100%; border: none; border-radius: 15px; padding: 16px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15.5px/1 Inter, sans-serif;
+    box-shadow: 0 12px 26px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+  .foot { text-align: center; font-size: 11.5px; color: var(--muted); margin-top: 12px; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .pro.run .reveal { opacity: 0; transform: translateY(12px); animation: rise .55s var(--ease) forwards; }
+    .pro.run .pro-copy { animation-delay: .7s; } .pro.run .unlocked { animation-delay: .9s; } .pro.run .cta { animation-delay: 1.08s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">After Start Pro</p>
+        <h1 class="stage-title">You're Pro</h1>
+        <p class="stage-sub">The moment right after payment succeeds. A short celebration that confirms what's unlocked, then one tap into My Certs.</p>
+      </div>
+      <div class="head-controls">
+        <button class="chip-btn" id="themeToggle" type="button" aria-label="Toggle light and dark">
+          <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+          <span id="themeLabel">Dark</span>
+        </button>
+        <button class="chip-btn" id="replayBtn" type="button">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12a9 9 0 1 0 3-6.7"></path><path d="M3 4v4h4"></path></svg>
+          Replay
+        </button>
+      </div>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="pro" id="pro">
+            <div class="ambient"></div>
+            <div class="confetti" id="confetti"></div>
+
+            <div class="emblem">
+              <span class="emblem-mark">
+                <svg viewBox="0 0 100 100" fill="none" aria-hidden="true">
+                  <path d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+                  <line x1="30" y1="84" x2="70" y2="16" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+                  <path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+              <span class="pro-pill">CertAnvil Pro</span>
+            </div>
+
+            <div class="pro-copy reveal">
+              <h1>You're Pro.</h1>
+              <p>The cap is gone, and every exam is yours.</p>
+            </div>
+
+            <div class="unlocked reveal">
+              <div class="ul-row"><span class="ul-ic"><svg viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"></path></svg></span>Unlimited questions, every day</div>
+              <div class="ul-row"><span class="ul-ic"><svg viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"></path></svg></span>All IT exams, switch anytime</div>
+              <div class="ul-row"><span class="ul-ic"><svg viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"></path></svg></span>Your readiness across every cert</div>
+            </div>
+
+            <div class="cta reveal">
+              <button class="btn-primary" type="button">See all your exams</button>
+              <p class="foot">Manage your plan anytime in Settings.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Tap Replay to watch the celebration again.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      var pro = document.getElementById('pro'), confetti = document.getElementById('confetti');
+      var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      function burst(){
+        if (reduce || !confetti) return; confetti.innerHTML = '';
+        var palette = ['var(--accent-bright)','var(--accent)','var(--pass)','var(--accent-deep)'];
+        for (var i=0;i<46;i++){ var p=document.createElement('span'); p.className='confetto';
+          var ang=Math.random()*Math.PI*2, dist=40+Math.random()*130;
+          p.style.setProperty('--dx', Math.round(Math.cos(ang)*dist)+'px');
+          p.style.setProperty('--dy', Math.round(60+Math.random()*300)+'px');
+          p.style.setProperty('--rot', Math.round(Math.random()*720-360)+'deg');
+          p.style.setProperty('--dur', (1.0+Math.random()*0.9).toFixed(2)+'s');
+          p.style.setProperty('--delay', (Math.random()*0.18).toFixed(2)+'s');
+          p.style.background = palette[i%palette.length];
+          var w=6+Math.random()*5; p.style.width=Math.round(w)+'px'; p.style.height=Math.round(w*1.5)+'px';
+          confetti.appendChild(p); }
+        setTimeout(function(){ if (confetti) confetti.innerHTML=''; }, 2400);
+      }
+      function play(){
+        pro.classList.remove('run'); void pro.offsetWidth; pro.classList.add('lit','run');
+        if (reduce) return;
+        setTimeout(burst, 360);   // confetti lands with the emblem pop
+      }
+      document.getElementById('replayBtn').addEventListener('click', play);
+      setTimeout(play, 240);
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-rollout-flow.html
+++ b/mockups/onboarding-rollout-flow.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Onboarding rollout flow</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css). Dark in :root, light in [data-theme=light]; light is primary. ── */
+  :root {
+    --bg: oklch(0.16 0.009 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.185 0.009 275);
+    --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.78 0.010 275); --muted: oklch(0.60 0.013 275);
+    --border: oklch(0.30 0.008 275); --border-soft: oklch(0.26 0.008 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.87 0.140 70); --accent-deep: oklch(0.70 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.76 0.140 152);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+    --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-bright: oklch(0.74 0.150 60); --accent-deep: oklch(0.42 0.150 52);
+    --on-accent: oklch(0.985 0.010 85); --pass: oklch(0.52 0.13 150);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body {
+    margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    padding: 30px 20px 72px; transition: background .35s var(--ease), color .35s var(--ease);
+  }
+  .stage { max-width: 720px; margin: 0 auto; }
+
+  /* page header */
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 26px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 26px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13.5px; margin: 8px 0 0; max-width: 52ch; line-height: 1.5; }
+  .theme-toggle {
+    flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif;
+    color: var(--accent-bright); background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim));
+    border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s;
+  }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+  @media (hover:hover) and (pointer:fine) { .theme-toggle:hover { background: color-mix(in oklab, var(--accent-bright) 9%, transparent); } }
+
+  /* ── flow spine ── */
+  .flow { display: flex; flex-direction: column; align-items: stretch; }
+
+  .node {
+    background: var(--surface); color: var(--ink); border: 1px solid var(--border);
+    border-radius: 15px; padding: 15px 17px; position: relative;
+    box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 16px 34px -26px color-mix(in oklab, var(--ink) 26%, transparent);
+  }
+  .node-kicker { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.15em; text-transform: uppercase; color: var(--muted); margin-bottom: 6px; display: inline-flex; align-items: center; gap: 7px; }
+  .node-kicker::before { content: ""; width: 5px; height: 5px; border-radius: 50%; background: var(--accent); opacity: .85; }
+  .node-title { font-size: 15.5px; font-weight: 650; letter-spacing: -0.005em; color: var(--ink); }
+  .node-meta { font-size: 12.5px; color: var(--ink-soft); margin-top: 4px; line-height: 1.45; }
+  .node-meta code { font: 600 11.5px/1.4 "Roboto Mono", ui-monospace, monospace; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 11%, transparent); padding: 1.5px 5px; border-radius: 5px; }
+
+  /* connector between stacked items */
+  .conn { width: 2px; height: 26px; background: color-mix(in oklab, var(--border) 80%, var(--accent)); margin: 0 auto; position: relative; }
+  .conn::after {
+    content: ""; position: absolute; left: 50%; bottom: -1px; width: 8px; height: 8px;
+    border-right: 2px solid color-mix(in oklab, var(--border) 80%, var(--accent)); border-bottom: 2px solid color-mix(in oklab, var(--border) 80%, var(--accent));
+    transform: translate(-50%, -2px) rotate(45deg);
+  }
+  .conn-label { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); background: var(--page-bg);
+    font: 700 10px/1 Inter, sans-serif; letter-spacing: 0.05em; text-transform: uppercase; color: var(--accent-deep); padding: 2px 7px; border-radius: 999px; border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)); white-space: nowrap; }
+
+  /* decision node */
+  .gate { border-color: color-mix(in oklab, var(--accent) 32%, var(--border)); background: color-mix(in oklab, var(--accent) 5%, var(--surface)); }
+  .gate .node-kicker { color: var(--accent-deep); }
+  .gate .node-kicker::before { background: var(--accent); opacity: 1; }
+  .gate-q { font-size: 15.5px; font-weight: 650; color: var(--ink); }
+
+  /* an exit branch off a gate: the path that leaves the on-ramp */
+  .exit { display: flex; align-items: flex-start; gap: 10px; margin-top: 11px; padding: 10px 12px; border-radius: 11px;
+    background: var(--surface-2); border: 1px dashed var(--border); }
+  .exit-tag { flex: 0 0 auto; font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted);
+    border: 1px solid var(--border); border-radius: 999px; padding: 4px 8px; margin-top: 1px; }
+  .exit-body { min-width: 0; }
+  .exit-title { font-size: 13.5px; font-weight: 600; color: var(--ink-soft); }
+  .exit-meta { font-size: 12px; color: var(--muted); margin-top: 2px; line-height: 1.4; }
+  .exit--calm { border-style: solid; border-color: color-mix(in oklab, var(--pass) 34%, var(--border)); background: color-mix(in oklab, var(--pass) 7%, var(--surface-2)); }
+  .exit--calm .exit-tag { color: var(--pass); border-color: color-mix(in oklab, var(--pass) 40%, var(--border)); }
+  .exit-split { list-style: none; margin: 8px 0 7px; padding: 0; display: grid; gap: 7px; }
+  .exit-split li { font-size: 12px; color: var(--ink-soft); line-height: 1.45; }
+  .exit-split b { color: var(--ink); font-weight: 650; }
+
+  /* the aha node */
+  .node--aha { border-color: color-mix(in oklab, var(--accent) 55%, var(--border)); background: color-mix(in oklab, var(--accent) 12%, var(--surface));
+    box-shadow: 0 1px 0 color-mix(in oklab, var(--accent) 22%, transparent), 0 20px 44px -22px color-mix(in oklab, var(--accent) 42%, transparent); }
+  .node--aha .node-kicker { color: var(--accent-deep); }
+  .node--aha .node-kicker::before { background: var(--accent); opacity: 1; box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent) 24%, transparent); }
+  .node--aha .node-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 18px; }
+
+  /* annotation notes */
+  .notes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 13px; margin-top: 30px; }
+  .note { background: var(--surface); border: 1px solid var(--border); border-radius: 13px; padding: 14px 15px; }
+  .note-h { font-size: 13px; font-weight: 700; color: var(--ink); display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+  .note-h svg { width: 16px; height: 16px; stroke: var(--accent-deep); fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; flex: 0 0 auto; }
+  .note-b { font-size: 12.5px; color: var(--ink-soft); line-height: 1.5; }
+  .note-b code { font: 600 11px/1.4 "Roboto Mono", ui-monospace, monospace; color: var(--accent-deep); }
+
+  .deferred { margin-top: 20px; text-align: center; font-size: 12.5px; color: var(--page-dim); font-style: italic; }
+
+  /* motivated motion: the flow reveals top-to-bottom on load (storytelling). Off under reduced-motion. */
+  @media (prefers-reduced-motion: no-preference) {
+    .flow > *, .notes, .deferred { opacity: 0; transform: translateY(10px); animation: rise .5s var(--ease) forwards; }
+    /* complete cascade across all 21 spine items (~30ms apart), then the notes + footnote */
+    .flow > *:nth-child(1){animation-delay:.02s} .flow > *:nth-child(2){animation-delay:.05s} .flow > *:nth-child(3){animation-delay:.08s}
+    .flow > *:nth-child(4){animation-delay:.11s} .flow > *:nth-child(5){animation-delay:.14s} .flow > *:nth-child(6){animation-delay:.17s}
+    .flow > *:nth-child(7){animation-delay:.20s} .flow > *:nth-child(8){animation-delay:.23s} .flow > *:nth-child(9){animation-delay:.26s}
+    .flow > *:nth-child(10){animation-delay:.29s} .flow > *:nth-child(11){animation-delay:.32s} .flow > *:nth-child(12){animation-delay:.35s}
+    .flow > *:nth-child(13){animation-delay:.38s} .flow > *:nth-child(14){animation-delay:.41s} .flow > *:nth-child(15){animation-delay:.44s}
+    .flow > *:nth-child(16){animation-delay:.47s} .flow > *:nth-child(17){animation-delay:.50s} .flow > *:nth-child(18){animation-delay:.53s}
+    .flow > *:nth-child(19){animation-delay:.56s} .flow > *:nth-child(20){animation-delay:.59s} .flow > *:nth-child(21){animation-delay:.62s}
+    .notes{animation-delay:.66s} .deferred{animation-delay:.72s}
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+
+  @media (max-width: 620px) { .notes { grid-template-columns: 1fr; } .stage-head { flex-direction: column; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Onboarding rollout</p>
+        <h1 class="stage-title">How a user lands</h1>
+        <p class="stage-sub">When the onboarding switch is on, every launch runs this path, on web and in the App Store app alike. The only platform difference is the logged-out front door. Anyone already activated feels no change at all.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="flow">
+
+      <div class="node">
+        <div class="node-kicker">Step</div>
+        <div class="node-title">App launch</div>
+        <div class="node-meta">Web, or the native shell opening into the lobby.</div>
+      </div>
+
+      <div class="conn"></div>
+
+      <div class="node">
+        <div class="node-kicker">Step</div>
+        <div class="node-title">Read the onboarding switch</div>
+        <div class="node-meta"><code>app_config.onboarding_enabled</code> from Supabase, read behind the loading skeleton. One switch, shared by every cert site.</div>
+      </div>
+
+      <div class="conn"></div>
+
+      <div class="node gate">
+        <div class="node-kicker">Decision</div>
+        <div class="gate-q">Switch on?</div>
+        <div class="exit">
+          <span class="exit-tag">Off</span>
+          <div class="exit-body">
+            <div class="exit-title">Today's app, unchanged.</div>
+            <div class="exit-meta">If the read fails, use the last cached value, otherwise stay off. This is the kill switch.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="conn"><span class="conn-label">On</span></div>
+
+      <div class="node">
+        <div class="node-kicker">Step</div>
+        <div class="node-title">Resolve sign-in</div>
+        <div class="node-meta">A neutral skeleton holds the screen. No flash of the landing page.</div>
+      </div>
+
+      <div class="conn"></div>
+
+      <div class="node gate">
+        <div class="node-kicker">Decision</div>
+        <div class="gate-q">Signed in?</div>
+        <div class="exit">
+          <span class="exit-tag">No</span>
+          <div class="exit-body">
+            <div class="exit-title">The logged-out front door, by platform:</div>
+            <ul class="exit-split">
+              <li><b>Web (desktop / Safari):</b> the marketing landing, your current site. Sign up or sign in there.</li>
+              <li><b>App Store app:</b> an in-app welcome. A one-line value prop, then Get started (Sign in with Apple or email) or Sign in. Never the marketing site.</li>
+            </ul>
+            <div class="exit-meta">Either door leads to the same place. Once they sign up, they re-enter this flow at the next step.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="conn"><span class="conn-label">Yes</span></div>
+
+      <div class="node">
+        <div class="node-kicker">Step</div>
+        <div class="node-title">Set the current cert</div>
+        <div class="node-meta">Free: their one locked cert. Pro: the last cert they were on.</div>
+      </div>
+
+      <div class="conn"></div>
+
+      <div class="node gate">
+        <div class="node-kicker">Decision</div>
+        <div class="gate-q">Activated for this cert?</div>
+        <div class="exit exit--calm">
+          <span class="exit-tag">Yes</span>
+          <div class="exit-body">
+            <div class="exit-title">Straight to the cert home. Nothing changes.</div>
+            <div class="exit-meta">Everyone with a readiness score already skips the on-ramp. This is most of your existing users.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="conn"><span class="conn-label">Not yet</span></div>
+
+      <div class="node">
+        <div class="node-kicker">On-ramp</div>
+        <div class="node-title">First-run diagnostic</div>
+        <div class="node-meta">A short check to place your readiness. Free, and it never counts against the daily cap. Take it, or skip straight in.</div>
+        <div class="exit">
+          <span class="exit-tag">Skip</span>
+          <div class="exit-body">
+            <div class="exit-title">Into the app. Start studying a topic now.</div>
+            <div class="exit-meta">A learner who only started today has nothing to diagnose yet. The diagnostic waits as an invite, not a gate. The score, and activation, happen whenever they choose to take it. Skips are tracked.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="conn"><span class="conn-label">Take it</span></div>
+
+      <div class="node">
+        <div class="node-kicker">On-ramp</div>
+        <div class="node-title">A readiness score appears</div>
+        <div class="node-meta">Scaled 100 to 900, the same number the rest of the app uses.</div>
+      </div>
+
+      <div class="conn"></div>
+
+      <div class="node node--aha">
+        <div class="node-kicker">The aha</div>
+        <div class="node-title">Practice a little, and the number moves</div>
+        <div class="node-meta">Delivered in the first session. This is the moment that predicts whether they come back.</div>
+      </div>
+
+      <div class="conn"></div>
+
+      <div class="node">
+        <div class="node-kicker">Step</div>
+        <div class="node-title">Mark the cert activated</div>
+        <div class="node-meta"><code>activated[certId] = { at, baseline, moved }</code>, cloud-synced. This is also what the activation metric counts.</div>
+      </div>
+
+    </div>
+
+    <div class="notes">
+      <div class="note">
+        <div class="note-h"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.4 5.6a9 9 0 1 1-12.8 0"></path><path d="M12 2v8"></path></svg>Kill switch</div>
+        <div class="note-b">Flip <code>onboarding_enabled</code> to off. Every device reverts on its next load, without a redeploy.</div>
+      </div>
+      <div class="note">
+        <div class="note-h"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3v18h18"></path><path d="M7 15l4-4 3 3 5-6"></path></svg>Activation metric</div>
+        <div class="note-b">The share of new accounts that move their readiness in session one. People who skip the diagnostic are tracked separately, so a beginner who studies first does not drag the number down. One Supabase query at this scale.</div>
+      </div>
+      <div class="note">
+        <div class="note-h"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 3h5v5"></path><path d="M21 3l-7 7"></path><path d="M8 21H3v-5"></path><path d="M3 21l7-7"></path></svg>Cert switching fixed</div>
+        <div class="note-b">One global switch, not a per-site flag. It stays on when you move from Network+ to Security+, so the switcher no longer disappears.</div>
+      </div>
+    </div>
+
+    <p class="deferred">A percentage ramp stays on the shelf until the audience is big enough to need one.</p>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint() { var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function () {
+        html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint();
+      });
+      paint();
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-sandbox.html
+++ b/mockups/onboarding-sandbox.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>CertAnvil Lab</title>
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex, nofollow">
+<!-- Installable app shell (iPhone 13 Pro Max: 428x926, notch + home-indicator safe areas) -->
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="CertAnvil Lab">
+<meta name="theme-color" content="#1a1714">
+<!-- monogram touch icon (forged-bronze tile) -->
+<link rel="apple-touch-icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Crect width='180' height='180' rx='40' fill='%231a1714'/%3E%3Cg fill='none' stroke='%23c98a3c' stroke-width='12' stroke-linecap='round'%3E%3Cpath d='M104 38 C76 26, 34 42, 30 70 C26 98, 44 116, 78 118'/%3E%3Cline x1='58' y1='150' x2='126' y2='32' stroke='%238a8a8a'/%3E%3Cpath d='M82 156 L116 86 L150 156 M95 130 L137 130'/%3E%3C/g%3E%3C/svg%3E">
+<link rel="stylesheet" href="../dg-system.css?v=sandbox">
+<style>
+  :root { color-scheme: light dark; }
+  html, body { margin: 0; height: 100%; background: var(--bg, #111); }
+  body { font-family: Inter, system-ui, sans-serif; color: var(--text, #eee); }
+  /* phone frame: full-bleed on device, centered 428-wide column on desktop */
+  .sbx-frame {
+    position: relative; width: 100%; max-width: 428px; min-height: 100dvh;
+    margin: 0 auto; background: var(--bg); overflow: hidden;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    box-sizing: border-box;
+  }
+  @media (min-width: 480px) { .sbx-frame { min-height: 926px; max-height: 96vh; margin-top: 2vh; border-radius: 44px; box-shadow: 0 30px 90px rgba(0,0,0,.4); border: 1px solid var(--border, #333); overflow-y: auto; } }
+  .sbx-bar { display:flex; align-items:center; justify-content:space-between; padding:16px 18px 10px; }
+  .sbx-brand { display:flex; align-items:center; gap:9px; font-family:'Fraunces',Georgia,serif; font-weight:600; font-size:18px; color:var(--text); }
+  .sbx-brand svg { width:26px; height:26px; }
+  .sbx-theme { font:600 13px Inter,sans-serif; color:var(--accent); background:transparent; border:1px solid color-mix(in oklab,var(--accent) 30%,var(--border)); border-radius:999px; padding:7px 13px; cursor:pointer; }
+  .sbx-intro { padding:4px 18px 14px; color:var(--text-dim); font-size:13.5px; line-height:1.5; }
+  .sbx-group { padding:10px 18px 4px; font:700 11px Inter,sans-serif; letter-spacing:.08em; text-transform:uppercase; color:var(--text-dim); }
+  .sbx-cards { display:flex; flex-direction:column; gap:9px; padding:4px 14px 18px; }
+  .sbx-card { display:flex; align-items:center; gap:12px; width:100%; text-align:left; background:var(--surface); border:1px solid var(--border); border-radius:15px; padding:15px 16px; cursor:pointer; color:var(--text); font:inherit; transition:transform .15s cubic-bezier(0.16,1,0.3,1); }
+  .sbx-card:active { transform:scale(0.985); }
+  .sbx-tag { margin-left:auto; font:600 10px Inter,sans-serif; padding:3px 8px; border-radius:999px; }
+  .sbx-tag.live { color:#1c7a47; background:color-mix(in oklab,#1c7a47 16%,transparent); }
+  .sbx-tag.design { color:var(--text-dim); background:color-mix(in oklab,var(--text) 10%,transparent); }
+  .sbx-card-t { font-weight:600; font-size:15px; }
+  .sbx-card-s { font-size:12.5px; color:var(--text-dim); margin-top:2px; }
+  /* panels (full-frame overlays) */
+  .sbx-panel { position:absolute; inset:0; background:var(--bg); display:none; flex-direction:column; z-index:50; }
+  .sbx-panel.open { display:flex; }
+  .sbx-panel-bar { display:flex; align-items:center; gap:10px; padding:calc(env(safe-area-inset-top) + 12px) 16px 12px; border-bottom:1px solid var(--border); }
+  .sbx-back { font:600 14px Inter,sans-serif; color:var(--accent); background:none; border:none; cursor:pointer; padding:6px 4px; }
+  .sbx-panel-title { font-weight:600; font-size:14px; color:var(--text); }
+  .sbx-panel-body { flex:1; overflow-y:auto; -webkit-overflow-scrolling:touch; position:relative; }
+  .sbx-panel-body iframe { width:100%; height:100%; border:0; display:block; }
+  /* cert-lock control */
+  .sbx-ctl { padding:22px 18px; display:flex; flex-direction:column; gap:14px; }
+  .sbx-ctl label { font:600 12px Inter,sans-serif; color:var(--text-dim); display:block; margin-bottom:6px; }
+  .sbx-ctl select { width:100%; font:500 15px Inter,sans-serif; color:var(--text); background:var(--surface); border:1px solid var(--border); border-radius:11px; padding:13px 12px; }
+  .sbx-ctl .sbx-go { background:var(--accent); color:var(--bg); border:none; border-radius:13px; padding:15px; font:700 15px Inter,sans-serif; cursor:pointer; }
+  .sbx-ctl .sbx-hint { font-size:12.5px; color:var(--text-dim); line-height:1.5; }
+  #onb-firstrun.onb-fr[hidden] { display:none; }
+</style>
+</head>
+<body>
+<div class="sbx-frame" id="sbx-menu-frame">
+  <div class="sbx-bar">
+    <div class="sbx-brand">
+      <svg viewBox="0 0 100 100" fill="none" aria-hidden="true">
+        <path d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" class="sb-brand-c" stroke-width="7" stroke-linecap="round"/>
+        <line x1="30" y1="84" x2="70" y2="16" class="sb-brand-slash" stroke-width="5" stroke-linecap="round"/>
+        <path d="M46 88 L64 50 L82 88 M53 74 L75 74" class="sb-brand-a" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      CertAnvil Lab
+    </div>
+    <button class="sbx-theme" id="sbx-theme">Dark</button>
+  </div>
+  <p class="sbx-intro">A sandbox to walk the onboarding flow. Green items are the real shipped code; tan items are the approved design mockups. Nothing here touches a real account.</p>
+
+  <div class="sbx-group">Live &amp; interactive</div>
+  <div class="sbx-cards">
+    <button class="sbx-card" data-act="certlock"><span><span class="sbx-card-t">Cert-lock wall</span><span class="sbx-card-s">The free-tier lock. Pick a cert pairing.</span></span><span class="sbx-tag live">live</span></button>
+    <button class="sbx-card" data-act="firstrun"><span><span class="sbx-card-t">First-run flow</span><span class="sbx-card-s">Lobby, diagnostic, the +movement aha, home.</span></span><span class="sbx-tag live">live</span></button>
+  </div>
+
+  <div class="sbx-group">Design mockups</div>
+  <div class="sbx-cards" id="sbx-mock-cards"><!-- filled by JS --></div>
+
+  <div class="sbx-group">The real app</div>
+  <div class="sbx-cards">
+    <button class="sbx-card" data-act="realapp"><span><span class="sbx-card-t">Open the live app</span><span class="sbx-card-s">The actual home chrome, with ?onb=1.</span></span><span class="sbx-tag design">link</span></button>
+  </div>
+
+  <!-- cert-lock control panel -->
+  <div class="sbx-panel" id="sbx-panel-certlock">
+    <div class="sbx-panel-bar"><button class="sbx-back" data-back>&larr; Menu</button><span class="sbx-panel-title">Cert-lock wall (live)</span></div>
+    <div class="sbx-panel-body">
+      <div class="sbx-ctl">
+        <div><label for="sbx-owned">Free user is locked to</label><select id="sbx-owned"></select></div>
+        <div><label for="sbx-visiting">and is now visiting</label><select id="sbx-visiting"></select></div>
+        <button class="sbx-go" id="sbx-show-wall">Show the wall</button>
+        <p class="sbx-hint">Pick two different certs to see the lock. Pick the same cert (their owned one) to confirm no wall appears. This calls the real <code>_certLock.check</code>.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- first-run panel (the module renders into #onb-firstrun) -->
+  <div class="sbx-panel" id="sbx-panel-firstrun">
+    <div class="sbx-panel-bar"><button class="sbx-back" data-back data-fr-close>&larr; Menu</button><span class="sbx-panel-title">First-run flow (live, placeholder data)</span></div>
+    <div class="sbx-panel-body"><div id="onb-firstrun" class="onb-fr" hidden></div></div>
+  </div>
+
+  <!-- mockup iframe panel -->
+  <div class="sbx-panel" id="sbx-panel-mock">
+    <div class="sbx-panel-bar"><button class="sbx-back" data-back>&larr; Menu</button><span class="sbx-panel-title" id="sbx-mock-title">Design</span><span class="sbx-tag design" style="margin-left:auto">design</span></div>
+    <div class="sbx-panel-body"><iframe id="sbx-mock-frame" title="design mockup"></iframe></div>
+  </div>
+</div>
+
+<!-- real shipped modules (order: router -> cert-lock -> firstrun) -->
+<script src="../lib/router.js"></script>
+<script src="../lib/cert-lock.js"></script>
+<script>window.showPage = function () {};  /* no-op stub: firstrun calls window.showPage('setup'); the sandbox has no app pages */</script>
+<script src="../lib/onboarding-firstrun.js"></script>
+<script>
+(function () {
+  'use strict';
+  var CERTS = [
+    ['netplus','Network+'],['secplus','Security+'],['az900','Azure AZ-900'],['ai900','Azure AI-900'],
+    ['aplus-core1','A+ Core 1'],['aplus-core2','A+ Core 2'],['sc900','Security SC-900'],['clfc02','AWS CLF-C02']
+  ];
+  var MOCKS = [
+    ['onboarding-native-welcome.html','Welcome','First screen on launch.'],
+    ['onboarding-signup-signin.html','Sign up / Sign in','Account step.'],
+    ['onboarding-upgrade-sheet.html','Pro upgrade sheet','The payment moment.'],
+    ['onboarding-free-capped-home.html','Done for today','After declining Pro.'],
+    ['onboarding-pro-welcome.html',"You're Pro",'Post-purchase celebration.'],
+    ['onboarding-my-certs-pro.html','My Certs (Pro)','Every exam unlocked.'],
+    ['onboarding-rollout-flow.html','Rollout flow map','Reference: the whole flow.']
+  ];
+  function $(id){ return document.getElementById(id); }
+
+  // theme toggle
+  var themeBtn = $('sbx-theme');
+  function applyTheme(t){ document.documentElement.setAttribute('data-theme', t); try{ localStorage.setItem('sbx_theme', t); }catch(_){} themeBtn.textContent = t === 'light' ? 'Light' : 'Dark'; }
+  themeBtn.addEventListener('click', function(){ var cur = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light'; applyTheme(cur); });
+  try { applyTheme(localStorage.getItem('sbx_theme') || 'light'); } catch(_) { applyTheme('light'); }
+
+  // populate cert dropdowns
+  function fill(sel, def){ CERTS.forEach(function(c){ var o=document.createElement('option'); o.value=c[0]; o.textContent=c[1]; if(c[0]===def)o.selected=true; sel.appendChild(o); }); }
+  fill($('sbx-owned'),'netplus'); fill($('sbx-visiting'),'secplus');
+
+  // mockup cards
+  var wrap = $('sbx-mock-cards');
+  MOCKS.forEach(function(m){
+    var b=document.createElement('button'); b.className='sbx-card'; b.setAttribute('data-mock', m[0]); b.setAttribute('data-mock-title', m[1]);
+    b.innerHTML='<span><span class="sbx-card-t">'+m[1]+'</span><span class="sbx-card-s">'+m[2]+'</span></span><span class="sbx-tag design">design</span>';
+    wrap.appendChild(b);
+  });
+
+  function openPanel(id){ var p=$(id); if(p) p.classList.add('open'); }
+  function closePanels(){ ['sbx-panel-certlock','sbx-panel-firstrun','sbx-panel-mock'].forEach(function(id){ $(id).classList.remove('open'); }); }
+
+  // delegated clicks
+  document.addEventListener('click', function(e){
+    var card = e.target.closest('[data-act]');
+    if (card){
+      var act = card.getAttribute('data-act');
+      if (act==='certlock') openPanel('sbx-panel-certlock');
+      else if (act==='firstrun') startFirstRun();
+      else if (act==='realapp') window.open('/?onb=1','_blank');
+      return;
+    }
+    var mock = e.target.closest('[data-mock]');
+    if (mock){ $('sbx-mock-frame').src = mock.getAttribute('data-mock'); $('sbx-mock-title').textContent = mock.getAttribute('data-mock-title'); openPanel('sbx-panel-mock'); return; }
+    if (e.target.closest('[data-back]')){ if (e.target.closest('[data-fr-close]') && window.onbFirstRun && window.onbFirstRun.close) { try{ window.onbFirstRun.close(); }catch(_){} } var f=$('sbx-mock-frame'); if(f) f.removeAttribute('src'); closePanels(); }
+  });
+
+  // cert-lock: drive the real module
+  $('sbx-show-wall').addEventListener('click', function(){
+    var owned=$('sbx-owned').value, visiting=$('sbx-visiting').value;
+    var ex=document.getElementById('cl-wall'); if(ex) ex.remove(); document.documentElement.classList.remove('cl-locked');
+    window.CURRENT_CERT = visiting;
+    try { window._certLock.check({ isLoggedIn:true, profile:{ role:'user', metadata:{ freeCertId: owned } } }); } catch(_){}
+    if (!document.getElementById('cl-wall')) { alert(owned===visiting ? 'No wall: this is their owned cert (correct).' : 'No wall rendered.'); }
+  });
+
+  // first-run: stub already set (window.showPage); start in mock mode
+  function startFirstRun(){
+    try { localStorage.setItem('onb_mock','1'); } catch(_){}
+    openPanel('sbx-panel-firstrun');
+    try { if (window.onbFirstRun && window.onbFirstRun.start) window.onbFirstRun.start({ certId:null, tier:'free', reason:'no-cert' }); } catch(_){}
+  }
+})();
+</script>
+</body>
+</html>

--- a/mockups/onboarding-sandbox.html
+++ b/mockups/onboarding-sandbox.html
@@ -38,8 +38,9 @@
   .sbx-tag { margin-left:auto; font:600 10px Inter,sans-serif; padding:3px 8px; border-radius:999px; }
   .sbx-tag.live { color:#1c7a47; background:color-mix(in oklab,#1c7a47 16%,transparent); }
   .sbx-tag.design { color:var(--text-dim); background:color-mix(in oklab,var(--text) 10%,transparent); }
-  .sbx-card-t { font-weight:600; font-size:15px; }
-  .sbx-card-s { font-size:12.5px; color:var(--text-dim); margin-top:2px; }
+  .sbx-card > span:first-child { display:flex; flex-direction:column; gap:2px; min-width:0; }
+  .sbx-card-t { display:block; font-weight:600; font-size:15px; }
+  .sbx-card-s { display:block; font-size:12.5px; color:var(--text-dim); }
   /* panels (full-frame overlays) */
   .sbx-panel { position:absolute; inset:0; background:var(--bg); display:none; flex-direction:column; z-index:50; }
   .sbx-panel.open { display:flex; }
@@ -135,6 +136,16 @@
   ];
   function $(id){ return document.getElementById(id); }
 
+  // The sandbox is served from the prod origin, so the live first-run module's
+  // localStorage writes (onb_mock, nplus_freeCertId) would otherwise leak into the
+  // real app's state on this origin. Snapshot those keys on load and restore them
+  // (remove if originally absent) whenever we leave first-run / close the app, so
+  // the sandbox is non-destructive to real state.
+  var SNAP_KEYS = ['onb_mock', 'nplus_freeCertId', 'nplus_activated', 'nplus_onb_skips'];
+  var SNAP = {}; SNAP_KEYS.forEach(function(k){ try { SNAP[k] = localStorage.getItem(k); } catch(_) { SNAP[k] = null; } });
+  function restoreLS(){ SNAP_KEYS.forEach(function(k){ try { if (SNAP[k] === null) localStorage.removeItem(k); else localStorage.setItem(k, SNAP[k]); } catch(_){} }); }
+  window.addEventListener('pagehide', restoreLS);
+
   // theme toggle
   var themeBtn = $('sbx-theme');
   function applyTheme(t){ document.documentElement.setAttribute('data-theme', t); try{ localStorage.setItem('sbx_theme', t); }catch(_){} themeBtn.textContent = t === 'light' ? 'Light' : 'Dark'; }
@@ -168,7 +179,7 @@
     }
     var mock = e.target.closest('[data-mock]');
     if (mock){ $('sbx-mock-frame').src = mock.getAttribute('data-mock'); $('sbx-mock-title').textContent = mock.getAttribute('data-mock-title'); openPanel('sbx-panel-mock'); return; }
-    if (e.target.closest('[data-back]')){ if (e.target.closest('[data-fr-close]') && window.onbFirstRun && window.onbFirstRun.close) { try{ window.onbFirstRun.close(); }catch(_){} } var f=$('sbx-mock-frame'); if(f) f.removeAttribute('src'); closePanels(); }
+    if (e.target.closest('[data-back]')){ if (e.target.closest('[data-fr-close]') && window.onbFirstRun && window.onbFirstRun.close) { try{ window.onbFirstRun.close(); }catch(_){} } var f=$('sbx-mock-frame'); if(f) f.removeAttribute('src'); closePanels(); restoreLS(); }
   });
 
   // cert-lock: drive the real module
@@ -185,6 +196,14 @@
     try { localStorage.setItem('onb_mock','1'); } catch(_){}
     openPanel('sbx-panel-firstrun');
     try { if (window.onbFirstRun && window.onbFirstRun.start) window.onbFirstRun.start({ certId:null, tier:'free', reason:'no-cert' }); } catch(_){}
+  }
+  // First-run finishing/skipping hides #onb-firstrun (handToHome). There's no real
+  // home underneath in the sandbox, so return to the menu cleanly when that happens.
+  var frEl = $('onb-firstrun');
+  if (frEl && window.MutationObserver) {
+    new MutationObserver(function(){
+      if (frEl.hidden && $('sbx-panel-firstrun').classList.contains('open')) { closePanels(); restoreLS(); }
+    }).observe(frEl, { attributes:true, attributeFilter:['hidden'] });
   }
 })();
 </script>

--- a/mockups/onboarding-signup-signin.html
+++ b/mockups/onboarding-signup-signin.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Sign up / Sign in concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the welcome mockup). Dark :root, light override; light is primary. ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275);
+    --apple-bg: oklch(0.98 0.004 275); --apple-fg: oklch(0.16 0.010 275);   /* white button on dark */
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.985 0.006 85); --surface: oklch(0.965 0.008 84); --surface-2: oklch(0.93 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85);
+    --apple-bg: oklch(0.17 0.010 280); --apple-fg: oklch(0.98 0.004 85);    /* black button on light */
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 46ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* phone */
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  /* auth layout */
+  .auth { flex: 1; display: flex; flex-direction: column; padding: 6px 28px 26px; }
+  .topbar { display: flex; align-items: center; gap: 10px; margin-top: 12px; }
+  .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .15s var(--ease); }
+  .back:active { transform: scale(0.95); }
+  .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .brand-mark { width: 26px; height: 26px; color: var(--accent); display: inline-flex; margin-left: 2px; }
+  .brand-mark svg { width: 100%; height: 100%; }
+  .brand-name { font: 700 15px/1 Inter, sans-serif; letter-spacing: -0.01em; color: var(--ink); }
+
+  .auth-body { display: flex; flex-direction: column; margin-top: 30px; }
+  .auth-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 27px; line-height: 1.1; letter-spacing: -0.015em; margin: 0; color: var(--ink); }
+  .auth-sub { font-size: 14px; color: var(--ink-soft); margin: 9px 0 0; }
+  .auth-sub b { color: var(--accent-deep); font-weight: 650; }
+
+  .segmented { display: grid; grid-template-columns: 1fr 1fr; gap: 3px; margin: 22px 0 20px; padding: 4px; background: var(--surface); border: 1px solid var(--border); border-radius: 13px; }
+  .seg { border: none; background: transparent; border-radius: 9px; padding: 10px; cursor: pointer; font: 650 13.5px/1 Inter, sans-serif; color: var(--muted); transition: color .2s, background .2s, box-shadow .2s; }
+  .seg.active { color: var(--ink); background: var(--bg); box-shadow: 0 1px 3px -1px color-mix(in oklab, var(--ink) 20%, transparent); }
+
+  .view { display: none; flex-direction: column; gap: 12px; }
+  .view.active { display: flex; }
+
+  .btn-apple { display: inline-flex; align-items: center; justify-content: center; gap: 9px; width: 100%; border: none; border-radius: 14px; padding: 15px; cursor: pointer;
+    background: var(--apple-bg); color: var(--apple-fg); font: 600 15px/1 Inter, sans-serif; transition: transform .15s var(--ease), filter .2s; }
+  .btn-apple svg { width: 17px; height: 17px; fill: currentColor; margin-top: -1px; }
+  .btn-apple:active { transform: scale(0.985); }
+  .btn-primary { width: 100%; border: none; border-radius: 14px; padding: 15px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 12px 26px -14px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  .btn-outline { width: 100%; border: 1px solid var(--border); border-radius: 14px; padding: 15px; cursor: pointer; background: var(--surface); color: var(--ink); font: 650 15px/1 Inter, sans-serif; transition: transform .15s var(--ease), border-color .2s; }
+  .btn-outline:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-apple:hover, .btn-primary:hover { filter: brightness(1.05); } .btn-outline:hover { border-color: color-mix(in oklab, var(--accent) 45%, var(--border)); } }
+
+  .divider { display: flex; align-items: center; gap: 12px; color: var(--muted); font: 600 11px/1 Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; margin: 3px 0; }
+  .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+
+  .field { display: flex; flex-direction: column; gap: 6px; }
+  .field label { font: 650 12px/1 Inter, sans-serif; color: var(--ink-soft); }
+  .field input { border: 1px solid var(--border); background: var(--surface); color: var(--ink); border-radius: 12px; padding: 13px 14px; font: 500 15px/1 Inter, sans-serif; transition: border-color .18s, box-shadow .18s; }
+  .field input::placeholder { color: var(--muted); }
+  .field input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 22%, transparent); }
+  .link-forgot { align-self: flex-end; background: none; border: none; cursor: pointer; font: 600 12.5px/1 Inter, sans-serif; color: var(--accent-bright); padding: 2px; margin-top: -2px; }
+
+  .legal { margin-top: auto; padding-top: 22px; text-align: center; font-size: 11px; line-height: 1.5; color: var(--muted); }
+  .legal a { color: var(--ink-soft); text-decoration: underline; text-underline-offset: 2px; }
+
+  /* gentle entrance — an account screen is functional, so motion stays light */
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(10px); animation: rise .5s var(--ease) forwards; }
+    .topbar { animation-delay: .02s; } .auth-title { animation-delay: .08s; } .auth-sub { animation-delay: .12s; }
+    .segmented { animation-delay: .16s; } .view.active { animation-delay: .2s; } .legal { animation-delay: .26s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">App Store · account</p>
+        <h1 class="stage-title">Sign up / Sign in</h1>
+        <p class="stage-sub">What a user hits after tapping Get started on the welcome. Account-first, free, no payment here. Toggle Create / Sign in below.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="auth">
+            <div class="topbar reveal">
+              <button class="back" type="button" aria-label="Back to welcome"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+              <span class="brand-mark" aria-hidden="true">
+                <svg viewBox="0 0 100 100" fill="none">
+                  <path class="ca-c" d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+                  <line class="ca-slash" x1="30" y1="84" x2="70" y2="16" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+                  <path class="ca-a" d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+              <span class="brand-name">CertAnvil</span>
+            </div>
+
+            <div class="auth-body">
+              <h1 class="auth-title reveal" id="authTitle">Create your account</h1>
+              <p class="auth-sub reveal" id="authSub"><b>Free to start.</b> No card needed.</p>
+
+              <div class="segmented reveal" role="tablist">
+                <button class="seg active" data-seg="create" type="button" role="tab">Create account</button>
+                <button class="seg" data-seg="signin" type="button" role="tab">Sign in</button>
+              </div>
+
+              <div class="view view-create active reveal" id="viewCreate">
+                <button class="btn-apple" type="button"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16.4 12.6c0-2 1.6-3 1.7-3.05-0.93-1.36-2.38-1.55-2.9-1.57-1.23-0.12-2.4 0.72-3.03 0.72-0.62 0-1.59-0.7-2.62-0.68-1.35 0.02-2.6 0.78-3.29 1.99-1.4 2.43-0.36 6.02 1.0 7.99 0.67 0.96 1.46 2.05 2.5 2.0 1.0-0.04 1.38-0.65 2.6-0.65 1.21 0 1.56 0.65 2.62 0.63 1.08-0.02 1.77-0.98 2.43-1.95 0.77-1.11 1.08-2.19 1.1-2.25-0.02-0.01-2.11-0.81-2.13-3.22zM14.5 6.6c0.55-0.67 0.92-1.6 0.82-2.53-0.79 0.03-1.76 0.53-2.33 1.2-0.51 0.59-0.96 1.54-0.84 2.45 0.88 0.07 1.79-0.45 2.35-1.12z"/></svg>Continue with Apple</button>
+                <div class="divider">or</div>
+                <div class="field"><label for="cEmail">Email</label><input id="cEmail" type="email" placeholder="you@example.com" autocomplete="email" /></div>
+                <button class="btn-primary" type="button">Continue with email</button>
+              </div>
+
+              <div class="view view-signin reveal" id="viewSignin">
+                <button class="btn-apple" type="button"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16.4 12.6c0-2 1.6-3 1.7-3.05-0.93-1.36-2.38-1.55-2.9-1.57-1.23-0.12-2.4 0.72-3.03 0.72-0.62 0-1.59-0.7-2.62-0.68-1.35 0.02-2.6 0.78-3.29 1.99-1.4 2.43-0.36 6.02 1.0 7.99 0.67 0.96 1.46 2.05 2.5 2.0 1.0-0.04 1.38-0.65 2.6-0.65 1.21 0 1.56 0.65 2.62 0.63 1.08-0.02 1.77-0.98 2.43-1.95 0.77-1.11 1.08-2.19 1.1-2.25-0.02-0.01-2.11-0.81-2.13-3.22zM14.5 6.6c0.55-0.67 0.92-1.6 0.82-2.53-0.79 0.03-1.76 0.53-2.33 1.2-0.51 0.59-0.96 1.54-0.84 2.45 0.88 0.07 1.79-0.45 2.35-1.12z"/></svg>Continue with Apple</button>
+                <div class="divider">or</div>
+                <div class="field"><label for="sEmail">Email</label><input id="sEmail" type="email" placeholder="you@example.com" autocomplete="email" /></div>
+                <div class="field"><label for="sPass">Password</label><input id="sPass" type="password" placeholder="Your password" autocomplete="current-password" /></div>
+                <button class="link-forgot" type="button">Forgot password?</button>
+                <button class="btn-primary" type="button">Sign in</button>
+              </div>
+
+              <p class="legal reveal">By continuing you agree to our <a href="#" onclick="return false">Terms</a> and <a href="#" onclick="return false">Privacy Policy</a>.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Tap Create account / Sign in to switch states.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      var title = document.getElementById('authTitle'), sub = document.getElementById('authSub');
+      var copy = {
+        create: { title: 'Create your account', sub: '<b>Free to start.</b> No card needed.' },
+        signin: { title: 'Welcome back',          sub: 'Pick up where you left off.' }
+      };
+      var segs = document.querySelectorAll('.seg');
+      function select(which){
+        segs.forEach(function(s){ s.classList.toggle('active', s.dataset.seg === which); });
+        document.getElementById('viewCreate').classList.toggle('active', which === 'create');
+        document.getElementById('viewSignin').classList.toggle('active', which === 'signin');
+        title.textContent = copy[which].title; sub.innerHTML = copy[which].sub;
+      }
+      segs.forEach(function(s){ s.addEventListener('click', function(){ select(s.dataset.seg); }); });
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-upgrade-sheet.html
+++ b/mockups/onboarding-upgrade-sheet.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Pro upgrade sheet concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the other onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152);
+    --sheet: oklch(0.205 0.009 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150);
+    --sheet: oklch(0.995 0.004 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .head-controls { display: flex; flex-direction: column; gap: 8px; align-items: flex-end; flex: 0 0 auto; }
+  .chip-btn { display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; white-space: nowrap; }
+  .chip-btn svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .chip-btn:active { transform: scale(0.97); }
+
+  /* phone */
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 30; }
+
+  /* dimmed home behind the sheet */
+  .behind { position: absolute; inset: 0; padding: 52px 22px 0; }
+  .b-cmd { display: flex; align-items: center; justify-content: space-between; border: 1px solid var(--border); border-radius: 16px; padding: 15px 16px; background: var(--surface); }
+  .b-cmd .sys { font: 700 9.5px/1 'Roboto Mono', monospace; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); }
+  .b-cmd .cert { font: 600 19px/1.1 Fraunces, serif; color: var(--ink); margin-top: 5px; }
+  .b-chip { font: 700 11px/1 Inter, sans-serif; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 7px 10px; }
+  .b-tile { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); height: 92px; margin-top: 14px; }
+  .scrim { position: absolute; inset: 0; background: oklch(0.10 0.01 275 / 0.55); opacity: 0; z-index: 18; transition: opacity .4s var(--ease); }
+  .screen.open .scrim { opacity: 1; }
+
+  /* the Pro sheet */
+  .sheet { position: absolute; left: 0; right: 0; bottom: 0; z-index: 20; background: var(--sheet);
+    border-radius: 26px 26px 42px 42px; padding: 10px 24px 30px; box-shadow: 0 -20px 50px -20px rgba(0,0,0,0.4);
+    transform: translateY(102%); transition: transform .52s var(--ease-drawer); }
+  .screen.open .sheet { transform: translateY(0); }
+  @media (prefers-reduced-motion: reduce) { .sheet { transition: none; } .scrim { transition: none; } }
+  .grab { width: 38px; height: 5px; border-radius: 999px; background: var(--border); margin: 0 auto 14px; }
+  .sheet-close { position: absolute; top: 16px; right: 18px; width: 30px; height: 30px; border-radius: 999px; border: none; background: var(--surface-2); color: var(--ink-soft); cursor: pointer; display: grid; place-items: center; }
+  .sheet-close svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 2.2; stroke-linecap: round; }
+
+  .pro-badge { display: inline-flex; align-items: center; gap: 8px; }
+  .pro-mark { width: 26px; height: 26px; color: var(--accent); display: inline-flex; }
+  .pro-mark svg { width: 100%; height: 100%; }
+  .pro-tag { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); background: color-mix(in oklab, var(--accent) 12%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); border-radius: 999px; padding: 5px 9px; }
+  .context { font: 600 12.5px/1.4 Inter, sans-serif; color: var(--muted); margin: 13px 0 4px; }
+  .sheet h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 25px; line-height: 1.12; letter-spacing: -0.015em; margin: 0 0 14px; color: var(--ink); }
+
+  .feat { list-style: none; margin: 0 0 14px; padding: 0; display: grid; gap: 11px; }
+  .feat li { display: flex; align-items: flex-start; gap: 11px; font-size: 14px; color: var(--ink); }
+  .feat .ic { flex: 0 0 auto; width: 22px; height: 22px; border-radius: 999px; background: color-mix(in oklab, var(--accent) 14%, transparent); display: grid; place-items: center; margin-top: 1px; }
+  .feat .ic svg { width: 13px; height: 13px; stroke: var(--accent-deep); fill: none; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; }
+  .feat b { font-weight: 650; }
+  .feat span.sub { display: block; font-size: 12.5px; color: var(--ink-soft); font-weight: 400; margin-top: 1px; }
+
+  .honest { font-size: 12px; line-height: 1.45; color: var(--muted); margin: 0 0 16px; padding: 10px 12px; border-radius: 11px; background: var(--surface); border: 1px solid var(--border); }
+
+  .price-eyebrow { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-bottom: 8px; }
+  .plans { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 16px; }
+  .plan { border: 1.5px solid var(--border); border-radius: 14px; padding: 13px 14px; cursor: pointer; background: var(--bg); position: relative; transition: border-color .18s, background .18s; }
+  .plan.sel { border-color: var(--accent); background: color-mix(in oklab, var(--accent) 7%, var(--bg)); }
+  .plan .pn { font: 700 12.5px/1 Inter, sans-serif; color: var(--ink-soft); }
+  .plan .pp { font-family: Fraunces, serif; font-weight: 600; font-size: 22px; color: var(--ink); margin-top: 6px; font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; }
+  .plan .pu { font-size: 11.5px; color: var(--muted); margin-top: 2px; }
+  .save { position: absolute; top: -9px; right: 10px; font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.04em; text-transform: uppercase; color: var(--on-accent); background: var(--accent); border-radius: 999px; padding: 4px 8px; }
+
+  .btn-primary { width: 100%; border: none; border-radius: 15px; padding: 16px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15.5px/1 Inter, sans-serif;
+    box-shadow: 0 12px 26px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+  .btn-later { width: 100%; background: none; border: none; cursor: pointer; margin-top: 10px; padding: 8px; font: 650 14px/1 Inter, sans-serif; color: var(--ink-soft); transition: color .2s; }
+  @media (hover:hover) and (pointer:fine) { .btn-later:hover { color: var(--ink); } }
+  .foot { text-align: center; font-size: 11.5px; color: var(--muted); margin-top: 8px; }
+  .foot button { background: none; border: none; color: var(--ink-soft); font: 600 11.5px/1 Inter, sans-serif; cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
+
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">The payment moment</p>
+        <h1 class="stage-title">Pro upgrade sheet</h1>
+        <p class="stage-sub">Appears after the aha, when a free user hits a Pro trigger (here: the daily question cap). Honest framing, example pricing. Billing wiring (web Stripe / iOS IAP) comes later.</p>
+      </div>
+      <div class="head-controls">
+        <button class="chip-btn" id="themeToggle" type="button" aria-label="Toggle light and dark">
+          <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+          <span id="themeLabel">Dark</span>
+        </button>
+        <button class="chip-btn" id="replayBtn" type="button">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12a9 9 0 1 0 3-6.7"></path><path d="M3 4v4h4"></path></svg>
+          Replay
+        </button>
+      </div>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen open" id="screen">
+          <div class="notch"></div>
+
+          <!-- the app behind the sheet (dimmed) -->
+          <div class="behind" aria-hidden="true">
+            <div class="b-cmd">
+              <div><div class="sys">CertAnvil console</div><div class="cert">Network+ N10-009</div></div>
+              <div class="b-chip">0 day streak</div>
+            </div>
+            <div class="b-tile"></div>
+            <div class="b-tile" style="height:120px"></div>
+          </div>
+
+          <div class="scrim"></div>
+
+          <!-- the Pro upgrade sheet -->
+          <div class="sheet" role="dialog" aria-label="Upgrade to Pro">
+            <div class="grab"></div>
+            <button class="sheet-close" type="button" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"></path></svg></button>
+
+            <div class="pro-badge">
+              <span class="pro-mark" aria-hidden="true">
+                <svg viewBox="0 0 100 100" fill="none">
+                  <path d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+                  <line x1="30" y1="84" x2="70" y2="16" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+                  <path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+              <span class="pro-tag">CertAnvil Pro</span>
+            </div>
+
+            <p class="context">You've used your 15 free questions for today.</p>
+            <h2>Keep the streak going, unlimited.</h2>
+
+            <ul class="feat">
+              <li><span class="ic"><svg viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"></path></svg></span><span><b>Unlimited questions, every day</b><span class="sub">No daily cap on new practice or Daily Review.</span></span></li>
+              <li><span class="ic"><svg viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"></path></svg></span><span><b>All IT exams, switch anytime</b><span class="sub">Network+, Security+, A+, Azure, AWS, and more being added.</span></span></li>
+              <li><span class="ic"><svg viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"></path></svg></span><span><b>Your readiness, across every cert</b><span class="sub">One place to see where you stand on each one.</span></span></li>
+            </ul>
+
+            <p class="honest">Pro is about access and volume. It is not a pass guarantee. Your readiness still moves only as you study.</p>
+
+            <p class="price-eyebrow">Example pricing</p>
+            <div class="plans">
+              <div class="plan" data-plan="monthly"><div class="pn">Monthly</div><div class="pp">£6.99</div><div class="pu">per month</div></div>
+              <div class="plan sel" data-plan="annual"><span class="save">Save 30%</span><div class="pn">Annual</div><div class="pp">£58</div><div class="pu">£4.83 / month</div></div>
+            </div>
+
+            <button class="btn-primary" type="button">Start Pro</button>
+            <button class="btn-later" id="maybeLater" type="button">Maybe later</button>
+            <p class="foot">Cancel anytime. <button type="button">Restore purchase</button></p>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Tap Replay to watch the sheet present again.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon'), screen = document.getElementById('screen');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // plan selection
+      document.querySelectorAll('.plan').forEach(function(p){ p.addEventListener('click', function(){
+        document.querySelectorAll('.plan').forEach(function(x){ x.classList.remove('sel'); }); p.classList.add('sel');
+      }); });
+
+      // present / dismiss / replay
+      function present(){ screen.classList.remove('open'); void screen.offsetWidth; setTimeout(function(){ screen.classList.add('open'); }, 60); }
+      document.querySelector('.sheet-close').addEventListener('click', function(){ screen.classList.remove('open'); });
+      document.getElementById('maybeLater').addEventListener('click', function(){ screen.classList.remove('open'); });
+      document.querySelector('.scrim').addEventListener('click', function(){ screen.classList.remove('open'); });
+      document.getElementById('replayBtn').addEventListener('click', present);
+      present();
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
An installable, phone-framed **sandbox** so the founder can tap through the onboarding flow + the new free-tier cert lock on their iPhone 13 Pro Max — no accounts, no flags, no App Store wait. Lives at `mockups/onboarding-sandbox.html` (deploy-served), unlinked + `noindex`.

- **Installable mini-app:** `apple-mobile-web-app-capable`, `viewport-fit=cover` + safe-area insets, monogram touch icon → Add to Home Screen launches full-screen.
- **Loads the real shipped files** (`../dg-system.css`, `../lib/{router,cert-lock,onboarding-firstrun}.js`) so live pieces are always exactly prod.
- **🟢 Live & interactive:** the **cert-lock wall** (pick any cert pairing) and the **first-run flow** (lobby → pick → diagnostic → +movement aha → habit → finish), driven via the module's no-engine fallback (placeholder data, no API key/app.js).
- **🎨 Design mockups:** welcome, sign-up, Pro upgrade sheet, done-for-today, You're Pro, My Certs, rollout map — iframed, labelled "design".
- **🔗** A button into the real app (`/?onb=1`).
- **Non-destructive:** snapshots + restores the few `localStorage` keys the live module writes (it shares the prod origin), and restores on `pagehide`.

Also brings the 7 session-1 onboarding design mockups onto `main` (they were only on the old worktree branch).

## Verification (live, at 428×926)
- [x] First-run walked **end to end** via real clicks (cert pick → Step 2 → score → aha → habit → finish), then auto-returns to menu
- [x] Cert-lock wall fires for a wrong-cert pick; mockups load; theme toggles light/dark
- [x] Console clean (no errors); `localStorage` restored after exit; app-shell meta present
- [ ] **Reviewer:** merge → then open the prod URL on iPhone and Add to Home Screen

## Lane
Fast lane — static `mockups/` + docs only, no gated files, no version bump.

## Files
`mockups/onboarding-sandbox.html` (new) + 7 brought-over `mockups/onboarding-*.html` + spec/plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)