### PR TITLE
fix(mockups): allow same-origin framing for /mockups/ (unblocks the sandbox)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,10 @@
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; connect-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https://user-images.githubusercontent.com; font-src 'self' https://cdn.jsdelivr.net; base-uri 'self'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
         }
       ]
     }


### PR DESCRIPTION
## Summary
The onboarding sandbox (`/mockups/onboarding-sandbox.html`) iframes the design mockups, which are same-origin. The site-wide `X-Frame-Options: DENY` blocks that even for same-origin frames, so the 6 design-mockup cards render blank on prod (the live cert-lock + first-run pieces are unaffected — no iframe).

**Fix:** add `X-Frame-Options: SAMEORIGIN` to the existing `/mockups/(.*)` header rule in `vercel.json`. That rule already overrides the CSP for `/mockups/` (proven: mockups serve the jsdelivr CSP, not the app CSP), so same-key override is the established behavior here. The real app keeps `DENY`.

**Safety:** the mockups are static design demos with no data, auth, or forms. Same-origin framing of them is harmless; `SAMEORIGIN` still blocks cross-origin clickjacking.

## Test plan
- [x] `vercel.json` is valid JSON
- [ ] After merge: open `https://networkplus.certanvil.com/mockups/onboarding-sandbox.html` on iPhone → the design-mockup cards now render in the frame; live pieces still work

## Lane
Fast lane (config/header change, scoped to demo `/mockups/`). No gated app files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)