### PR TITLE
fix(mockups): correct Fraunces/Inter fonts in the sandbox (final polish)

### DIFF
--- a/mockups/onboarding-sandbox.html
+++ b/mockups/onboarding-sandbox.html
@@ -13,6 +13,9 @@
 <meta name="theme-color" content="#1a1714">
 <!-- monogram touch icon (forged-bronze tile) -->
 <link rel="apple-touch-icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'%3E%3Crect width='180' height='180' rx='40' fill='%231a1714'/%3E%3Cg fill='none' stroke='%23c98a3c' stroke-width='12' stroke-linecap='round'%3E%3Cpath d='M104 38 C76 26, 34 42, 30 70 C26 98, 44 116, 78 118'/%3E%3Cline x1='58' y1='150' x2='126' y2='32' stroke='%238a8a8a'/%3E%3Cpath d='M82 156 L116 86 L150 156 M95 130 L137 130'/%3E%3C/g%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap">
 <link rel="stylesheet" href="../dg-system.css?v=sandbox">
 <style>
   :root { color-scheme: light dark; }

--- a/vercel.json
+++ b/vercel.json
@@ -22,7 +22,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; connect-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https://user-images.githubusercontent.com; font-src 'self' https://cdn.jsdelivr.net; base-uri 'self'"
+          "value": "default-src 'self' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; connect-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https://user-images.githubusercontent.com; font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com; base-uri 'self'"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
Last polish on the onboarding sandbox: the sandbox chrome + the iframed design mockups reference Fraunces/Inter but rendered in a serif fallback on prod, because (a) the sandbox had no font `<link>` and (b) the `/mockups/` CSP blocked `fonts.googleapis.com`/`fonts.gstatic.com`.

**Fix:**
- Add the Fraunces + Inter Google Fonts `<link>` to `mockups/onboarding-sandbox.html`.
- Allow `https://fonts.googleapis.com` (style-src) + `https://fonts.gstatic.com` (font-src) in the existing `/mockups/(.*)` CSP override. Scoped to `/mockups/` only; the real app CSP is unchanged. (This also fixes fonts for every other mockup viewed on prod.)

## Lane
Fast lane (config/static, scoped to `/mockups/`). No gated app files.

## After merge
The sandbox renders Fraunces headings correctly on iPhone. Then it's done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)