### PR TITLE
Complete Apple onboarding flow: 11 mockups + sandbox wiring

### DIFF
--- a/mockups/onboarding-account-deletion.html
+++ b/mockups/onboarding-account-deletion.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Delete account</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --danger: oklch(0.62 0.190 25); --danger-deep: oklch(0.55 0.200 26); --on-danger: oklch(0.98 0.010 30);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --danger: oklch(0.52 0.195 26); --danger-deep: oklch(0.45 0.200 27); --on-danger: oklch(0.99 0.010 30);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 10px; }
+  .hdr .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .14s var(--ease), border-color .18s; }
+  .hdr .back:active { transform: scale(0.94); }
+  @media (hover:hover) and (pointer:fine) { .hdr .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .hdr .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+  .hdr .plan-tag { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); background: color-mix(in oklab, var(--ink) 6%, transparent); border: 1px solid var(--border); border-radius: 999px; padding: 6px 9px; }
+
+  .body { flex: 1; overflow-y: auto; padding: 4px 22px 22px; }
+  .body::-webkit-scrollbar { width: 0; }
+  .sect { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin: 18px 2px 10px; }
+
+  /* identity card at the top of Settings */
+  .acct { display: flex; align-items: center; gap: 13px; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 14px; }
+  .acct .avatar { flex: 0 0 auto; width: 46px; height: 46px; border-radius: 13px; background: color-mix(in oklab, var(--accent) 16%, var(--surface-2)); color: var(--accent-deep); display: grid; place-items: center; font: 800 16px/1 Inter, sans-serif; }
+  .acct .who { min-width: 0; }
+  .acct .nm { font: 650 15px/1.2 Inter, sans-serif; color: var(--ink); }
+  .acct .em { font-size: 12.5px; color: var(--muted); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .acct .pro { flex: 0 0 auto; margin-left: auto; font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 12%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); border-radius: 999px; padding: 6px 9px; }
+
+  /* settings rows group */
+  .group { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); overflow: hidden; }
+  .row { display: flex; align-items: center; gap: 12px; padding: 13px 14px; cursor: pointer; background: transparent; border: none; width: 100%; text-align: left; color: var(--ink); transition: background .18s; }
+  .row + .row { border-top: 1px solid color-mix(in oklab, var(--border) 64%, transparent); }
+  .row:active { background: color-mix(in oklab, var(--ink) 5%, transparent); }
+  @media (hover:hover) and (pointer:fine) { .row:hover { background: color-mix(in oklab, var(--ink) 4%, transparent); } }
+  .row .ri { flex: 0 0 auto; width: 32px; height: 32px; border-radius: 9px; display: grid; place-items: center; background: color-mix(in oklab, var(--ink) 6%, var(--surface-2)); color: var(--ink-soft); }
+  .row .ri svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .row .rl { flex: 1 1 auto; font: 600 14px/1.25 Inter, sans-serif; }
+  .row .chev { flex: 0 0 auto; color: var(--muted); }
+  .row .chev svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  /* destructive row */
+  .row.danger .rl { color: var(--danger-deep); }
+  .row.danger .ri { background: color-mix(in oklab, var(--danger) 12%, var(--surface-2)); color: var(--danger-deep); }
+  .group.solo { border-color: color-mix(in oklab, var(--danger) 26%, var(--border)); }
+  .group-note { font-size: 12px; line-height: 1.45; color: var(--muted); margin: 9px 4px 0; }
+
+  /* sticky bar reused on the goodbye screen */
+  .footer { flex: 0 0 auto; padding: 12px 22px calc(12px + env(safe-area-inset-bottom)); border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent); background: var(--bg); }
+  .btn-primary { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s, opacity .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+  .btn-primary[disabled] { opacity: 0.45; box-shadow: none; cursor: default; }
+
+  /* destructive primary (reuses btn-primary shape, danger token) */
+  .btn-danger { background: var(--danger); color: var(--on-danger); box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--danger) 70%, transparent); }
+  @media (hover:hover) and (pointer:fine) { .btn-danger:hover { filter: brightness(1.06); } }
+
+  /* confirm sheet (reuses the sibling pattern) */
+  .scrim { position: absolute; inset: 0; background: color-mix(in oklab, #07080b 52%, transparent); opacity: 0; pointer-events: none; transition: opacity .28s var(--ease); z-index: 8; }
+  .scrim.open { opacity: 1; pointer-events: auto; }
+  .sheet { position: absolute; left: 0; right: 0; bottom: 0; z-index: 9; background: var(--surface); border-top-left-radius: 26px; border-top-right-radius: 26px;
+    border-top: 1px solid var(--border); padding: 10px 20px calc(20px + env(safe-area-inset-bottom)); transform: translateY(102%); transition: transform .34s var(--ease-drawer); will-change: transform; box-shadow: 0 -24px 50px -30px rgba(0,0,0,0.5); max-height: 92%; overflow-y: auto; }
+  .sheet::-webkit-scrollbar { width: 0; }
+  .sheet.open { transform: none; }
+  .grab { width: 38px; height: 4px; border-radius: 999px; background: color-mix(in oklab, var(--ink) 22%, var(--track)); margin: 4px auto 14px; }
+  .sheet-head { display: flex; align-items: center; gap: 11px; margin-bottom: 6px; }
+  .sheet-lock { flex: 0 0 auto; width: 38px; height: 38px; border-radius: 11px; display: grid; place-items: center; background: color-mix(in oklab, var(--danger) 14%, var(--surface-2)); }
+  .sheet-lock svg { width: 19px; height: 19px; stroke: var(--danger-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .sheet h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 20px; letter-spacing: -0.01em; margin: 0; color: var(--ink); }
+  .sheet-intro { font-size: 13px; line-height: 1.5; color: var(--ink-soft); margin: 8px 0 14px; }
+  .terms { list-style: none; margin: 0 0 14px; padding: 0; }
+  .terms li { display: flex; align-items: flex-start; gap: 12px; padding: 11px 0; }
+  .terms li + li { border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); }
+  .ti { flex: 0 0 auto; width: 30px; height: 30px; border-radius: 9px; display: grid; place-items: center; background: color-mix(in oklab, var(--danger) 10%, var(--surface-2)); }
+  .ti svg { width: 16px; height: 16px; stroke: var(--danger-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .terms .tt { font: 650 13.5px/1.3 Inter, sans-serif; color: var(--ink); }
+  .terms .ts { font-size: 12.5px; line-height: 1.45; color: var(--ink-soft); margin-top: 3px; }
+  .terms .ts b { color: var(--ink); font-weight: 650; }
+
+  /* permanence callout + subscription note */
+  .callout { display: flex; align-items: flex-start; gap: 10px; border-radius: 13px; padding: 11px 13px; margin: 0 0 12px; font-size: 12.5px; line-height: 1.45; }
+  .callout svg { flex: 0 0 auto; width: 16px; height: 16px; margin-top: 1px; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .callout.warn { border: 1px solid color-mix(in oklab, var(--danger) 30%, var(--border)); background: color-mix(in oklab, var(--danger) 7%, var(--surface)); color: var(--ink-soft); }
+  .callout.warn svg { stroke: var(--danger-deep); }
+  .callout.warn b { color: var(--ink); font-weight: 650; }
+  .callout.info { border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border)); background: color-mix(in oklab, var(--accent) 6%, var(--surface)); color: var(--ink-soft); }
+  .callout.info svg { stroke: var(--accent-deep); }
+  .callout.info b { color: var(--ink); font-weight: 650; }
+
+  /* type-to-confirm field */
+  .confirm-field { margin: 0 0 16px; }
+  .confirm-field label { display: block; font: 650 12.5px/1.4 Inter, sans-serif; color: var(--ink); margin-bottom: 7px; }
+  .confirm-field label .em { font-weight: 700; color: var(--danger-deep); }
+  .confirm-field input { width: 100%; border: 1.5px solid var(--border); border-radius: 12px; background: var(--bg); color: var(--ink); padding: 12px 13px; font: 500 14px/1.2 Inter, sans-serif; transition: border-color .18s, box-shadow .18s; }
+  .confirm-field input::placeholder { color: var(--muted); }
+  .confirm-field input:focus { outline: none; border-color: color-mix(in oklab, var(--danger) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--danger) 18%, transparent); }
+  .confirm-field input.match { border-color: color-mix(in oklab, var(--pass) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--pass) 16%, transparent); }
+  .confirm-hint { font-size: 11.5px; color: var(--muted); margin: 7px 0 0; }
+
+  .sheet-actions { display: flex; flex-direction: column; gap: 9px; }
+  .btn-ghost { width: 100%; border: 1px solid var(--border); border-radius: 13px; padding: 13px; cursor: pointer; background: transparent; color: var(--ink-soft); font: 650 14px/1 Inter, sans-serif; transition: background .2s, transform .15s var(--ease); }
+  .btn-ghost:active { transform: scale(0.98); }
+  @media (hover:hover) and (pointer:fine) { .btn-ghost:hover { background: color-mix(in oklab, var(--ink) 5%, transparent); } }
+
+  /* deleting state (overlay) */
+  .deleting { position: absolute; inset: 0; z-index: 11; background: var(--bg); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 18px; padding: 0 40px; text-align: center; opacity: 0; pointer-events: none; transition: opacity .3s var(--ease); }
+  .deleting.open { opacity: 1; pointer-events: auto; }
+  .spinner { width: 38px; height: 38px; border-radius: 999px; border: 3px solid color-mix(in oklab, var(--ink) 14%, var(--track)); border-top-color: var(--accent); }
+  @media (prefers-reduced-motion: no-preference) { .deleting.open .spinner { animation: spin 0.9s linear infinite; } }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .deleting .dl-t { font: 650 16px/1.3 Inter, sans-serif; color: var(--ink); }
+  .deleting .dl-s { font-size: 12.5px; line-height: 1.5; color: var(--muted); max-width: 30ch; }
+
+  /* goodbye / signed-out state (overlay) */
+  .goodbye { position: absolute; inset: 0; z-index: 12; background: var(--bg); display: flex; flex-direction: column; opacity: 0; pointer-events: none; transition: opacity .35s var(--ease); }
+  .goodbye.open { opacity: 1; pointer-events: auto; }
+  .goodbye-body { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 16px; padding: 0 38px; text-align: center; }
+  .gb-mark { width: 60px; height: 60px; border-radius: 17px; display: grid; place-items: center; background: color-mix(in oklab, var(--pass) 13%, var(--surface-2)); }
+  .gb-mark svg { width: 28px; height: 28px; stroke: var(--pass); fill: none; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+  .goodbye h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 23px; letter-spacing: -0.012em; margin: 0; color: var(--ink); }
+  .goodbye p { font-size: 13.5px; line-height: 1.55; color: var(--ink-soft); margin: 0; max-width: 32ch; }
+  .goodbye .quiet { font-size: 12px; color: var(--muted); max-width: 32ch; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(9px); animation: rise .5s var(--ease) forwards; }
+    .reveal:nth-child(1){animation-delay:.04s}.reveal:nth-child(2){animation-delay:.08s}.reveal:nth-child(3){animation-delay:.12s}
+    .reveal:nth-child(4){animation-delay:.16s}.reveal:nth-child(5){animation-delay:.20s}.reveal:nth-child(6){animation-delay:.24s}
+    .reveal:nth-child(7){animation-delay:.28s}.reveal:nth-child(8){animation-delay:.32s}
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .sheet .terms li { opacity: 0; transform: translateY(6px); }
+    .sheet.open .terms li { animation: termIn .42s var(--ease) forwards; }
+    .sheet.open .terms li:nth-child(1) { animation-delay: .08s; }
+    .sheet.open .terms li:nth-child(2) { animation-delay: .14s; }
+    .sheet.open .terms li:nth-child(3) { animation-delay: .20s; }
+    .sheet.open .terms li:nth-child(4) { animation-delay: .26s; }
+    @keyframes termIn { to { opacity: 1; transform: none; } }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .scrim, .sheet, .deleting, .goodbye { transition: none; }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Settings · delete account</p>
+        <h1 class="stage-title">Delete account</h1>
+        <p class="stage-sub">Apple requires in-app account deletion for apps with accounts. This is the Settings row, a confirm sheet that is honest about what is lost, the brief deleting state, and the signed-out goodbye.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="hdr">
+            <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+            <h1>Settings</h1>
+            <span class="plan-tag">Pro</span>
+          </div>
+
+          <div class="body">
+            <div class="acct reveal">
+              <span class="avatar">SO</span>
+              <div class="who">
+                <div class="nm">Simi Oremosu</div>
+                <div class="em">simi_oremosu@hotmail.com</div>
+              </div>
+              <span class="pro">Pro</span>
+            </div>
+
+            <div class="sect reveal">Account</div>
+            <div class="group reveal">
+              <button class="row" type="button">
+                <span class="ri"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 21a8 8 0 0 0-16 0"></path><circle cx="12" cy="7" r="4"></circle></svg></span>
+                <span class="rl">Manage profile</span>
+                <span class="chev"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18l6-6-6-6"></path></svg></span>
+              </button>
+              <button class="row" type="button">
+                <span class="ri"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg></span>
+                <span class="rl">Email and password</span>
+                <span class="chev"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18l6-6-6-6"></path></svg></span>
+              </button>
+              <button class="row" type="button">
+                <span class="ri"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg></span>
+                <span class="rl">Export my data</span>
+                <span class="chev"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18l6-6-6-6"></path></svg></span>
+              </button>
+            </div>
+
+            <div class="sect reveal">Subscription</div>
+            <div class="group reveal">
+              <button class="row" type="button">
+                <span class="ri"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="2" y="5" width="20" height="14" rx="2"></rect><path d="M2 10h20"></path></svg></span>
+                <span class="rl">Pro, billed through Apple</span>
+                <span class="chev"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18l6-6-6-6"></path></svg></span>
+              </button>
+            </div>
+
+            <div class="sect reveal">Danger zone</div>
+            <div class="group solo reveal">
+              <button class="row danger" id="deleteRow" type="button">
+                <span class="ri"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path><path d="M10 11v6M14 11v6"></path></svg></span>
+                <span class="rl">Delete my account</span>
+                <span class="chev"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18l6-6-6-6"></path></svg></span>
+              </button>
+            </div>
+            <p class="group-note reveal">Deleting your account removes your data for good. You can export it first from the Account section above.</p>
+          </div>
+
+          <!-- confirm sheet -->
+          <div class="scrim" id="scrim"></div>
+          <div class="sheet" id="sheet" role="dialog" aria-modal="true" aria-labelledby="sheetTitle">
+            <div class="grab"></div>
+            <div class="sheet-head">
+              <span class="sheet-lock"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path><path d="M10 11v6M14 11v6"></path></svg></span>
+              <h2 id="sheetTitle">Delete your account?</h2>
+            </div>
+            <p class="sheet-intro">Here is exactly what gets removed. Read it, then confirm by typing your email.</p>
+
+            <ul class="terms">
+              <li>
+                <span class="ti"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3v18h18"></path><path d="M7 15l4-4 3 3 5-6"></path></svg></span>
+                <div><div class="tt">Your progress and history</div><div class="ts">Every quiz, exam, and review you have done. Gone, not paused.</div></div>
+              </li>
+              <li>
+                <span class="ti"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2L3 14h7l-1 8 10-12h-7z"></path></svg></span>
+                <div><div class="tt">Your streak and readiness</div><div class="ts">Your current <b>14 day streak</b> and your readiness score reset to zero.</div></div>
+              </li>
+              <li>
+                <span class="ti"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 11l3 3L22 4"></path><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg></span>
+                <div><div class="tt">Your saved Pass Plan</div><div class="ts">The study plan built around your exam date is deleted with everything else.</div></div>
+              </li>
+            </ul>
+
+            <div class="callout warn">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"></path><path d="M12 9v4M12 17h.01"></path></svg>
+              <span><b>This cannot be undone.</b> We do not keep a backup. To return later you would start a new account from scratch.</span>
+            </div>
+
+            <div class="callout info" id="subNote">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 8h.01M11 12h1v4h1"></path></svg>
+              <span>Your <b>Pro subscription is billed by Apple</b>, so deleting your account does not cancel it. To stop billing, cancel in Apple Settings, your name, Subscriptions. You can cancel any time.</span>
+            </div>
+
+            <div class="confirm-field">
+              <label for="confirmEmail">Type <span class="em">simi_oremosu@hotmail.com</span> to confirm</label>
+              <input id="confirmEmail" type="email" inputmode="email" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="Your email" />
+              <p class="confirm-hint">This makes sure the delete is really you.</p>
+            </div>
+
+            <div class="sheet-actions">
+              <button class="btn-primary btn-danger" id="confirmBtn" type="button" disabled>Delete account</button>
+              <button class="btn-ghost" id="cancelBtn" type="button">Cancel</button>
+            </div>
+          </div>
+
+          <!-- deleting state -->
+          <div class="deleting" id="deleting">
+            <div class="spinner"></div>
+            <div class="dl-t">Deleting your account...</div>
+            <div class="dl-s">Removing your data. This takes a moment.</div>
+          </div>
+
+          <!-- goodbye / signed-out -->
+          <div class="goodbye" id="goodbye">
+            <div class="goodbye-body">
+              <span class="gb-mark"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg></span>
+              <h2>You are signed out</h2>
+              <p>Your account and data are gone. Thanks for studying with CertAnvil.</p>
+              <p class="quiet" id="goodbyeSub">If you had Pro, remember to cancel it in Apple Settings so you are not billed again.</p>
+            </div>
+            <div class="footer">
+              <button class="btn-primary" id="restartBtn" type="button">Back to start</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Tap Delete my account to open the confirm sheet. Type the email to enable the delete.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      var EMAIL = 'simi_oremosu@hotmail.com';
+      var scrim = document.getElementById('scrim'), sheet = document.getElementById('sheet');
+      var input = document.getElementById('confirmEmail');
+      var confirmBtn = document.getElementById('confirmBtn');
+      var deleting = document.getElementById('deleting');
+      var goodbye = document.getElementById('goodbye');
+
+      function openSheet(){ scrim.classList.add('open'); sheet.classList.add('open'); }
+      function closeSheet(){ scrim.classList.remove('open'); sheet.classList.remove('open'); input.value = ''; sync(); }
+
+      // type-to-confirm gate
+      function sync(){
+        var ok = input.value.trim().toLowerCase() === EMAIL;
+        confirmBtn.disabled = !ok;
+        input.classList.toggle('match', ok && input.value.length > 0);
+      }
+      input.addEventListener('input', sync);
+
+      document.getElementById('deleteRow').addEventListener('click', openSheet);
+      scrim.addEventListener('click', closeSheet);
+      document.getElementById('cancelBtn').addEventListener('click', closeSheet);
+
+      confirmBtn.addEventListener('click', function(){
+        if (confirmBtn.disabled) return;
+        closeSheet();
+        deleting.classList.add('open');
+        // mockup: real flow would call the delete endpoint then sign out
+        setTimeout(function(){
+          goodbye.classList.add('open');
+          setTimeout(function(){ deleting.classList.remove('open'); }, 400);
+        }, 1700);
+      });
+
+      // restart the demo
+      document.getElementById('restartBtn').addEventListener('click', function(){
+        goodbye.classList.remove('open');
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-error-states.html
+++ b/mockups/onboarding-error-states.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Error states</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* chip row: switches which state the phone shows */
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
+  .chip { font: 650 12.5px/1 Inter, sans-serif; color: var(--page-dim); background: transparent;
+    border: 1px solid color-mix(in oklab, var(--page-dim) 34%, transparent); border-radius: 999px; padding: 9px 14px; cursor: pointer;
+    transition: transform .15s var(--ease), background .2s, border-color .2s, color .2s; }
+  .chip:active { transform: scale(0.96); }
+  @media (hover:hover) and (pointer:fine) { .chip:hover { border-color: color-mix(in oklab, var(--accent-bright) 45%, var(--page-dim)); color: var(--page-ink); } }
+  .chip[aria-pressed="true"] { color: var(--on-accent); background: var(--accent); border-color: var(--accent); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 10px; }
+  .hdr .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .14s var(--ease), border-color .18s; }
+  .hdr .back:active { transform: scale(0.94); }
+  @media (hover:hover) and (pointer:fine) { .hdr .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .hdr .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+  .hdr .plan-tag { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); background: color-mix(in oklab, var(--ink) 6%, transparent); border: 1px solid var(--border); border-radius: 999px; padding: 6px 9px; }
+
+  .body { flex: 1; overflow-y: auto; padding: 6px 22px 20px; display: flex; flex-direction: column; }
+  .body::-webkit-scrollbar { width: 0; }
+
+  /* one error state: centred, calm, one clear action */
+  .state { display: none; flex: 1; flex-direction: column; }
+  .state.on { display: flex; }
+  .state-mid { flex: 1; display: flex; flex-direction: column; justify-content: center; padding: 4px 0 8px; }
+
+  .glyph { width: 56px; height: 56px; border-radius: 16px; display: grid; place-items: center; margin-bottom: 18px;
+    background: color-mix(in oklab, var(--accent) 13%, var(--surface-2)); }
+  .glyph svg { width: 26px; height: 26px; stroke: var(--accent-deep); fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+
+  .state h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; line-height: 1.14; letter-spacing: -0.014em; margin: 0 0 10px; color: var(--ink); }
+  .state h2 .mono { font-family: 'Roboto Mono', monospace; font-weight: 600; font-size: 0.82em; letter-spacing: -0.01em; }
+  .state p { font-size: 14px; line-height: 1.55; color: var(--ink-soft); margin: 0; max-width: 38ch; }
+  .state p b { color: var(--ink); font-weight: 650; }
+
+  /* small contextual line under the message */
+  .fineline { display: flex; align-items: flex-start; gap: 9px; margin-top: 16px; padding: 11px 13px;
+    border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+  .fineline svg { flex: 0 0 auto; width: 15px; height: 15px; margin-top: 1px; stroke: var(--muted); fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .fineline p { font-size: 12.5px; line-height: 1.45; color: var(--muted); margin: 0; }
+
+  /* a suggested-fix row (email typo) */
+  .suggest { margin-top: 16px; display: flex; align-items: center; gap: 12px; border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border));
+    border-radius: 14px; background: color-mix(in oklab, var(--accent) 6%, var(--surface)); padding: 13px 15px; }
+  .suggest .em { font: 600 14px/1.2 'Roboto Mono', monospace; color: var(--ink); word-break: break-all; }
+  .suggest .lbl { font-size: 11.5px; color: var(--muted); margin-bottom: 3px; }
+
+  /* footer action(s) */
+  .footer { flex: 0 0 auto; padding: 12px 22px calc(14px + env(safe-area-inset-bottom)); border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent); background: var(--bg); }
+  .btn-primary { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+  .btn-ghost { width: 100%; border: 1px solid var(--border); border-radius: 13px; padding: 13px; cursor: pointer; background: transparent; color: var(--ink-soft); font: 650 14px/1 Inter, sans-serif; transition: background .2s, transform .15s var(--ease); }
+  .btn-ghost:active { transform: scale(0.98); }
+  @media (hover:hover) and (pointer:fine) { .btn-ghost:hover { background: color-mix(in oklab, var(--ink) 5%, transparent); } }
+  .footer .stack { display: flex; flex-direction: column; gap: 9px; }
+  .foot-hint { text-align: center; font-size: 11.5px; color: var(--muted); margin: 9px 0 0; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .state.on .glyph, .state.on h2, .state.on p, .state.on .fineline, .state.on .suggest {
+      opacity: 0; transform: translateY(9px); animation: rise .5s var(--ease) forwards; }
+    .state.on .glyph { animation-delay: .03s; }
+    .state.on h2 { animation-delay: .09s; }
+    .state.on p { animation-delay: .15s; }
+    .state.on .fineline, .state.on .suggest { animation-delay: .21s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Onboarding · error states</p>
+        <h1 class="stage-title">Error states</h1>
+        <p class="stage-sub">The moments that can go wrong during sign-up and checkout. Each one is a calm, plain message that names the situation and offers one clear way forward. Tap a chip to switch states.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="chips" id="chips" role="tablist" aria-label="Error state">
+      <button class="chip" type="button" data-state="declined" aria-pressed="true">Card declined</button>
+      <button class="chip" type="button" data-state="renewal" aria-pressed="false">Renewal failed</button>
+      <button class="chip" type="button" data-state="link" aria-pressed="false">Link expired</button>
+      <button class="chip" type="button" data-state="exists" aria-pressed="false">Account exists</button>
+      <button class="chip" type="button" data-state="typo" aria-pressed="false">Email typo</button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="hdr">
+            <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+            <h1 id="hdrTitle">Checkout</h1>
+            <span class="plan-tag" id="hdrTag">Pro</span>
+          </div>
+
+          <div class="body">
+            <!-- Card declined -->
+            <section class="state on" data-state="declined">
+              <div class="state-mid">
+                <span class="glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="2" y="5" width="20" height="14" rx="2.5"></rect><path d="M2 10h20"></path></svg></span>
+                <h2>That payment didn't go through.</h2>
+                <p>Apple couldn't charge your card. Nothing was taken, and your account is unchanged. You can try again whenever you're ready.</p>
+                <div class="fineline">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 11v5M12 8h.01"></path></svg>
+                  <p>Payment is handled by Apple in Settings. To update a card, open Settings, then your name, then Payment.</p>
+                </div>
+              </div>
+              <div class="footer">
+                <button class="btn-primary" type="button">Try again</button>
+              </div>
+            </section>
+
+            <!-- Renewal failed -->
+            <section class="state" data-state="renewal">
+              <div class="state-mid">
+                <span class="glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"></path><path d="M21 4v4h-4"></path></svg></span>
+                <h2>Your Pro renewal didn't go through.</h2>
+                <p>You have a few days to update payment before Pro pauses. Until then, everything stays exactly where it is and your progress is safe.</p>
+                <div class="fineline">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"></rect><path d="M16 2v4M8 2v4M3 10h18"></path></svg>
+                  <p>Pro stays active until the grace period ends. Update payment any time before then and nothing changes.</p>
+                </div>
+              </div>
+              <div class="footer">
+                <button class="btn-primary" type="button">Update payment</button>
+              </div>
+            </section>
+
+            <!-- Magic-link expired -->
+            <section class="state" data-state="link">
+              <div class="state-mid">
+                <span class="glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 2"></path></svg></span>
+                <h2>This sign-in link expired.</h2>
+                <p>Links are good for 15 minutes, so this one timed out. Send a fresh one and it will land in your inbox in a moment.</p>
+                <div class="fineline">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="M4 7l8 6 8-6"></path></svg>
+                  <p>The new link goes to the same email. If it's slow to arrive, check your spam folder.</p>
+                </div>
+              </div>
+              <div class="footer">
+                <button class="btn-primary" type="button">Send a new link</button>
+              </div>
+            </section>
+
+            <!-- Account already exists -->
+            <section class="state" data-state="exists">
+              <div class="state-mid">
+                <span class="glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4"></circle><path d="M4 21a8 8 0 0 1 16 0"></path></svg></span>
+                <h2>You already have an account with this email.</h2>
+                <p>Good news, your progress is already saved to it. Sign in and you'll pick up right where you left off.</p>
+                <div class="fineline">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M9 12l2 2 4-4"></path></svg>
+                  <p>Forgot the password? You can sign in with a one-time email link instead.</p>
+                </div>
+              </div>
+              <div class="footer">
+                <button class="btn-primary" type="button">Sign in instead</button>
+              </div>
+            </section>
+
+            <!-- Email typo -->
+            <section class="state" data-state="typo">
+              <div class="state-mid">
+                <span class="glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="M4 7l8 6 8-6"></path></svg></span>
+                <h2>Did you mean <span class="mono">you@gmail.com</span>?</h2>
+                <p>The address you typed looks a little off, so we want to be sure your sign-in link reaches you.</p>
+                <div class="suggest">
+                  <svg viewBox="0 0 24 24" aria-hidden="true" style="flex:0 0 auto;width:18px;height:18px;stroke:var(--accent-deep);fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;"><path d="M20 6L9 17l-5-5"></path></svg>
+                  <div><div class="lbl">Suggested</div><div class="em">you@gmail.com</div></div>
+                </div>
+              </div>
+              <div class="footer">
+                <div class="stack">
+                  <button class="btn-primary" type="button">Yes, fix it</button>
+                  <button class="btn-ghost" type="button">No, keep mine</button>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Each state names what happened and offers one clear next step. Nothing blames the person.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // chip selector switches which state the phone shows
+      var chips = document.getElementById('chips');
+      var states = document.querySelectorAll('.state');
+      var hdrTitle = document.getElementById('hdrTitle');
+      var hdrTag = document.getElementById('hdrTag');
+      // header context per state: { title, tag(or null) }
+      var ctx = {
+        declined: { title: 'Checkout', tag: 'Pro' },
+        renewal:  { title: 'Your plan', tag: 'Pro' },
+        link:     { title: 'Sign in', tag: null },
+        exists:   { title: 'Create account', tag: null },
+        typo:     { title: 'Sign in', tag: null }
+      };
+      function show(name){
+        states.forEach(function(s){ s.classList.toggle('on', s.getAttribute('data-state') === name); });
+        chips.querySelectorAll('.chip').forEach(function(c){ c.setAttribute('aria-pressed', String(c.getAttribute('data-state') === name)); });
+        var c = ctx[name] || { title: 'CertAnvil', tag: null };
+        hdrTitle.textContent = c.title;
+        if (c.tag) { hdrTag.textContent = c.tag; hdrTag.style.display = ''; } else { hdrTag.style.display = 'none'; }
+      }
+      chips.addEventListener('click', function(e){
+        var chip = e.target.closest('.chip'); if (!chip) return;
+        show(chip.getAttribute('data-state'));
+      });
+      show('declined');
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-first-run-diagnostic.html
+++ b/mockups/onboarding-first-run-diagnostic.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · First-run diagnostic</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* moment switcher above the phone */
+  .moments { display: inline-flex; gap: 4px; padding: 4px; margin: 0 auto 22px; border: 1px solid var(--border); border-radius: 999px; background: color-mix(in oklab, var(--page-ink) 4%, transparent); }
+  .moments { display: flex; max-width: max-content; }
+  .moments-wrap { display: flex; justify-content: center; }
+  .moment-chip { border: none; background: transparent; cursor: pointer; border-radius: 999px; padding: 9px 16px; font: 700 12.5px/1 Inter, sans-serif; color: var(--page-dim);
+    transition: color .2s, background .2s, transform .14s var(--ease); }
+  .moment-chip:active { transform: scale(0.97); }
+  .moment-chip[aria-selected="true"] { color: var(--on-accent); background: var(--accent); box-shadow: 0 8px 18px -12px color-mix(in oklab, var(--accent) 70%, transparent); }
+  @media (hover:hover) and (pointer:fine) { .moment-chip:not([aria-selected="true"]):hover { color: var(--page-ink); background: color-mix(in oklab, var(--page-ink) 6%, transparent); } }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 10px; }
+  .hdr .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .14s var(--ease), border-color .18s; }
+  .hdr .back:active { transform: scale(0.94); }
+  @media (hover:hover) and (pointer:fine) { .hdr .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .hdr .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+  .hdr .plan-tag { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); background: color-mix(in oklab, var(--ink) 6%, transparent); border: 1px solid var(--border); border-radius: 999px; padding: 6px 9px; }
+
+  .body { flex: 1; overflow-y: auto; padding: 4px 22px 18px; }
+  .body::-webkit-scrollbar { width: 0; }
+
+  /* ── (A) The check ── */
+  .progress-row { display: flex; align-items: center; justify-content: space-between; margin: 10px 0 9px; }
+  .progress-row .q-count { font: 700 11px/1 Inter, sans-serif; letter-spacing: 0.04em; color: var(--muted); }
+  .progress-row .q-topic { font: 700 11px/1 'Roboto Mono', monospace; letter-spacing: 0.02em; color: var(--accent-deep); }
+  .qbar { height: 6px; border-radius: 999px; background: var(--track); overflow: hidden; }
+  .qbar > span { display: block; height: 100%; border-radius: 999px; background: var(--accent); transition: width .4s var(--ease); }
+
+  .topic-tag { display: inline-flex; align-items: center; gap: 7px; margin: 18px 0 12px; padding: 6px 11px; border: 1px solid var(--border); border-radius: 999px; background: var(--surface); font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.05em; text-transform: uppercase; color: var(--ink-soft); }
+  .topic-tag .dot { width: 6px; height: 6px; border-radius: 999px; background: var(--accent); }
+
+  .q-text { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 20px; line-height: 1.32; letter-spacing: -0.008em; color: var(--ink); margin: 0 0 16px; }
+  .q-text code { font: 600 17px/1 'Roboto Mono', monospace; background: color-mix(in oklab, var(--accent) 10%, var(--surface-2)); border-radius: 6px; padding: 1px 6px; color: var(--accent-deep); }
+
+  .opt { display: flex; align-items: center; gap: 12px; width: 100%; text-align: left; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 13px 14px; margin-bottom: 10px; cursor: pointer; font: inherit; color: var(--ink);
+    transition: border-color .18s, background .18s, transform .12s var(--ease); }
+  .opt:active { transform: scale(0.99); }
+  @media (hover:hover) and (pointer:fine) { .opt:hover { border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); } }
+  .opt .key { flex: 0 0 auto; width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 11%, var(--surface-2)); color: var(--accent-deep); font: 700 12.5px/1 Inter, sans-serif; transition: background .18s, color .18s; }
+  .opt .label { flex: 1 1 auto; font: 500 14px/1.4 Inter, sans-serif; color: var(--ink); }
+  .opt.sel { border-color: color-mix(in oklab, var(--accent) 55%, var(--border)); background: color-mix(in oklab, var(--accent) 7%, var(--surface)); }
+  .opt.sel .key { background: var(--accent); color: var(--on-accent); }
+
+  .free-note { display: flex; align-items: flex-start; gap: 9px; margin: 14px 0 0; padding: 11px 13px; border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border)); border-radius: 13px; background: color-mix(in oklab, var(--accent) 5%, var(--surface)); }
+  .free-note svg { flex: 0 0 auto; width: 15px; height: 15px; margin-top: 1px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .free-note p { margin: 0; font-size: 12px; line-height: 1.45; color: var(--ink-soft); }
+  .free-note b { color: var(--ink); font-weight: 650; }
+
+  /* ── (B) Your readiness ── (reuses .active-card readiness block) */
+  .kicker { font: 800 10.5px/1 Inter, sans-serif; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 22px 0 12px; }
+  .active-card { border: 1px solid color-mix(in oklab, var(--accent) 34%, var(--border)); border-radius: 16px; background: color-mix(in oklab, var(--accent) 6%, var(--surface)); padding: 16px 16px 17px; }
+  .ac-top { display: flex; align-items: center; gap: 12px; }
+  .mark { flex: 0 0 auto; width: 40px; height: 40px; border-radius: 11px; background: color-mix(in oklab, var(--accent) 13%, var(--surface-2)); color: var(--accent-deep); display: grid; place-items: center; font: 800 13px/1 Inter, sans-serif; }
+  .nm { font: 650 15px/1.1 Inter, sans-serif; color: var(--ink); }
+  .cd { font: 600 11.5px/1 'Roboto Mono', monospace; color: var(--muted); margin-top: 3px; }
+  .ac-badge { margin-left: auto; font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 13%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 34%, transparent); border-radius: 999px; padding: 5px 8px; }
+  .ac-score { display: flex; align-items: baseline; gap: 7px; margin: 16px 0 8px; }
+  .ac-num { font: 600 44px/1 Fraunces, serif; color: var(--ink); font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; }
+  .ac-of { font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+  .bar { height: 7px; border-radius: 999px; background: var(--track); position: relative; overflow: hidden; margin-bottom: 5px; }
+  .bar > span { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 999px; background: var(--accent); }
+  .bar .tick { position: absolute; top: -2px; bottom: -2px; width: 2px; background: color-mix(in oklab, var(--ink) 45%, var(--track)); }
+  .bar-legend { display: flex; justify-content: space-between; font: 600 10.5px/1 Inter, sans-serif; color: var(--muted); }
+  .bar-legend .p { color: var(--accent-deep); }
+
+  .frame-line { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 17px; line-height: 1.35; letter-spacing: -0.006em; color: var(--ink); margin: 20px 0 8px; }
+  .aha { display: flex; align-items: flex-start; gap: 9px; margin: 0; padding: 12px 14px; border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border)); border-radius: 13px; background: color-mix(in oklab, var(--accent) 5%, var(--surface)); }
+  .aha svg { flex: 0 0 auto; width: 16px; height: 16px; margin-top: 1px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .aha p { margin: 0; font-size: 13px; line-height: 1.45; color: var(--ink-soft); }
+  .aha b { color: var(--ink); font-weight: 650; }
+
+  .btn-primary { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+  /* sticky footer for each moment */
+  .footer { flex: 0 0 auto; padding: 12px 22px calc(12px + env(safe-area-inset-bottom)); border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent); background: var(--bg); }
+  .btn-text { display: block; width: 100%; border: none; background: transparent; cursor: pointer; padding: 11px; margin-top: 4px; font: 600 13px/1 Inter, sans-serif; color: var(--muted); transition: color .18s, transform .14s var(--ease); }
+  .btn-text:active { transform: scale(0.98); }
+  @media (hover:hover) and (pointer:fine) { .btn-text:hover { color: var(--ink-soft); } }
+
+  /* moment visibility */
+  .moment { display: none; flex: 1; flex-direction: column; min-height: 0; }
+  .moment.active { display: flex; }
+  .moment .body { flex: 1; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(9px); animation: rise .5s var(--ease) forwards; }
+    .reveal:nth-child(1){animation-delay:.04s}.reveal:nth-child(2){animation-delay:.09s}.reveal:nth-child(3){animation-delay:.14s}
+    .reveal:nth-child(4){animation-delay:.19s}.reveal:nth-child(5){animation-delay:.24s}.reveal:nth-child(6){animation-delay:.29s}
+    .reveal:nth-child(7){animation-delay:.34s}.reveal:nth-child(8){animation-delay:.39s}
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Onboarding · first run</p>
+        <h1 class="stage-title">First-run diagnostic</h1>
+        <p class="stage-sub">The optional placement check and the readiness reveal that follows it. Switch between the two moments below to design each in place.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="moments-wrap">
+      <div class="moments" role="tablist" aria-label="Moment">
+        <button class="moment-chip" id="chipA" type="button" role="tab" aria-selected="true" aria-controls="momentA">The check</button>
+        <button class="moment-chip" id="chipB" type="button" role="tab" aria-selected="false" aria-controls="momentB">Your readiness</button>
+      </div>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <!-- ── (A) The check ── -->
+          <div class="moment active" id="momentA" role="tabpanel" aria-labelledby="chipA">
+            <div class="hdr">
+              <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+              <h1>Quick check</h1>
+              <span class="plan-tag">Free</span>
+            </div>
+
+            <div class="body">
+              <div class="progress-row reveal">
+                <span class="q-count">Question 3 of 20</span>
+                <span class="q-topic">N10-009</span>
+              </div>
+              <div class="qbar reveal"><span style="width:15%"></span></div>
+
+              <span class="topic-tag reveal"><span class="dot"></span>Network fundamentals</span>
+
+              <p class="q-text reveal">Which port does HTTPS use by default to carry encrypted web traffic?</p>
+
+              <button class="opt reveal" type="button"><span class="key">A</span><span class="label">Port 80</span></button>
+              <button class="opt sel reveal" type="button"><span class="key">B</span><span class="label">Port 443</span></button>
+              <button class="opt reveal" type="button"><span class="key">C</span><span class="label">Port 22</span></button>
+              <button class="opt reveal" type="button"><span class="key">D</span><span class="label">Port 3389</span></button>
+
+              <div class="free-note reveal">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 8v4l3 2"></path></svg>
+                <p>This check is <b>free and never counts against your daily 15</b>. There are no wrong answers here, only a read on where you are starting.</p>
+              </div>
+            </div>
+
+            <div class="footer">
+              <button class="btn-primary" type="button">Next question</button>
+              <button class="btn-text" type="button">Skip the check</button>
+            </div>
+          </div>
+
+          <!-- ── (B) Your readiness ── -->
+          <div class="moment" id="momentB" role="tabpanel" aria-labelledby="chipB">
+            <div class="hdr">
+              <h1>Your readiness</h1>
+              <span class="plan-tag">Free</span>
+            </div>
+
+            <div class="body">
+              <p class="kicker reveal">Your starting point</p>
+
+              <div class="active-card reveal">
+                <div class="ac-top">
+                  <span class="mark">N+</span>
+                  <span><span class="nm">Network+</span><div class="cd">N10-009</div></span>
+                  <span class="ac-badge">Day one</span>
+                </div>
+                <div class="ac-score"><span class="ac-num" id="scoreNum">465</span><span class="ac-of">/ 900 readiness</span></div>
+                <div class="bar"><span id="scoreBar" style="width:51.6%"></span><span class="tick" style="left:80%"></span></div>
+                <div class="bar-legend"><span>100</span><span class="p">Pass 720</span><span>900</span></div>
+              </div>
+
+              <p class="frame-line reveal">A starting point, not a grade.</p>
+
+              <div class="aha reveal">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17l6-6 4 4 8-8"></path><path d="M21 7v4h-4"></path></svg>
+                <p>Practise a little and this number moves. Most people see it climb in their first few sessions, so the best read on your progress is the next one.</p>
+              </div>
+            </div>
+
+            <div class="footer">
+              <button class="btn-primary" type="button">Start practising</button>
+              <button class="btn-text" type="button">See how readiness works</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">A static design mockup. The check is skippable; the reveal frames the score as a starting point.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // option select within the check (single-choice, mockup)
+      var momentA = document.getElementById('momentA');
+      momentA.addEventListener('click', function(e){
+        var opt = e.target.closest('.opt'); if (!opt) return;
+        momentA.querySelectorAll('.opt').forEach(function(o){ o.classList.remove('sel'); });
+        opt.classList.add('sel');
+      });
+
+      // moment switcher
+      var chipA = document.getElementById('chipA'), chipB = document.getElementById('chipB');
+      var momentB = document.getElementById('momentB');
+      var scoreNum = document.getElementById('scoreNum'), scoreBar = document.getElementById('scoreBar');
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      var TARGET = 465;
+
+      function countUp(){
+        if (reduce) { scoreNum.textContent = TARGET; scoreBar.style.width = '51.6%'; return; }
+        scoreBar.style.transition = 'none'; scoreBar.style.width = '0%';
+        var start = null, dur = 850;
+        // settle from 0 to 51.6% on the bar
+        requestAnimationFrame(function(){ scoreBar.style.transition = 'width .85s cubic-bezier(0.16,1,0.3,1)'; scoreBar.style.width = '51.6%'; });
+        function step(ts){
+          if (start === null) start = ts;
+          var t = Math.min((ts - start) / dur, 1);
+          var eased = 1 - Math.pow(1 - t, 3);
+          scoreNum.textContent = Math.round(100 + (TARGET - 100) * eased);
+          if (t < 1) requestAnimationFrame(step); else scoreNum.textContent = TARGET;
+        }
+        requestAnimationFrame(step);
+      }
+
+      function show(which){
+        var aOn = which === 'A';
+        chipA.setAttribute('aria-selected', aOn ? 'true' : 'false');
+        chipB.setAttribute('aria-selected', aOn ? 'false' : 'true');
+        momentA.classList.toggle('active', aOn);
+        momentB.classList.toggle('active', !aOn);
+        if (!aOn) countUp();
+      }
+      chipA.addEventListener('click', function(){ show('A'); });
+      chipB.addEventListener('click', function(){ show('B'); });
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-free-home-day0.html
+++ b/mockups/onboarding-free-home-day0.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Free home (day 0)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .home { flex: 1; padding: 10px 20px 24px; overflow-y: auto; }
+  .home::-webkit-scrollbar { width: 0; }
+
+  /* greeting */
+  .greet { margin: 10px 2px 4px; }
+  .greet .hi { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent-bright); margin-bottom: 7px; }
+  .greet h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; line-height: 1.12; letter-spacing: -0.015em; margin: 0; color: var(--ink); }
+
+  /* free home bar (fresh state) - same .hb family as the capped home */
+  .hb { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 14px 15px; margin-top: 14px; }
+  .hb-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px; }
+  .hb-cert { display: inline-flex; align-items: center; gap: 9px; min-width: 0; }
+  .hb-mark { flex: 0 0 auto; width: 34px; height: 34px; border-radius: 9px; background: color-mix(in oklab, var(--accent) 14%, var(--surface-2)); color: var(--accent-deep); display: grid; place-items: center; font: 800 13px/1 Inter, sans-serif; }
+  .hb-name { font: 650 15px/1.1 Inter, sans-serif; color: var(--ink); }
+  .hb-code { font: 600 11.5px/1 'Roboto Mono', monospace; color: var(--muted); margin-top: 3px; }
+  .hb-plan { flex: 0 0 auto; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 5px 9px; }
+  .hb-quota { border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); padding-top: 4px; }
+  .hb-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 0; }
+  .hb-row + .hb-row { border-top: 1px solid color-mix(in oklab, var(--border) 55%, transparent); }
+  .hb-rn { font-size: 13.5px; color: var(--ink-soft); }
+  .hb-rv { font: 600 13px/1 Inter, sans-serif; color: var(--ink); }
+  .hb-full { display: inline-flex; align-items: center; gap: 6px; font: 700 11.5px/1 Inter, sans-serif; color: var(--pass); background: color-mix(in oklab, var(--pass) 12%, transparent); border: 1px solid color-mix(in oklab, var(--pass) 30%, var(--border)); border-radius: 999px; padding: 6px 10px; }
+  .hb-full svg { width: 12px; height: 12px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* readiness placeholder (no score yet) */
+  .ready { margin-top: 14px; border: 1px dashed color-mix(in oklab, var(--accent) 34%, var(--border)); border-radius: 16px; background: color-mix(in oklab, var(--accent) 4%, var(--surface)); padding: 16px 15px; display: flex; align-items: center; gap: 14px; }
+  .ready-dial { flex: 0 0 auto; width: 52px; height: 52px; border-radius: 999px; display: grid; place-items: center; background: var(--surface); border: 2px dashed color-mix(in oklab, var(--accent) 40%, var(--border)); }
+  .ready-dial svg { width: 22px; height: 22px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .ready-t { font: 650 14px/1.15 Inter, sans-serif; color: var(--ink); }
+  .ready-s { font-size: 12.5px; line-height: 1.45; color: var(--ink-soft); margin-top: 3px; }
+
+  /* first-run diagnostic invite (the prominent card) */
+  .diag { margin-top: 16px; border: 1px solid color-mix(in oklab, var(--accent) 38%, var(--border)); border-radius: 18px; background: color-mix(in oklab, var(--accent) 8%, var(--surface)); padding: 17px 16px; }
+  .diag-head { display: flex; align-items: center; gap: 12px; margin-bottom: 11px; }
+  .diag-badge { flex: 0 0 auto; width: 42px; height: 42px; border-radius: 12px; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 16%, var(--surface-2)); }
+  .diag-badge svg { width: 22px; height: 22px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .diag-kick { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 5px; }
+  .diag-h { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 18px; line-height: 1.15; letter-spacing: -0.01em; color: var(--ink); }
+  .diag-p { font-size: 12.8px; line-height: 1.5; color: var(--ink-soft); margin: 0 0 14px; }
+  .diag-p b { color: var(--ink); font-weight: 650; }
+  .btn-primary { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+  /* secondary path: just start practising */
+  .start { margin-top: 14px; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 16px; }
+  .start-head { display: flex; align-items: center; gap: 12px; margin-bottom: 13px; }
+  .start-ring { flex: 0 0 auto; width: 44px; height: 44px; border-radius: 999px; display: grid; place-items: center; background: var(--surface); border: 2px solid color-mix(in oklab, var(--accent) 45%, var(--border)); font-family: Fraunces, serif; font-weight: 600; font-size: 18px; color: var(--accent-deep); font-variant-numeric: lining-nums; font-feature-settings: "lnum"; }
+  .start-t { font: 650 15px/1.1 Inter, sans-serif; color: var(--ink); }
+  .start-s { font-size: 12.5px; color: var(--ink-soft); margin-top: 3px; }
+  .btn-ghost { width: 100%; border: 1px solid color-mix(in oklab, var(--accent) 36%, var(--border)); border-radius: 13px; padding: 13px; cursor: pointer; background: transparent; color: var(--accent-bright); font: 650 14px/1 Inter, sans-serif; transition: background .2s, transform .15s var(--ease); }
+  .btn-ghost:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-ghost:hover { background: color-mix(in oklab, var(--accent) 8%, transparent); } }
+
+  .aha { display: flex; align-items: center; gap: 8px; justify-content: center; margin-top: 18px; font-size: 12px; color: var(--muted); }
+  .aha svg { width: 14px; height: 14px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(10px); animation: rise .5s var(--ease) forwards; }
+    .greet { animation-delay: .04s; } .hb { animation-delay: .10s; } .ready { animation-delay: .16s; } .diag { animation-delay: .24s; } .start { animation-delay: .32s; } .aha { animation-delay: .40s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Free · day 0</p>
+        <h1 class="stage-title">Free home (day 0)</h1>
+        <p class="stage-sub">The first home a free user sees right after locking their exam, before doing anything. A full quota waits, there's no readiness score yet, and a 30-second check is offered to place one.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="home">
+            <div class="greet reveal">
+              <div class="hi">Your exam is set</div>
+              <h2>Let's place your readiness.</h2>
+            </div>
+
+            <div class="hb reveal">
+              <div class="hb-top">
+                <div class="hb-cert"><span class="hb-mark">N+</span><span><span class="hb-name">Network+</span><div class="hb-code">N10-009</div></span></div>
+                <span class="hb-plan">Free</span>
+              </div>
+              <div class="hb-quota">
+                <div class="hb-row"><span class="hb-rn">New practice</span><span class="hb-full"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>15 of 15 ready</span></div>
+                <div class="hb-row"><span class="hb-rn">Daily Review</span><span class="hb-rv">5 ready when you have cards</span></div>
+              </div>
+            </div>
+
+            <div class="ready reveal">
+              <span class="ready-dial"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 14l4-4"></path><path d="M3.5 18a9 9 0 1 1 17 0"></path></svg></span>
+              <div>
+                <div class="ready-t">Readiness: not placed yet</div>
+                <div class="ready-s">Scored 100 to 900, with 720 to pass. Answer a few and it appears here.</div>
+              </div>
+            </div>
+
+            <div class="diag reveal">
+              <div class="diag-head">
+                <span class="diag-badge"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20v-6"></path><path d="M6 20v-3"></path><path d="M18 20v-9"></path><path d="M4 11l6-5 4 3 6-6"></path></svg></span>
+                <div><div class="diag-kick">Recommended first step</div><div class="diag-h">Place your readiness</div></div>
+              </div>
+              <p class="diag-p">A 30-second check, free, and it never counts against <b>your daily 15</b>. It gives you a starting number so you can watch it move.</p>
+              <button class="btn-primary" type="button">Take the 30-second check</button>
+            </div>
+
+            <div class="start reveal">
+              <div class="start-head">
+                <div class="start-ring">15</div>
+                <div><div class="start-t">Just start practising</div><div class="start-s">Skip the check and dive into today's 15. Your readiness still builds as you go.</div></div>
+              </div>
+              <button class="btn-ghost" type="button">Start today's 15</button>
+            </div>
+
+            <div class="aha reveal">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17l6-6 4 4 8-8"></path><path d="M21 7v5h-5"></path></svg>
+              <span>Answer a few and watch your readiness move.</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Fresh counterpart to the "done for today" capped home: full quota, no score yet.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-loading-states.html
+++ b/mockups/onboarding-loading-states.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Loading and offline</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* chip row: switches which state the phone shows */
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
+  .chip { font: 650 12.5px/1 Inter, sans-serif; color: var(--page-dim); background: transparent;
+    border: 1px solid color-mix(in oklab, var(--page-dim) 34%, transparent); border-radius: 999px; padding: 9px 14px; cursor: pointer;
+    transition: transform .15s var(--ease), background .2s, border-color .2s, color .2s; }
+  .chip:active { transform: scale(0.96); }
+  @media (hover:hover) and (pointer:fine) { .chip:hover { border-color: color-mix(in oklab, var(--accent-bright) 45%, var(--page-dim)); color: var(--page-ink); } }
+  .chip[aria-pressed="true"] { color: var(--on-accent); background: var(--accent); border-color: var(--accent); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .home { flex: 1; padding: 10px 20px 24px; overflow-y: auto; }
+  .home::-webkit-scrollbar { width: 0; }
+
+  /* state switching */
+  .state { display: none; }
+  .state.on { display: block; }
+
+  /* ── skeleton primitives (match the real home layout shape) ── */
+  .sk { background: color-mix(in oklab, var(--ink) 9%, var(--surface-2)); border-radius: 7px; position: relative; overflow: hidden; }
+  @media (prefers-reduced-motion: no-preference) {
+    .sk::after { content: ""; position: absolute; inset: 0; transform: translateX(-100%);
+      background: linear-gradient(90deg, transparent, color-mix(in oklab, var(--ink) 7%, transparent), transparent);
+      animation: shimmer 1.5s var(--ease) infinite; }
+    @keyframes shimmer { to { transform: translateX(100%); } }
+  }
+  .sk-line { height: 12px; }
+  .sk-line.sm { height: 10px; }
+  .sk-line.lg { height: 16px; }
+
+  /* skeleton home bar - same shape as the real .hb */
+  .skb { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 14px 15px; margin-top: 8px; }
+  .skb-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 14px; }
+  .skb-cert { display: inline-flex; align-items: center; gap: 9px; min-width: 0; }
+  .sk-mark { flex: 0 0 auto; width: 34px; height: 34px; border-radius: 9px; }
+  .sk-stack { display: flex; flex-direction: column; gap: 6px; }
+  .sk-plan { flex: 0 0 auto; width: 44px; height: 22px; border-radius: 999px; }
+  .skb-quota { border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); padding-top: 4px; }
+  .skb-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 11px 0; }
+  .skb-row + .skb-row { border-top: 1px solid color-mix(in oklab, var(--border) 55%, transparent); }
+
+  /* skeleton "start practice" card - matches the real .review card shape */
+  .skcard { margin-top: 20px; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 16px; }
+  .skcard-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+  .sk-ring { flex: 0 0 auto; width: 44px; height: 44px; border-radius: 999px; }
+  .sk-btn { height: 48px; border-radius: 13px; margin-top: 2px; }
+
+  /* quiet status line under the skeleton */
+  .sk-note { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 20px; color: var(--muted); font-size: 12.5px; }
+  .sk-note svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  @media (prefers-reduced-motion: no-preference) {
+    .sk-note svg { animation: spin 1.1s linear infinite; transform-origin: center; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  }
+
+  /* ── offline state ── */
+  .off { display: flex; flex-direction: column; align-items: center; text-align: center; padding: 64px 6px 0; }
+  .off-glyph { width: 60px; height: 60px; border-radius: 17px; display: grid; place-items: center; margin-bottom: 18px;
+    background: color-mix(in oklab, var(--accent) 13%, var(--surface-2)); }
+  .off-glyph svg { width: 28px; height: 28px; stroke: var(--accent-deep); fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .off h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; line-height: 1.14; letter-spacing: -0.014em; margin: 0 0 10px; color: var(--ink); }
+  .off p { font-size: 14px; line-height: 1.55; color: var(--ink-soft); margin: 0 auto; max-width: 32ch; }
+  .off p b { color: var(--ink); font-weight: 650; }
+  .saved { margin-top: 20px; display: inline-flex; align-items: center; gap: 9px; padding: 11px 15px;
+    border: 1px solid color-mix(in oklab, var(--pass) 32%, var(--border)); border-radius: 999px;
+    background: color-mix(in oklab, var(--pass) 9%, var(--surface)); }
+  .saved svg { width: 15px; height: 15px; stroke: var(--pass); fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .saved span { font: 650 12.5px/1 Inter, sans-serif; color: var(--ink); }
+
+  /* subtle offline indicator pinned at the top of the screen body */
+  .off-bar { display: flex; align-items: center; justify-content: center; gap: 8px; margin: 8px 0 2px;
+    padding: 8px 12px; border-radius: 999px; background: color-mix(in oklab, var(--ink) 6%, var(--surface));
+    border: 1px solid var(--border); color: var(--muted); font: 650 11.5px/1 Inter, sans-serif; }
+  .off-bar .dot { width: 7px; height: 7px; border-radius: 999px; background: var(--muted); }
+  @media (prefers-reduced-motion: no-preference) {
+    .off-bar .dot { animation: pulse 1.8s var(--ease) infinite; }
+    @keyframes pulse { 0%,100% { opacity: .45; } 50% { opacity: 1; } }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .off.on { opacity: 0; transform: translateY(9px); animation: rise .5s var(--ease) forwards; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Onboarding · loading and offline</p>
+        <h1 class="stage-title">Loading and offline</h1>
+        <p class="stage-sub">What the home screen shows while it's still settling, and what happens when the connection drops. Skeletons hold the real layout in place so nothing flashes or jumps. Tap a chip to switch states.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="chips" id="chips" role="tablist" aria-label="Loading state">
+      <button class="chip" type="button" data-state="restore" aria-pressed="true">Session restore</button>
+      <button class="chip" type="button" data-state="content" aria-pressed="false">Content loading</button>
+      <button class="chip" type="button" data-state="offline" aria-pressed="false">Offline</button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="home">
+            <!-- Session restore skeleton: neutral home shape, holds the screen so no landing flash -->
+            <section class="state on" data-state="restore">
+              <div class="skb">
+                <div class="skb-top">
+                  <div class="skb-cert">
+                    <span class="sk sk-mark"></span>
+                    <span class="sk-stack"><span class="sk sk-line" style="width:96px"></span><span class="sk sk-line sm" style="width:60px"></span></span>
+                  </div>
+                  <span class="sk sk-plan"></span>
+                </div>
+                <div class="skb-quota">
+                  <div class="skb-row"><span class="sk sk-line" style="width:104px"></span><span class="sk sk-line sm" style="width:64px"></span></div>
+                  <div class="skb-row"><span class="sk sk-line" style="width:88px"></span><span class="sk sk-line sm" style="width:108px"></span></div>
+                </div>
+              </div>
+              <div class="skcard">
+                <div class="skcard-head">
+                  <span class="sk sk-ring"></span>
+                  <span class="sk-stack"><span class="sk sk-line lg" style="width:120px"></span><span class="sk sk-line sm" style="width:170px"></span></span>
+                </div>
+                <span class="sk sk-btn" style="display:block;width:100%"></span>
+              </div>
+              <div class="sk-note">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"></path><path d="M21 4v4h-4"></path></svg>
+                <span>Picking up where you left off</span>
+              </div>
+            </section>
+
+            <!-- Content loading skeleton: same home shape, cards loading in -->
+            <section class="state" data-state="content">
+              <div class="skb">
+                <div class="skb-top">
+                  <div class="skb-cert">
+                    <span class="sk sk-mark"></span>
+                    <span class="sk-stack"><span class="sk sk-line" style="width:96px"></span><span class="sk sk-line sm" style="width:60px"></span></span>
+                  </div>
+                  <span class="sk sk-plan"></span>
+                </div>
+                <div class="skb-quota">
+                  <div class="skb-row"><span class="sk sk-line" style="width:104px"></span><span class="sk sk-line sm" style="width:64px"></span></div>
+                  <div class="skb-row"><span class="sk sk-line" style="width:88px"></span><span class="sk sk-line sm" style="width:108px"></span></div>
+                </div>
+              </div>
+              <div class="skcard">
+                <div class="skcard-head">
+                  <span class="sk sk-ring"></span>
+                  <span class="sk-stack"><span class="sk sk-line lg" style="width:108px"></span><span class="sk sk-line sm" style="width:188px"></span></span>
+                </div>
+                <span class="sk sk-btn" style="display:block;width:100%"></span>
+              </div>
+              <div class="skcard">
+                <div class="skcard-head">
+                  <span class="sk sk-ring"></span>
+                  <span class="sk-stack"><span class="sk sk-line lg" style="width:96px"></span><span class="sk sk-line sm" style="width:150px"></span></span>
+                </div>
+                <span class="sk sk-btn" style="display:block;width:100%"></span>
+              </div>
+            </section>
+
+            <!-- Offline: honest, reassuring, progress safe -->
+            <section class="state" data-state="offline">
+              <div class="off-bar"><span class="dot"></span>Offline</div>
+              <div class="off">
+                <span class="off-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2 8.8a16 16 0 0 1 20 0"></path><path d="M5 12.5a11 11 0 0 1 14 0"></path><path d="M8.5 16a6 6 0 0 1 7 0"></path><path d="M12 20h.01"></path><path d="M3 3l18 18"></path></svg></span>
+                <h2>You're offline.</h2>
+                <p>Your progress is <b>saved on this device</b> and will sync when you're back. Nothing is lost, so you can keep going or pick up later.</p>
+                <span class="saved">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>
+                  <span>Saved locally, will sync</span>
+                </span>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Skeletons mirror the real home layout, so the screen never flashes a landing page or empty state.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // chip selector switches which state the phone shows
+      var chips = document.getElementById('chips');
+      var states = document.querySelectorAll('.state');
+      function show(name){
+        states.forEach(function(s){ s.classList.toggle('on', s.getAttribute('data-state') === name); });
+        chips.querySelectorAll('.chip').forEach(function(c){ c.setAttribute('aria-pressed', String(c.getAttribute('data-state') === name)); });
+      }
+      chips.addEventListener('click', function(e){
+        var chip = e.target.closest('.chip'); if (!chip) return;
+        show(chip.getAttribute('data-state'));
+      });
+      show('restore');
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-magic-link-sent.html
+++ b/mockups/onboarding-magic-link-sent.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Check your inbox</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). Dark :root, light override; light is primary. ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --apple-bg: oklch(0.98 0.004 275); --apple-fg: oklch(0.16 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.985 0.006 85); --surface: oklch(0.965 0.008 84); --surface-2: oklch(0.93 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --apple-bg: oklch(0.17 0.010 280); --apple-fg: oklch(0.98 0.004 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* phone */
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  /* preview state chips (stage chrome, sits above the phone body) */
+  .chips { display: flex; align-items: center; gap: 7px; padding: 12px 22px 4px; }
+  .chips .chips-label { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-right: 2px; }
+  .chip { border: 1px solid var(--border); background: var(--surface); color: var(--muted); border-radius: 999px; padding: 7px 12px; cursor: pointer; font: 650 11.5px/1 Inter, sans-serif; transition: color .18s, background .18s, border-color .18s, transform .14s var(--ease); }
+  .chip:active { transform: scale(0.96); }
+  @media (hover:hover) and (pointer:fine) { .chip:hover { border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); } }
+  .chip.active { color: var(--ink); background: color-mix(in oklab, var(--accent) 9%, var(--surface)); border-color: color-mix(in oklab, var(--accent) 50%, var(--border)); }
+
+  /* check-inbox layout */
+  .inbox { flex: 1; display: flex; flex-direction: column; padding: 6px 30px 26px; }
+  .topbar { display: flex; align-items: center; gap: 10px; margin-top: 12px; }
+  .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .15s var(--ease), border-color .18s; }
+  .back:active { transform: scale(0.95); }
+  @media (hover:hover) and (pointer:fine) { .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .brand-mark { width: 26px; height: 26px; color: var(--accent); display: inline-flex; margin-left: 2px; }
+  .brand-mark svg { width: 100%; height: 100%; }
+  .brand-name { font: 700 15px/1 Inter, sans-serif; letter-spacing: -0.01em; color: var(--ink); }
+
+  .inbox-body { display: flex; flex-direction: column; align-items: center; text-align: center; margin-top: 38px; }
+
+  /* brand stroke envelope icon: same line-icon language as the sibling mockups */
+  .env { width: 76px; height: 76px; border-radius: 22px; display: grid; place-items: center; margin-bottom: 22px;
+    background: color-mix(in oklab, var(--accent) 12%, var(--surface-2)); border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)); }
+  .env svg { width: 38px; height: 38px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+
+  .inbox-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 27px; line-height: 1.1; letter-spacing: -0.015em; margin: 0; color: var(--ink); }
+  .inbox-sub { font-size: 14px; line-height: 1.55; color: var(--ink-soft); margin: 11px 0 0; max-width: 32ch; }
+  .inbox-sub .addr { color: var(--accent-deep); font-weight: 650; }
+
+  .actions { width: 100%; display: flex; flex-direction: column; gap: 11px; margin-top: 26px; }
+  .btn-primary { width: 100%; border: none; border-radius: 14px; padding: 15px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 12px 26px -14px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  .btn-outline { width: 100%; border: 1px solid var(--border); border-radius: 14px; padding: 14px; cursor: pointer; background: var(--surface); color: var(--ink); font: 650 14.5px/1 Inter, sans-serif; transition: transform .15s var(--ease), border-color .2s, opacity .2s, color .2s; }
+  .btn-outline:active { transform: scale(0.985); }
+  .btn-outline[disabled] { opacity: 0.55; cursor: default; color: var(--muted); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } .btn-outline:not([disabled]):hover { border-color: color-mix(in oklab, var(--accent) 45%, var(--border)); } }
+
+  /* resend status line under the secondary button */
+  .resend-note { font-size: 12px; line-height: 1.4; color: var(--muted); margin: 12px 0 0; min-height: 16px; transition: color .2s; }
+  .resend-note.ok { color: var(--accent-deep); font-weight: 600; }
+
+  .change-link { background: none; border: none; cursor: pointer; font: 600 13px/1 Inter, sans-serif; color: var(--accent-bright); padding: 8px; margin-top: 18px; transition: transform .15s var(--ease), opacity .2s; }
+  .change-link:active { transform: scale(0.97); }
+
+  .expiry { margin-top: auto; padding-top: 22px; display: flex; align-items: center; justify-content: center; gap: 7px; color: var(--muted); font-size: 11.5px; }
+  .expiry svg { width: 13px; height: 13px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* faithful iOS Mail representation (neutral system style, distinct from app UI) */
+  .mailsheet-scrim { position: absolute; inset: 0; background: color-mix(in oklab, #07080b 52%, transparent); opacity: 0; pointer-events: none; transition: opacity .28s var(--ease); z-index: 8; }
+  .mailsheet-scrim.open { opacity: 1; pointer-events: auto; }
+  .mailapp { position: absolute; inset: 0; z-index: 9; background: #f2f2f7; color: #1c1c1e;
+    display: flex; flex-direction: column; transform: translateY(101%); transition: transform .36s var(--ease-drawer); will-change: transform;
+    font: 15px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Text", Inter, sans-serif; }
+  .mailapp.open { transform: none; }
+  .mail-statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 -apple-system, sans-serif; color: #1c1c1e; }
+  .mail-statusbar .sb-icons svg { fill: #1c1c1e; }
+  .mail-nav { display: flex; align-items: center; justify-content: space-between; padding: 8px 16px 6px; }
+  .mail-back { display: inline-flex; align-items: center; gap: 2px; color: #007aff; font: 400 16px/1 -apple-system, sans-serif; background: none; border: none; cursor: pointer; padding: 4px; }
+  .mail-back svg { width: 12px; height: 20px; stroke: #007aff; fill: none; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; }
+  .mail-edit { color: #007aff; font: 400 16px/1 -apple-system, sans-serif; background: none; border: none; cursor: pointer; padding: 4px; }
+  .mail-h { font: 700 30px/1.1 -apple-system, sans-serif; letter-spacing: -0.02em; color: #1c1c1e; padding: 4px 18px 8px; }
+  .mail-search { margin: 0 16px 8px; background: #e3e3e8; border-radius: 10px; padding: 9px 12px; display: flex; align-items: center; gap: 7px; color: #8e8e93; font-size: 15px; }
+  .mail-search svg { width: 15px; height: 15px; stroke: #8e8e93; fill: none; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+  .mail-list { flex: 1; overflow-y: auto; background: #fff; }
+  .mail-row { display: flex; gap: 11px; padding: 12px 16px; border-bottom: 0.5px solid #d8d8dc; cursor: pointer; }
+  .mail-row:active { background: #d1d1d6; }
+  .mail-dot { flex: 0 0 auto; width: 9px; height: 9px; border-radius: 999px; background: #007aff; margin-top: 7px; }
+  .mail-dot.read { background: transparent; }
+  .mail-rowmain { flex: 1; min-width: 0; }
+  .mail-toprow { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+  .mail-from { font: 600 15px/1.2 -apple-system, sans-serif; color: #000; }
+  .mail-time { flex: 0 0 auto; font-size: 13px; color: #8e8e93; display: inline-flex; align-items: center; gap: 4px; }
+  .mail-time svg { width: 11px; height: 16px; stroke: #c7c7cc; fill: none; stroke-width: 2.4; }
+  .mail-subj { font: 400 14px/1.3 -apple-system, sans-serif; color: #1c1c1e; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mail-prev { font: 400 14px/1.35 -apple-system, sans-serif; color: #8e8e93; margin-top: 2px; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+  .mail-hint { text-align: center; font-size: 12px; color: #8e8e93; padding: 14px 16px calc(14px + env(safe-area-inset-bottom)); background: #fff; }
+  .mail-close { display: block; margin: 0 auto; color: #007aff; font: 600 15px/1 -apple-system, sans-serif; background: none; border: none; cursor: pointer; padding: 6px 10px; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(10px); animation: rise .5s var(--ease) forwards; }
+    .topbar { animation-delay: .02s; } .env { animation-delay: .08s; } .inbox-title { animation-delay: .14s; }
+    .inbox-sub { animation-delay: .19s; } .actions { animation-delay: .25s; } .resend-note { animation-delay: .30s; }
+    .change-link { animation-delay: .35s; } .expiry { animation-delay: .40s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .mailsheet-scrim, .mailapp { transition: none; }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Account · magic link</p>
+        <h1 class="stage-title">Check your inbox</h1>
+        <p class="stage-sub">The interstitial after a user enters their email at sign up or sign in. We sent a one-tap link, so there is nothing to type back here. Use the chips to preview each state.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="chips">
+      <span class="chips-label">State</span>
+      <button class="chip active" data-state="sent" type="button">Just sent</button>
+      <button class="chip" data-state="cooldown" type="button">Resend cooldown</button>
+      <button class="chip" data-state="resent" type="button">Resent</button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="inbox">
+            <div class="topbar reveal">
+              <button class="back" type="button" aria-label="Back to sign in"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+              <span class="brand-mark" aria-hidden="true">
+                <svg viewBox="0 0 100 100" fill="none">
+                  <path class="ca-c" d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+                  <line class="ca-slash" x1="30" y1="84" x2="70" y2="16" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+                  <path class="ca-a" d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+              <span class="brand-name">CertAnvil</span>
+            </div>
+
+            <div class="inbox-body">
+              <span class="env reveal" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><rect x="2.5" y="5" width="19" height="14" rx="2.5"></rect><path d="M3 7l9 6 9-6"></path></svg>
+              </span>
+              <h1 class="inbox-title reveal">Check your inbox</h1>
+              <p class="inbox-sub reveal">We sent a one-tap sign-in link to <span class="addr">you@gmail.com</span>. Tap it and you're in. No password to remember.</p>
+
+              <div class="actions reveal">
+                <button class="btn-primary" id="openMail" type="button">Open Mail</button>
+                <button class="btn-outline" id="resendBtn" type="button">Resend link</button>
+              </div>
+              <p class="resend-note reveal" id="resendNote"></p>
+
+              <button class="change-link reveal" type="button">Wrong email? Change it</button>
+            </div>
+
+            <p class="expiry reveal">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 2"></path></svg>
+              The link expires in 15 minutes.
+            </p>
+          </div>
+
+          <!-- iOS Mail (neutral system UI, faithful, distinct from the app) -->
+          <div class="mailsheet-scrim" id="mailScrim"></div>
+          <div class="mailapp" id="mailApp" role="dialog" aria-modal="true" aria-label="Mail">
+            <div class="mail-statusbar">
+              <span>9:41</span>
+              <span class="sb-icons">
+                <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+                <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+              </span>
+            </div>
+            <div class="mail-nav">
+              <button class="mail-back" type="button"><svg viewBox="0 0 12 20" aria-hidden="true"><path d="M10 2L2 10l8 8"></path></svg>Mailboxes</button>
+              <button class="mail-edit" type="button">Edit</button>
+            </div>
+            <div class="mail-h">Inbox</div>
+            <div class="mail-search">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4-4"></path></svg>
+              Search
+            </div>
+            <div class="mail-list">
+              <div class="mail-row">
+                <span class="mail-dot"></span>
+                <div class="mail-rowmain">
+                  <div class="mail-toprow">
+                    <span class="mail-from">CertAnvil</span>
+                    <span class="mail-time">9:41 AM <svg viewBox="0 0 12 20" aria-hidden="true"><path d="M2 2l8 8-8 8"></path></svg></span>
+                  </div>
+                  <div class="mail-subj">Your sign-in link</div>
+                  <div class="mail-prev">Tap to sign in to CertAnvil. This link works once and expires in 15 minutes. If you did not ask for it, you can ignore this email.</div>
+                </div>
+              </div>
+              <div class="mail-row">
+                <span class="mail-dot read"></span>
+                <div class="mail-rowmain">
+                  <div class="mail-toprow">
+                    <span class="mail-from">CompTIA</span>
+                    <span class="mail-time">8:12 AM <svg viewBox="0 0 12 20" aria-hidden="true"><path d="M2 2l8 8-8 8"></path></svg></span>
+                  </div>
+                  <div class="mail-subj">Your exam voucher receipt</div>
+                  <div class="mail-prev">Thanks for your order. Your N10-009 voucher is attached and ready to schedule.</div>
+                </div>
+              </div>
+            </div>
+            <div class="mail-hint">
+              <button class="mail-close" id="mailClose" type="button">Close Mail preview</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Tap a chip to preview a state. Open Mail shows the neutral iOS Mail view.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // state preview: just-sent, resend-cooldown, resent
+      var resendBtn = document.getElementById('resendBtn');
+      var note = document.getElementById('resendNote');
+      var chips = document.querySelectorAll('.chip');
+      var copy = {
+        sent:     { btn: 'Resend link', disabled: false, note: '',                        ok: false },
+        cooldown: { btn: 'Resend link', disabled: true,  note: 'You can resend in 30s.',   ok: false },
+        resent:   { btn: 'Resend link', disabled: false, note: 'Sent again. Check your inbox.', ok: true }
+      };
+      function apply(state){
+        var c = copy[state];
+        resendBtn.textContent = c.btn;
+        resendBtn.disabled = c.disabled;
+        note.textContent = c.note;
+        note.classList.toggle('ok', c.ok);
+        chips.forEach(function(ch){ ch.classList.toggle('active', ch.dataset.state === state); });
+      }
+      chips.forEach(function(ch){ ch.addEventListener('click', function(){ apply(ch.dataset.state); }); });
+      apply('sent');
+
+      // iOS Mail preview
+      var mailScrim = document.getElementById('mailScrim'), mailApp = document.getElementById('mailApp');
+      function openMail(){ mailScrim.classList.add('open'); mailApp.classList.add('open'); }
+      function closeMail(){ mailScrim.classList.remove('open'); mailApp.classList.remove('open'); }
+      document.getElementById('openMail').addEventListener('click', openMail);
+      document.getElementById('mailClose').addEventListener('click', closeMail);
+      mailScrim.addEventListener('click', closeMail);
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-manage-subscription.html
+++ b/mockups/onboarding-manage-subscription.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Manage subscription</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 10px; }
+  .hdr .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .14s var(--ease), border-color .18s; }
+  .hdr .back:active { transform: scale(0.94); }
+  @media (hover:hover) and (pointer:fine) { .hdr .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .hdr .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+  .hdr .plan-tag { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 12%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border)); border-radius: 999px; padding: 6px 9px; }
+
+  .body { flex: 1; overflow-y: auto; padding: 6px 22px 20px; }
+  .body::-webkit-scrollbar { width: 0; }
+  .sect { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin: 18px 2px 10px; }
+
+  /* current plan card */
+  .plan-now { border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border)); border-radius: 18px; background: color-mix(in oklab, var(--accent) 6%, var(--surface)); padding: 16px; margin-top: 6px; }
+  .pn-top { display: flex; align-items: center; gap: 12px; }
+  .pn-mark { flex: 0 0 auto; width: 44px; height: 44px; border-radius: 12px; background: color-mix(in oklab, var(--accent) 16%, var(--surface-2)); display: grid; place-items: center; }
+  .pn-mark svg { width: 22px; height: 22px; stroke: var(--accent-deep); fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .pn-name { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 20px; letter-spacing: -0.01em; color: var(--ink); display: flex; align-items: center; gap: 9px; }
+  .pn-active { font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: var(--pass); background: color-mix(in oklab, var(--pass) 14%, transparent); border: 1px solid color-mix(in oklab, var(--pass) 34%, var(--border)); border-radius: 999px; padding: 4px 7px; }
+  .pn-price { font-size: 12.5px; color: var(--ink-soft); margin-top: 4px; }
+  .pn-price b { color: var(--ink); font-weight: 650; font-variant-numeric: lining-nums; }
+  .pn-rows { margin-top: 14px; border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); padding-top: 4px; }
+  .pn-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 0; }
+  .pn-row + .pn-row { border-top: 1px solid color-mix(in oklab, var(--border) 55%, transparent); }
+  .pn-k { font-size: 13px; color: var(--ink-soft); }
+  .pn-v { font: 600 13px/1 Inter, sans-serif; color: var(--ink); }
+  .pn-v.mono { font-family: 'Roboto Mono', monospace; font-weight: 600; font-variant-numeric: lining-nums; }
+
+  /* saving callout */
+  .saving { margin-top: 14px; display: flex; align-items: flex-start; gap: 11px; border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)); border-radius: 14px; background: color-mix(in oklab, var(--accent) 6%, var(--surface)); padding: 12px 14px; }
+  .saving svg { flex: 0 0 auto; width: 18px; height: 18px; margin-top: 1px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .saving p { margin: 0; font-size: 12.5px; line-height: 1.5; color: var(--ink-soft); }
+  .saving b { color: var(--ink); font-weight: 650; }
+
+  /* switch plan row */
+  .switch { margin-top: 10px; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); overflow: hidden; }
+  .sw-opt { display: flex; align-items: center; gap: 12px; padding: 14px 15px; cursor: pointer; transition: background .18s, transform .12s var(--ease); }
+  .sw-opt:active { transform: scale(0.992); }
+  .sw-opt + .sw-opt { border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); }
+  .sw-radio { flex: 0 0 auto; width: 22px; height: 22px; border-radius: 999px; border: 2px solid color-mix(in oklab, var(--ink) 22%, var(--border)); display: grid; place-items: center; transition: border-color .18s, background .18s; }
+  .sw-radio svg { width: 13px; height: 13px; stroke: var(--on-accent); fill: none; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; opacity: 0; transform: scale(0.6); transition: opacity .15s var(--ease), transform .15s var(--ease); }
+  .sw-meta { flex: 1 1 auto; min-width: 0; }
+  .sw-nm { font: 650 14.5px/1.2 Inter, sans-serif; color: var(--ink); display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .sw-sub { font-size: 12px; color: var(--muted); margin-top: 3px; }
+  .sw-price { flex: 0 0 auto; text-align: right; font: 600 13.5px/1 Inter, sans-serif; color: var(--ink); font-variant-numeric: lining-nums; }
+  .sw-tag { font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 4px 7px; }
+  .save-pill { font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; color: var(--on-accent); background: var(--accent); border-radius: 999px; padding: 4px 7px; }
+  .sw-opt.sel { background: color-mix(in oklab, var(--accent) 8%, var(--surface-2)); }
+  .sw-opt.sel .sw-radio { border-color: var(--accent); background: var(--accent); }
+  .sw-opt.sel .sw-radio svg { opacity: 1; transform: none; }
+  .sw-current { font: 700 10px/1 Inter, sans-serif; letter-spacing: 0.04em; text-transform: uppercase; color: var(--accent-deep); }
+
+  /* guarantee line */
+  .guar { margin-top: 14px; display: flex; align-items: flex-start; gap: 11px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 12px 14px; }
+  .guar svg { flex: 0 0 auto; width: 18px; height: 18px; margin-top: 1px; stroke: var(--pass); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .guar p { margin: 0; font-size: 12.5px; line-height: 1.5; color: var(--ink-soft); }
+  .guar b { color: var(--ink); font-weight: 650; }
+
+  /* manage in App Store */
+  .btn-secondary { width: 100%; margin-top: 16px; border: 1px solid color-mix(in oklab, var(--accent) 40%, var(--border)); border-radius: 13px; padding: 14px; cursor: pointer; background: transparent; color: var(--accent-deep); font: 700 14.5px/1 Inter, sans-serif;
+    display: inline-flex; align-items: center; justify-content: center; gap: 9px; transition: background .2s, transform .15s var(--ease); }
+  .btn-secondary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-secondary:hover { background: color-mix(in oklab, var(--accent) 8%, transparent); } }
+  .btn-secondary svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .manage-note { font-size: 12px; line-height: 1.5; color: var(--muted); margin: 10px 2px 0; text-align: center; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(9px); animation: rise .5s var(--ease) forwards; }
+    .reveal:nth-child(1){animation-delay:.04s}.reveal:nth-child(2){animation-delay:.10s}.reveal:nth-child(3){animation-delay:.16s}
+    .reveal:nth-child(4){animation-delay:.22s}.reveal:nth-child(5){animation-delay:.28s}.reveal:nth-child(6){animation-delay:.34s}.reveal:nth-child(7){animation-delay:.40s}
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sw-opt:active, .btn-secondary:active, .theme-toggle:active, .hdr .back:active { transform: none; }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Settings · subscription</p>
+        <h1 class="stage-title">Manage subscription</h1>
+        <p class="stage-sub">Settings, then Subscription. Shows the current plan, an honest Annual-or-Monthly switch, and a plain handoff to Apple for billing and cancellation.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="hdr">
+            <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+            <h1>Subscription</h1>
+            <span class="plan-tag">Pro</span>
+          </div>
+
+          <div class="body">
+            <div class="sect reveal">Your plan</div>
+
+            <div class="plan-now reveal">
+              <div class="pn-top">
+                <span class="pn-mark"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l7 3v6c0 4-3 7-7 8-4-1-7-4-7-8V6z"></path><path d="M9 12l2 2 4-4" /></svg></span>
+                <div>
+                  <div class="pn-name">Pro Annual <span class="pn-active">Active</span></div>
+                  <div class="pn-price"><b>$89</b> / year</div>
+                </div>
+              </div>
+              <div class="pn-rows">
+                <div class="pn-row"><span class="pn-k">Renews</span><span class="pn-v">8 June 2027</span></div>
+                <div class="pn-row"><span class="pn-k">Price</span><span class="pn-v mono">$89.00 / yr</span></div>
+                <div class="pn-row"><span class="pn-k">Works out to</span><span class="pn-v">about $7.42 / mo</span></div>
+              </div>
+            </div>
+
+            <div class="saving reveal">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2l2.4 6.9H22l-6 4.4 2.3 7-6.3-4.4-6.3 4.4 2.3-7-6-4.4h7.6z"></path></svg>
+              <p>You're on <b>Annual</b> and saving <b>26%</b> versus paying monthly. That is about <b>$30 a year</b> back in your pocket.</p>
+            </div>
+
+            <div class="sect reveal">Switch plan</div>
+            <div class="switch reveal" id="switch">
+              <div class="sw-opt sel" data-plan="annual">
+                <span class="sw-radio"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg></span>
+                <div class="sw-meta">
+                  <div class="sw-nm">Pro Annual <span class="save-pill">Save 26%</span></div>
+                  <div class="sw-sub" id="annSub">Your current plan. About $7.42 / mo.</div>
+                </div>
+                <span class="sw-price">$89 / yr</span>
+              </div>
+              <div class="sw-opt" data-plan="monthly">
+                <span class="sw-radio"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg></span>
+                <div class="sw-meta">
+                  <div class="sw-nm">Pro Monthly</div>
+                  <div class="sw-sub" id="monSub">Pay month to month. Costs about $30 more a year.</div>
+                </div>
+                <span class="sw-price">$9.99 / mo</span>
+              </div>
+            </div>
+
+            <div class="guar reveal">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l7 3v6c0 4-3 7-7 8-4-1-7-4-7-8V6z"></path></svg>
+              <p><b>Pass-guarantee.</b> Pass your cert, or your money back. The window runs while your Pro plan is active.</p>
+            </div>
+
+            <button class="btn-secondary reveal" id="manageBtn" type="button">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 17L17 7M9 7h8v8"></path></svg>
+              Manage in App Store
+            </button>
+            <p class="manage-note">Billing and cancellation are handled in your Apple ID settings. Switching plans and cancelling both happen there, and your Pro access stays until the current period ends.</p>
+          </div>
+
+        </div>
+      </div>
+      <p class="hint">No cancel maze: the App Store button takes you straight to Apple's controls.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // plan switch preview (real switch is handled by Apple, this just previews the choice)
+      var sw = document.getElementById('switch');
+      sw.addEventListener('click', function(e){
+        var opt = e.target.closest('.sw-opt'); if (!opt) return;
+        sw.querySelectorAll('.sw-opt').forEach(function(o){ o.classList.toggle('sel', o === opt); });
+      });
+      document.getElementById('manageBtn').addEventListener('click', function(){ /* mockup: deep-links to the iOS App Store subscription screen */ });
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-notifications-prime.html
+++ b/mockups/onboarding-notifications-prime.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Turn on reminders</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 10px; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+  .hdr .step { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); background: color-mix(in oklab, var(--ink) 6%, transparent); border: 1px solid var(--border); border-radius: 999px; padding: 6px 9px; }
+
+  .body { flex: 1; overflow-y: auto; padding: 6px 22px 16px; display: flex; flex-direction: column; }
+  .body::-webkit-scrollbar { width: 0; }
+
+  /* hero bell */
+  .hero { text-align: center; margin: 18px 4px 4px; }
+  .bell-wrap { width: 80px; height: 80px; margin: 0 auto 18px; border-radius: 22px; display: grid; place-items: center;
+    background: color-mix(in oklab, var(--accent) 12%, var(--surface-2)); border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border)); }
+  .bell-wrap svg { width: 38px; height: 38px; stroke: var(--accent-deep); fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+  .hero h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 25px; line-height: 1.12; letter-spacing: -0.015em; margin: 0 0 10px; color: var(--ink); }
+  .hero p { font-size: 13.5px; line-height: 1.5; color: var(--ink-soft); margin: 0 auto; max-width: 36ch; }
+
+  /* what reminders cover */
+  .covers { list-style: none; margin: 22px 0 0; padding: 0; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); }
+  .covers li { display: flex; align-items: flex-start; gap: 12px; padding: 13px 15px; }
+  .covers li + li { border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); }
+  .ci { flex: 0 0 auto; width: 32px; height: 32px; border-radius: 9px; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 11%, var(--surface-2)); }
+  .ci svg { width: 17px; height: 17px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .ct { font: 650 13.5px/1.3 Inter, sans-serif; color: var(--ink); }
+  .cs { font-size: 12.5px; line-height: 1.45; color: var(--ink-soft); margin-top: 3px; }
+  .cs b { color: var(--ink); font-weight: 650; }
+
+  .quiet { display: flex; align-items: center; gap: 8px; justify-content: center; margin-top: 16px; font-size: 12px; color: var(--muted); }
+  .quiet svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* sticky action bar */
+  .footer { flex: 0 0 auto; padding: 12px 22px calc(12px + env(safe-area-inset-bottom)); border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent); background: var(--bg); }
+  .btn-primary { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+  .btn-ghost { width: 100%; border: none; border-radius: 13px; padding: 12px; margin-top: 8px; cursor: pointer; background: transparent; color: var(--ink-soft); font: 650 14px/1 Inter, sans-serif; transition: background .2s, transform .15s var(--ease); }
+  .btn-ghost:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-ghost:hover { background: color-mix(in oklab, var(--ink) 5%, transparent); } }
+
+  /* iOS system permission alert representation (neutral, NOT app-styled) */
+  .ios-scrim { position: absolute; inset: 0; background: rgba(0,0,0,0.28); opacity: 0; pointer-events: none; transition: opacity .26s var(--ease-drawer); z-index: 10; display: grid; place-items: center; }
+  .ios-scrim.open { opacity: 1; pointer-events: auto; }
+  .ios-alert { width: 270px; border-radius: 14px; overflow: hidden; text-align: center;
+    background: rgba(248,248,248,0.94); -webkit-backdrop-filter: blur(20px); backdrop-filter: blur(20px);
+    font-family: -apple-system, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif; color: #000;
+    box-shadow: 0 20px 60px -10px rgba(0,0,0,0.45); transform: scale(0.86); opacity: 0; transition: transform .26s var(--ease-drawer), opacity .2s; }
+  .ios-scrim.open .ios-alert { transform: none; opacity: 1; }
+  .ios-alert-body { padding: 18px 16px 14px; }
+  .ios-alert-title { font-size: 16px; font-weight: 600; line-height: 1.3; margin: 0 0 4px; letter-spacing: -0.01em; }
+  .ios-alert-msg { font-size: 12.5px; line-height: 1.35; color: rgba(0,0,0,0.86); margin: 0; }
+  .ios-alert-actions { display: flex; border-top: 0.5px solid rgba(0,0,0,0.22); }
+  .ios-btn { flex: 1; padding: 11px 6px; font-size: 16px; line-height: 1.1; color: #007aff; background: transparent; border: none; cursor: pointer; -webkit-tap-highlight-color: transparent; transition: background .12s ease; }
+  .ios-btn:active { background: rgba(0,0,0,0.06); }
+  .ios-btn + .ios-btn { border-left: 0.5px solid rgba(0,0,0,0.22); }
+  .ios-btn.bold { font-weight: 600; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(10px); animation: rise .5s var(--ease) forwards; }
+    .hero { animation-delay: .04s; } .covers { animation-delay: .14s; } .quiet { animation-delay: .22s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+    .covers li { opacity: 0; transform: translateY(7px); animation: rise .46s var(--ease) forwards; }
+    .covers li:nth-child(1) { animation-delay: .18s; }
+    .covers li:nth-child(2) { animation-delay: .24s; }
+    .covers li:nth-child(3) { animation-delay: .30s; }
+  }
+  @media (prefers-reduced-motion: reduce) { .ios-scrim, .ios-alert { transition: none; } }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Onboarding · before the system prompt</p>
+        <h1 class="stage-title">Turn on reminders</h1>
+        <p class="stage-sub">A short priming screen shown before iOS asks. It explains what a reminder is for, so the system prompt is an easy yes. Honest and benefit-framed, never naggy.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="hdr">
+            <h1>Stay on track</h1>
+            <span class="step">Almost done</span>
+          </div>
+
+          <div class="body">
+            <div class="hero reveal">
+              <div class="bell-wrap">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.7 21a2 2 0 0 1-3.4 0"></path></svg>
+              </div>
+              <h2>Keep your streak going</h2>
+              <p>A gentle daily nudge for your 15 questions and any reviews that are due, plus a heads-up as your exam gets close.</p>
+            </div>
+
+            <ul class="covers reveal">
+              <li>
+                <span class="ci"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2L3 14h7l-1 8 10-12h-7z"></path></svg></span>
+                <div><div class="ct">A daily practice nudge</div><div class="cs">One reminder a day for <b>your 15</b>, at a time that fits your routine.</div></div>
+              </li>
+              <li>
+                <span class="ci"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"></path><path d="M21 4v4h-4"></path></svg></span>
+                <div><div class="ct">Daily Review when cards are due</div><div class="cs">A quick ping when the cards you've missed come back around, so nothing slips.</div></div>
+              </li>
+              <li>
+                <span class="ci"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="16" rx="2"></rect><path d="M3 9h18M8 3v4M16 3v4"></path></svg></span>
+                <div><div class="ct">An exam countdown</div><div class="cs">A heads-up as <b>your exam</b> gets close, so the days don't sneak up on you.</div></div>
+              </li>
+            </ul>
+
+            <div class="quiet reveal">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>
+              <span>One a day at most. Turn it off any time in Settings.</span>
+            </div>
+          </div>
+
+          <div class="footer">
+            <button class="btn-primary" id="primeBtn" type="button">Turn on reminders</button>
+            <button class="btn-ghost" id="laterBtn" type="button">Maybe later</button>
+          </div>
+
+          <!-- iOS system permission alert REPRESENTATION (neutral system styling) -->
+          <div class="ios-scrim" id="iosScrim" role="dialog" aria-modal="true" aria-labelledby="iosTitle">
+            <div class="ios-alert">
+              <div class="ios-alert-body">
+                <p class="ios-alert-title" id="iosTitle">"CertAnvil" Would Like to Send You Notifications</p>
+                <p class="ios-alert-msg">Notifications may include alerts, sounds and icon badges. These can be configured in Settings.</p>
+              </div>
+              <div class="ios-alert-actions">
+                <button class="ios-btn" id="iosDeny" type="button">Don't Allow</button>
+                <button class="ios-btn bold" id="iosAllow" type="button">Allow</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Turn on reminders opens the real iOS prompt (shown here as a faithful mock).</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // priming -> iOS system prompt representation
+      var scrim = document.getElementById('iosScrim');
+      function openIos(){ scrim.classList.add('open'); }
+      function closeIos(){ scrim.classList.remove('open'); }
+      document.getElementById('primeBtn').addEventListener('click', openIos);
+      document.getElementById('iosAllow').addEventListener('click', closeIos);
+      document.getElementById('iosDeny').addEventListener('click', closeIos);
+      document.getElementById('laterBtn').addEventListener('click', function(){ /* mockup: real flow routes on to home without asking */ });
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-pro-iap.html
+++ b/mockups/onboarding-pro-iap.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Pay with Apple (Pro)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 10px; }
+  .hdr .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .14s var(--ease), border-color .18s; }
+  .hdr .back:active { transform: scale(0.94); }
+  @media (hover:hover) and (pointer:fine) { .hdr .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .hdr .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+  .hdr .plan-tag { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 12%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border)); border-radius: 999px; padding: 6px 9px; }
+
+  .body { flex: 1; overflow-y: auto; padding: 4px 22px 16px; }
+  .body::-webkit-scrollbar { width: 0; }
+  .sect { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin: 18px 2px 10px; }
+
+  /* plan summary card */
+  .plan-card { border: 1px solid var(--border); border-radius: 18px; background: var(--surface); padding: 6px; margin-top: 6px; }
+  .plan-opt { display: flex; align-items: center; gap: 12px; border-radius: 14px; padding: 13px 13px; cursor: pointer; position: relative; transition: background .18s, transform .12s var(--ease); }
+  .plan-opt:active { transform: scale(0.992); }
+  .plan-opt + .plan-opt { margin-top: 2px; }
+  .plan-radio { flex: 0 0 auto; width: 22px; height: 22px; border-radius: 999px; border: 2px solid color-mix(in oklab, var(--ink) 22%, var(--border)); display: grid; place-items: center; transition: border-color .18s, background .18s; }
+  .plan-radio svg { width: 13px; height: 13px; stroke: var(--on-accent); fill: none; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; opacity: 0; transform: scale(0.6); transition: opacity .15s var(--ease), transform .15s var(--ease); }
+  .plan-meta { flex: 1 1 auto; min-width: 0; }
+  .plan-nm { font: 650 15px/1.15 Inter, sans-serif; color: var(--ink); display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .plan-sub { font-size: 12.5px; color: var(--ink-soft); margin-top: 3px; }
+  .plan-price { flex: 0 0 auto; text-align: right; }
+  .plan-amt { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 18px; color: var(--ink); letter-spacing: -0.01em; font-variant-numeric: lining-nums; }
+  .plan-per { font-size: 11px; color: var(--muted); margin-top: 2px; }
+  .save-pill { font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; color: var(--on-accent); background: var(--accent); border-radius: 999px; padding: 4px 7px; }
+  .best-pill { font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 13%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); border-radius: 999px; padding: 4px 7px; }
+  .plan-opt.sel { background: color-mix(in oklab, var(--accent) 8%, var(--surface-2)); }
+  .plan-opt.sel .plan-radio { border-color: var(--accent); background: var(--accent); }
+  .plan-opt.sel .plan-radio svg { opacity: 1; transform: none; }
+
+  .anchor-note { font-size: 12px; line-height: 1.45; color: var(--muted); margin: 10px 4px 0; }
+  .anchor-note b { color: var(--ink-soft); font-weight: 650; }
+
+  /* what you get */
+  .gets { list-style: none; margin: 8px 0 0; padding: 0; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); overflow: hidden; }
+  .gets li { display: flex; align-items: flex-start; gap: 12px; padding: 12px 14px; }
+  .gets li + li { border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); }
+  .gi { flex: 0 0 auto; width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 11%, var(--surface-2)); }
+  .gi svg { width: 16px; height: 16px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .gt { font: 600 13.5px/1.35 Inter, sans-serif; color: var(--ink); }
+  .gt span { display: block; font-weight: 400; font-size: 12px; color: var(--muted); margin-top: 2px; }
+  .guarantee .gi { background: color-mix(in oklab, var(--pass) 14%, var(--surface-2)); }
+  .guarantee .gi svg { stroke: var(--pass); }
+
+  /* sticky purchase bar */
+  .footer { flex: 0 0 auto; padding: 12px 22px calc(12px + env(safe-area-inset-bottom)); border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent); background: var(--bg); }
+  .btn-apple { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    display: inline-flex; align-items: center; justify-content: center; gap: 9px;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s, opacity .2s; }
+  .btn-apple:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-apple:hover { filter: brightness(1.05); } }
+  .btn-apple svg { width: 17px; height: 17px; fill: var(--on-accent); }
+  .restore { display: block; width: 100%; text-align: center; background: none; border: none; cursor: pointer; font: 650 13px/1 Inter, sans-serif; color: var(--accent-deep); padding: 12px 0 4px; transition: opacity .18s; }
+  @media (hover:hover) and (pointer:fine) { .restore:hover { opacity: 0.75; } }
+  .foot-legal { text-align: center; font-size: 11px; line-height: 1.45; color: var(--muted); margin: 4px 0 0; }
+
+  /* ── Apple StoreKit system sheet (faithful REPRESENTATION, not real Apple UI) ── */
+  .scrim { position: absolute; inset: 0; background: color-mix(in oklab, #07080b 52%, transparent); opacity: 0; pointer-events: none; transition: opacity .28s var(--ease); z-index: 8; }
+  .scrim.open { opacity: 1; pointer-events: auto; }
+  /* the system sheet is deliberately neutral system-gray + SF-style, NOT the app's bronze */
+  .sk { position: absolute; left: 8px; right: 8px; bottom: 8px; z-index: 9;
+    font-family: -apple-system, "SF Pro Text", "Helvetica Neue", system-ui, sans-serif;
+    background: #f2f2f7; color: #1c1c1e; border-radius: 22px;
+    padding: 0 0 calc(10px + env(safe-area-inset-bottom)); transform: translateY(106%);
+    transition: transform .36s var(--ease-drawer); will-change: transform; box-shadow: 0 -24px 50px -22px rgba(0,0,0,0.5); }
+  .sk.open { transform: none; }
+  [data-theme="light"] .sk { background: #f2f2f7; }
+  html:not([data-theme="light"]) .sk { background: #1c1c1e; color: #f2f2f7; }
+  .sk-label { text-align: center; font: 600 10px/1 -apple-system, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; color: #8e8e93; padding: 9px 0 0; }
+  .sk-bar { display: flex; align-items: center; justify-content: space-between; padding: 8px 16px 10px; border-bottom: 0.5px solid rgba(120,120,128,0.3); }
+  .sk-cancel { background: none; border: none; cursor: pointer; font: 400 16px/1 -apple-system, sans-serif; color: #007aff; padding: 4px 2px; transition: opacity .15s; }
+  .sk-cancel:active { opacity: 0.5; }
+  .sk-acct { display: inline-flex; align-items: center; gap: 6px; font: 400 13px/1 -apple-system, sans-serif; color: #8e8e93; }
+  .sk-acct .dot { width: 18px; height: 18px; border-radius: 999px; background: #c7c7cc; display: grid; place-items: center; }
+  .sk-acct .dot svg { width: 11px; height: 11px; stroke: #6d6d72; fill: none; stroke-width: 2; }
+  html:not([data-theme="light"]) .sk-acct .dot { background: #3a3a3c; }
+  .sk-product { display: flex; align-items: center; gap: 13px; padding: 16px; }
+  .sk-icon { flex: 0 0 auto; width: 56px; height: 56px; border-radius: 13px; background: linear-gradient(160deg, #8a5a2b, #5e3a18); display: grid; place-items: center; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+  .sk-icon span { font: 700 22px/1 "SF Pro Display", -apple-system, sans-serif; color: #fff; }
+  .sk-pinfo { flex: 1 1 auto; min-width: 0; }
+  .sk-app { font: 600 17px/1.2 -apple-system, sans-serif; }
+  .sk-plan { font: 400 14px/1.3 -apple-system, sans-serif; color: #8e8e93; margin-top: 2px; }
+  .sk-amt { flex: 0 0 auto; font: 600 17px/1 -apple-system, sans-serif; }
+  .sk-row { display: flex; align-items: center; justify-content: space-between; padding: 11px 16px; border-top: 0.5px solid rgba(120,120,128,0.3); font: 400 14px/1.3 -apple-system, sans-serif; }
+  .sk-row .k { color: #8e8e93; }
+  .sk-row .v { color: inherit; }
+  .sk-confirm { margin: 14px 16px 8px; border-radius: 12px; background: #007aff; color: #fff; border: none; cursor: pointer; width: calc(100% - 32px);
+    padding: 13px; font: 600 16px/1 -apple-system, sans-serif; display: inline-flex; align-items: center; justify-content: center; gap: 9px; transition: opacity .15s, transform .15s var(--ease); }
+  .sk-confirm:active { transform: scale(0.985); opacity: 0.9; }
+  .sk-confirm svg { width: 16px; height: 16px; stroke: #fff; fill: none; stroke-width: 2; }
+  .sk-faceid { text-align: center; font: 400 12px/1.4 -apple-system, sans-serif; color: #8e8e93; margin: 2px 16px 0; }
+  .sk-legal { font: 400 11px/1.45 -apple-system, sans-serif; color: #8e8e93; padding: 12px 16px 2px; border-top: 0.5px solid rgba(120,120,128,0.3); margin-top: 8px; }
+  .sk-legal a { color: #007aff; text-decoration: none; }
+
+  /* success state */
+  .success { position: absolute; inset: 0; z-index: 10; background: var(--bg); display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 40px 32px calc(40px + env(safe-area-inset-bottom));
+    opacity: 0; pointer-events: none; transition: opacity .3s var(--ease); }
+  .success.open { opacity: 1; pointer-events: auto; }
+  .success-badge { width: 76px; height: 76px; border-radius: 999px; display: grid; place-items: center; background: color-mix(in oklab, var(--pass) 16%, var(--surface)); border: 1px solid color-mix(in oklab, var(--pass) 40%, var(--border)); margin-bottom: 20px; }
+  .success-badge svg { width: 36px; height: 36px; stroke: var(--pass); fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .success h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 27px; letter-spacing: -0.015em; margin: 0 0 10px; color: var(--ink); }
+  .success p { font-size: 14px; line-height: 1.5; color: var(--ink-soft); margin: 0 0 26px; max-width: 30ch; }
+  .success .btn-apple { max-width: 280px; }
+  @media (prefers-reduced-motion: no-preference) {
+    .success-badge { transform: scale(0.95); opacity: 0; }
+    .success.open .success-badge { animation: pop .42s var(--ease) .08s forwards; }
+    @keyframes pop { to { transform: none; opacity: 1; } }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(9px); animation: rise .5s var(--ease) forwards; }
+    .reveal:nth-child(1){animation-delay:.04s}.reveal:nth-child(2){animation-delay:.10s}.reveal:nth-child(3){animation-delay:.16s}
+    .reveal:nth-child(4){animation-delay:.22s}.reveal:nth-child(5){animation-delay:.28s}.reveal:nth-child(6){animation-delay:.34s}
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .scrim, .sk, .success { transition: none; }
+    .plan-opt:active, .btn-apple:active, .theme-toggle:active, .hdr .back:active, .sk-confirm:active { transform: none; }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Pro · pay with Apple</p>
+        <h1 class="stage-title">Go Pro</h1>
+        <p class="stage-sub">The purchase moment. On iOS, subscriptions go through Apple In-App Purchase, so tapping Subscribe hands off to Apple's own sheet (shown here as a neutral system representation).</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="hdr">
+            <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+            <h1>Go Pro</h1>
+            <span class="plan-tag">Pro</span>
+          </div>
+
+          <div class="body">
+            <div class="sect reveal">Choose your plan</div>
+
+            <div class="plan-card reveal" id="planCard">
+              <div class="plan-opt sel" data-plan="annual">
+                <span class="plan-radio"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg></span>
+                <div class="plan-meta">
+                  <div class="plan-nm">Pro Annual <span class="save-pill">Save 26%</span> <span class="best-pill">Best value</span></div>
+                  <div class="plan-sub">About $7.42 a month, billed once a year.</div>
+                </div>
+                <div class="plan-price"><div class="plan-amt">$89</div><div class="plan-per">per year</div></div>
+              </div>
+              <div class="plan-opt" data-plan="monthly">
+                <span class="plan-radio"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg></span>
+                <div class="plan-meta">
+                  <div class="plan-nm">Pro Monthly</div>
+                  <div class="plan-sub">Pay month to month, switch whenever.</div>
+                </div>
+                <div class="plan-price"><div class="plan-amt">$9.99</div><div class="plan-per">per month</div></div>
+              </div>
+            </div>
+            <p class="anchor-note" id="anchorNote">Annual works out to <b>about $7.42 a month</b>. That is <b>$30 less a year</b> than paying monthly.</p>
+
+            <div class="sect reveal">What you get with Pro</div>
+            <ul class="gets reveal">
+              <li>
+                <span class="gi"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="11" width="18" height="10" rx="2"></rect><path d="M7 11V8a5 5 0 0 1 10 0"></path><path d="M12 15v3" /></svg></span>
+                <div class="gt">Every exam unlocked<span>Network+, Security+, A+, Azure, AWS and the rest. No single-exam limit.</span></div>
+              </li>
+              <li>
+                <span class="gi"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2L3 14h7l-1 8 10-12h-7z"></path></svg></span>
+                <div class="gt">Unlimited questions<span>No daily cap. Practice as much as the day allows.</span></div>
+              </li>
+              <li>
+                <span class="gi"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7z"></path><path d="M9 12l2 2 4-4" /></svg></span>
+                <div class="gt">All drills and labs<span>Subnet trainer, port drills, topology builder, guided labs.</span></div>
+              </li>
+              <li class="guarantee">
+                <span class="gi"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l7 3v6c0 4-3 7-7 8-4-1-7-4-7-8V6z"></path></svg></span>
+                <div class="gt">Pass-guarantee<span>Pass your cert, or your money back. Honest terms, no fine print games.</span></div>
+              </li>
+            </ul>
+          </div>
+
+          <div class="footer">
+            <button class="btn-apple" id="subscribeBtn" type="button">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17.05 13.13c-.02-2.07 1.69-3.06 1.77-3.11-.97-1.42-2.47-1.61-3-1.63-1.28-.13-2.5.75-3.15.75-.65 0-1.65-.73-2.71-.71-1.4.02-2.69.81-3.41 2.06-1.45 2.52-.37 6.25 1.04 8.29.69.99 1.51 2.11 2.59 2.07 1.04-.04 1.43-.67 2.69-.67 1.25 0 1.61.67 2.71.65 1.12-.02 1.83-1.01 2.51-2.01.79-1.15 1.12-2.27 1.14-2.33-.03-.01-2.18-.84-2.2-3.31zM15 6.6c.57-.7.96-1.66.85-2.62-.83.03-1.83.55-2.42 1.24-.53.61-1 1.6-.87 2.54.92.07 1.87-.47 2.44-1.16z"/></svg>
+              Subscribe with Apple
+            </button>
+            <button class="restore" id="restoreLink" type="button">Restore purchases</button>
+            <p class="foot-legal">Billed through your Apple ID. Cancel anytime in Settings.</p>
+          </div>
+
+          <!-- Apple StoreKit system sheet (neutral system representation, not the app's UI) -->
+          <div class="scrim" id="scrim"></div>
+          <div class="sk" id="sk" role="dialog" aria-modal="true" aria-label="Apple subscription confirmation">
+            <div class="sk-label">Apple · App Store</div>
+            <div class="sk-bar">
+              <button class="sk-cancel" id="skCancel" type="button">Cancel</button>
+              <span class="sk-acct"><span class="dot"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.5"></circle><path d="M5 20a7 7 0 0 1 14 0"></path></svg></span>you@icloud.com</span>
+            </div>
+            <div class="sk-product">
+              <span class="sk-icon"><span>CA</span></span>
+              <div class="sk-pinfo">
+                <div class="sk-app">CertAnvil Pro</div>
+                <div class="sk-plan" id="skPlanName">Pro Annual</div>
+              </div>
+              <span class="sk-amt" id="skPriceTop">$89.00</span>
+            </div>
+            <div class="sk-row"><span class="k">Account</span><span class="v">you@icloud.com</span></div>
+            <div class="sk-row"><span class="k" id="skBillKey">Billed yearly</span><span class="v" id="skPriceRow">$89.00 / year</span></div>
+            <button class="sk-confirm" id="skConfirm" type="button">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="3"></rect><path d="M9 9.5a3 3 0 0 1 6 0v1M9 14h6"></path></svg>
+              Double-click to confirm
+            </button>
+            <p class="sk-faceid">Confirm with Face ID</p>
+            <p class="sk-legal">A subscription renews automatically until cancelled. Cancel at least one day before it renews in your Apple ID Settings. By confirming you agree to the <a href="#">Terms</a>.</p>
+          </div>
+
+          <!-- success state -->
+          <div class="success" id="success">
+            <div class="success-badge"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg></div>
+            <h2>You're Pro.</h2>
+            <p>Every exam is unlocked and the daily cap is gone. Your streak and progress carried over.</p>
+            <button class="btn-apple" id="startBtn" type="button">Start studying</button>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Tap Subscribe with Apple to see the system sheet, then Double-click to confirm.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // plan switch
+      var planCard = document.getElementById('planCard');
+      var anchorNote = document.getElementById('anchorNote');
+      var subBtn = document.getElementById('subscribeBtn');
+      var skPlanName = document.getElementById('skPlanName');
+      var skPriceTop = document.getElementById('skPriceTop');
+      var skPriceRow = document.getElementById('skPriceRow');
+      var skBillKey = document.getElementById('skBillKey');
+      var plan = 'annual';
+
+      function setPlan(p){
+        plan = p;
+        planCard.querySelectorAll('.plan-opt').forEach(function(o){ o.classList.toggle('sel', o.getAttribute('data-plan') === p); });
+        if (p === 'annual') {
+          anchorNote.innerHTML = 'Annual works out to <b>about $7.42 a month</b>. That is <b>$30 less a year</b> than paying monthly.';
+          skPlanName.textContent = 'Pro Annual';
+          skPriceTop.textContent = '$89.00';
+          skPriceRow.textContent = '$89.00 / year';
+          skBillKey.textContent = 'Billed yearly';
+        } else {
+          anchorNote.innerHTML = 'Monthly is <b>$9.99 a month</b>. Switching to Annual later saves you <b>26%</b>.';
+          skPlanName.textContent = 'Pro Monthly';
+          skPriceTop.textContent = '$9.99';
+          skPriceRow.textContent = '$9.99 / month';
+          skBillKey.textContent = 'Billed monthly';
+        }
+      }
+      planCard.addEventListener('click', function(e){
+        var opt = e.target.closest('.plan-opt'); if (!opt) return;
+        setPlan(opt.getAttribute('data-plan'));
+      });
+
+      // Apple sheet
+      var scrim = document.getElementById('scrim'), sk = document.getElementById('sk');
+      function openSheet(){ scrim.classList.add('open'); sk.classList.add('open'); }
+      function closeSheet(){ scrim.classList.remove('open'); sk.classList.remove('open'); }
+      subBtn.addEventListener('click', openSheet);
+      document.getElementById('restoreLink').addEventListener('click', function(){ /* mockup: routes to onboarding-restore-purchase */ });
+      scrim.addEventListener('click', closeSheet);
+      document.getElementById('skCancel').addEventListener('click', closeSheet);
+
+      // confirm -> success
+      var success = document.getElementById('success');
+      document.getElementById('skConfirm').addEventListener('click', function(){
+        closeSheet();
+        setTimeout(function(){ success.classList.add('open'); }, 220);
+      });
+      document.getElementById('startBtn').addEventListener('click', function(){ success.classList.remove('open'); /* mockup: routes to Pro home */ });
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-restore-purchase.html
+++ b/mockups/onboarding-restore-purchase.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Restore purchases</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.955 0.009 84); --surface-2: oklch(0.92 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* state preview chips (outside the phone) */
+  .state-chips { display: flex; flex-wrap: wrap; gap: 8px; max-width: 390px; margin: 0 auto 16px; }
+  .chip { flex: 1 1 auto; background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 30%, var(--page-dim)); border-radius: 999px; padding: 8px 12px; cursor: pointer;
+    font: 650 12px/1 Inter, sans-serif; color: var(--page-dim); transition: background .2s, color .2s, border-color .2s, transform .14s var(--ease); }
+  .chip:active { transform: scale(0.96); }
+  .chip.on { background: color-mix(in oklab, var(--accent-bright) 16%, transparent); color: var(--accent-bright); border-color: color-mix(in oklab, var(--accent-bright) 55%, var(--page-dim)); }
+  @media (hover:hover) and (pointer:fine) { .chip:hover { border-color: color-mix(in oklab, var(--accent-bright) 50%, var(--page-dim)); } }
+
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  .hdr { display: flex; align-items: center; gap: 11px; padding: 14px 22px 10px; }
+  .hdr .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .14s var(--ease), border-color .18s; }
+  .hdr .back:active { transform: scale(0.94); }
+  @media (hover:hover) and (pointer:fine) { .hdr .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .hdr .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .hdr h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 0; color: var(--ink); flex: 1; }
+
+  .body { flex: 1; overflow-y: auto; padding: 8px 22px 16px; display: flex; flex-direction: column; }
+  .body::-webkit-scrollbar { width: 0; }
+
+  /* hero icon + explainer */
+  .restore-hero { text-align: center; padding: 18px 6px 4px; }
+  .rh-icon { width: 64px; height: 64px; border-radius: 17px; display: grid; place-items: center; margin: 0 auto 16px; background: color-mix(in oklab, var(--accent) 13%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border)); }
+  .rh-icon svg { width: 30px; height: 30px; stroke: var(--accent-deep); fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .rh-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 22px; line-height: 1.15; letter-spacing: -0.012em; margin: 0 0 9px; color: var(--ink); }
+  .rh-sub { font-size: 13.5px; line-height: 1.5; color: var(--ink-soft); margin: 0 auto; max-width: 32ch; }
+  .rh-sub b { color: var(--ink); font-weight: 650; }
+
+  /* outcome card (success / empty) */
+  .outcome { margin: 22px 0 0; border-radius: 16px; padding: 16px; border: 1px solid var(--border); background: var(--surface); display: flex; align-items: flex-start; gap: 13px; }
+  .outcome.ok { border-color: color-mix(in oklab, var(--pass) 38%, var(--border)); background: color-mix(in oklab, var(--pass) 8%, var(--surface)); }
+  .oi { flex: 0 0 auto; width: 38px; height: 38px; border-radius: 11px; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 12%, var(--surface-2)); }
+  .oi svg { width: 20px; height: 20px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .outcome.ok .oi { background: color-mix(in oklab, var(--pass) 16%, var(--surface-2)); }
+  .outcome.ok .oi svg { stroke: var(--pass); }
+  .ot { font: 650 15px/1.25 Inter, sans-serif; color: var(--ink); }
+  .os { font-size: 12.5px; line-height: 1.5; color: var(--ink-soft); margin-top: 5px; }
+  .os b { color: var(--ink); font-weight: 650; }
+
+  /* checking (loading, no spinner, calm progress strip) */
+  .checking { margin: 22px 0 0; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 16px; }
+  .ck-row { display: flex; align-items: center; gap: 11px; }
+  .ck-dot { flex: 0 0 auto; width: 38px; height: 38px; border-radius: 11px; background: color-mix(in oklab, var(--accent) 12%, var(--surface-2)); display: grid; place-items: center; }
+  .ck-dot svg { width: 19px; height: 19px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .ck-t { font: 650 15px/1.2 Inter, sans-serif; color: var(--ink); }
+  .ck-s { font-size: 12.5px; color: var(--ink-soft); margin-top: 4px; }
+  .ck-bar { margin-top: 14px; height: 4px; border-radius: 999px; background: var(--track); overflow: hidden; }
+  .ck-fill { height: 100%; width: 40%; border-radius: 999px; background: var(--accent); }
+  @media (prefers-reduced-motion: no-preference) {
+    .ck-fill { animation: sweep 1.4s var(--ease) infinite; }
+    @keyframes sweep { 0% { transform: translateX(-110%); } 100% { transform: translateX(310%); } }
+  }
+  @media (prefers-reduced-motion: reduce) { .ck-fill { width: 55%; } }
+
+  .spacer { flex: 1 1 auto; min-height: 12px; }
+
+  /* footer actions per state */
+  .footer { flex: 0 0 auto; padding: 12px 22px calc(12px + env(safe-area-inset-bottom)); border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent); background: var(--bg); }
+  .btn-primary { width: 100%; border: none; border-radius: 13px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s, opacity .2s; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+  .btn-primary[disabled] { opacity: 0.55; box-shadow: none; cursor: default; }
+  .link-row { text-align: center; margin: 11px 0 0; }
+  .link-btn { background: none; border: none; cursor: pointer; font: 650 13px/1 Inter, sans-serif; color: var(--accent-deep); padding: 4px; transition: opacity .18s; }
+  @media (hover:hover) and (pointer:fine) { .link-btn:hover { opacity: 0.75; } }
+  .foot-legal { text-align: center; font-size: 11px; line-height: 1.45; color: var(--muted); margin: 10px 0 0; }
+
+  /* state visibility */
+  .state { display: none; }
+  .state.show { display: block; }
+  .state.show.flexcol { display: flex; flex-direction: column; flex: 1 1 auto; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .state.show .restore-hero, .state.show .outcome, .state.show .checking { opacity: 0; transform: translateY(9px); animation: rise .42s var(--ease) forwards; }
+    .state.show .outcome, .state.show .checking { animation-delay: .08s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .chip:active, .btn-primary:active, .theme-toggle:active, .hdr .back:active { transform: none; }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Pro · restore purchases</p>
+        <h1 class="stage-title">Restore purchases</h1>
+        <p class="stage-sub">Apple-required restore path, reachable from the paywall and from sign-in (a returning Pro user on a new device). Use the chips to preview each state inside the phone.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="state-chips" role="tablist" aria-label="Preview state">
+      <button class="chip on" data-state="idle" type="button">Idle</button>
+      <button class="chip" data-state="checking" type="button">Checking</button>
+      <button class="chip" data-state="success" type="button">Restored</button>
+      <button class="chip" data-state="empty" type="button">Not found</button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="hdr">
+            <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+            <h1>Restore purchases</h1>
+          </div>
+
+          <!-- IDLE -->
+          <div class="state show flexcol" id="state-idle">
+            <div class="body">
+              <div class="restore-hero">
+                <span class="rh-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"></path><path d="M21 4v4h-4"></path></svg></span>
+                <h2 class="rh-title">Already bought Pro?</h2>
+                <p class="rh-sub">Bought Pro on another device? Restore it here with the <b>same Apple ID</b> you used to buy it. Nothing is charged again.</p>
+              </div>
+              <div class="spacer"></div>
+            </div>
+            <div class="footer">
+              <button class="btn-primary" id="restoreBtn" type="button">Restore purchases</button>
+              <p class="foot-legal">CertAnvil checks with Apple. We never see your card details.</p>
+            </div>
+          </div>
+
+          <!-- CHECKING (loading, no spinner) -->
+          <div class="state flexcol" id="state-checking">
+            <div class="body">
+              <div class="restore-hero">
+                <span class="rh-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"></path><path d="M21 4v4h-4"></path></svg></span>
+                <h2 class="rh-title">Checking with Apple</h2>
+                <p class="rh-sub">Looking for a Pro subscription on <b>you@icloud.com</b>. This usually takes a moment.</p>
+              </div>
+              <div class="checking">
+                <div class="ck-row">
+                  <span class="ck-dot"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 2"></path></svg></span>
+                  <div><div class="ck-t">Checking with Apple...</div><div class="ck-s">Confirming your purchase history.</div></div>
+                </div>
+                <div class="ck-bar"><div class="ck-fill"></div></div>
+              </div>
+              <div class="spacer"></div>
+            </div>
+            <div class="footer">
+              <button class="btn-primary" type="button" disabled>Checking...</button>
+              <p class="foot-legal">CertAnvil checks with Apple. We never see your card details.</p>
+            </div>
+          </div>
+
+          <!-- SUCCESS -->
+          <div class="state flexcol" id="state-success">
+            <div class="body">
+              <div class="restore-hero">
+                <span class="rh-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"></path><path d="M21 4v4h-4"></path></svg></span>
+                <h2 class="rh-title">Restore purchases</h2>
+                <p class="rh-sub">Bought Pro on another device? Restore it here with the same Apple ID.</p>
+              </div>
+              <div class="outcome ok">
+                <span class="oi"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg></span>
+                <div>
+                  <div class="ot">Pro restored. Welcome back.</div>
+                  <div class="os">Your <b>Pro Annual</b> plan is active on this device. Every exam is unlocked and the daily cap is gone.</div>
+                </div>
+              </div>
+              <div class="spacer"></div>
+            </div>
+            <div class="footer">
+              <button class="btn-primary" type="button">Continue to CertAnvil</button>
+            </div>
+          </div>
+
+          <!-- EMPTY -->
+          <div class="state flexcol" id="state-empty">
+            <div class="body">
+              <div class="restore-hero">
+                <span class="rh-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"></path><path d="M21 4v4h-4"></path></svg></span>
+                <h2 class="rh-title">Restore purchases</h2>
+                <p class="rh-sub">Bought Pro on another device? Restore it here with the same Apple ID.</p>
+              </div>
+              <div class="outcome">
+                <span class="oi"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4.3-4.3"></path></svg></span>
+                <div>
+                  <div class="ot">No subscription found on this Apple ID.</div>
+                  <div class="os">Make sure you're signed in with the <b>same Apple ID</b> you used to buy Pro. You can check it in Settings, at the top of the screen.</div>
+                </div>
+              </div>
+              <div class="spacer"></div>
+            </div>
+            <div class="footer">
+              <button class="btn-primary" type="button">Try again</button>
+              <div class="link-row"><button class="link-btn" type="button">Never bought Pro? Start Pro</button></div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+      <p class="hint">Restore is honest: it only confirms what Apple already has on file.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      var chips = document.querySelectorAll('.chip');
+      function show(state){
+        chips.forEach(function(c){ c.classList.toggle('on', c.getAttribute('data-state') === state); });
+        document.querySelectorAll('.state').forEach(function(s){ s.classList.remove('show'); });
+        document.getElementById('state-' + state).classList.add('show');
+      }
+      chips.forEach(function(c){ c.addEventListener('click', function(){ show(c.getAttribute('data-state')); }); });
+
+      // tapping Restore in idle previews the checking flow, then settles on success
+      document.getElementById('restoreBtn').addEventListener('click', function(){
+        show('checking');
+        setTimeout(function(){ show('success'); }, 1600);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/mockups/onboarding-sandbox.html
+++ b/mockups/onboarding-sandbox.html
@@ -131,12 +131,23 @@
   var MOCKS = [
     ['onboarding-native-welcome.html','Welcome','First screen on launch.'],
     ['onboarding-signup-signin.html','Sign up / Sign in','Account step.'],
+    ['onboarding-magic-link-sent.html','Check your inbox','Magic-link sent, the interstitial.'],
+    ['onboarding-welcome-back.html','Welcome back','Returning-user sign-in.'],
     ['onboarding-plan-picker-concept.html','Choose your plan','Monthly, yearly, or free, right after signup.'],
     ['onboarding-free-cert-picker.html','Pick your exam (Free)','Free path: one exam, locked in.'],
-    ['onboarding-upgrade-sheet.html','Pro upgrade sheet','The payment moment.'],
+    ['onboarding-free-home-day0.html','Free home (day 0)','First home, place your readiness.'],
+    ['onboarding-first-run-diagnostic.html','First-run diagnostic','The 30-second check and the aha.'],
     ['onboarding-free-capped-home.html','Done for today','After declining Pro.'],
+    ['onboarding-pro-iap.html','Pay with Apple (Pro)','The Apple In-App Purchase moment.'],
+    ['onboarding-upgrade-sheet.html','Pro upgrade sheet','The marketing upsell sheet.'],
     ['onboarding-pro-welcome.html',"You're Pro",'Post-purchase celebration.'],
     ['onboarding-my-certs-pro.html','My Certs (Pro)','Every exam unlocked.'],
+    ['onboarding-restore-purchase.html','Restore purchases','Apple-required restore path.'],
+    ['onboarding-manage-subscription.html','Manage subscription','Switch plan, billing via Apple.'],
+    ['onboarding-notifications-prime.html','Turn on reminders','Notification permission prime.'],
+    ['onboarding-account-deletion.html','Delete account','Apple-required account deletion.'],
+    ['onboarding-error-states.html','Error states','Card, link, account, typo errors.'],
+    ['onboarding-loading-states.html','Loading and offline','Skeletons and the offline state.'],
     ['onboarding-rollout-flow.html','Rollout flow map','Reference: the whole flow.']
   ];
   function $(id){ return document.getElementById(id); }

--- a/mockups/onboarding-welcome-back.html
+++ b/mockups/onboarding-welcome-back.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>CertAnvil · Welcome back</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=Roboto+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ── Forged-bronze tokens (matches dg-system.css + the onboarding mockups). Dark :root, light override; light is primary. ── */
+  :root {
+    --bg: oklch(0.15 0.010 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.255 0.010 275);
+    --ink: oklch(0.97 0.006 275); --ink-soft: oklch(0.80 0.010 275); --muted: oklch(0.62 0.013 275);
+    --border: oklch(0.34 0.009 275);
+    --accent: oklch(0.82 0.150 66); --accent-bright: oklch(0.88 0.140 72); --accent-deep: oklch(0.72 0.150 62);
+    --on-accent: oklch(0.18 0.020 275); --pass: oklch(0.78 0.150 152); --track: oklch(0.30 0.010 275);
+    --apple-bg: oklch(0.98 0.004 275); --apple-fg: oklch(0.16 0.010 275);
+    --page-bg: oklch(0.22 0.012 275); --page-ink: oklch(0.92 0.008 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.985 0.006 85); --surface: oklch(0.965 0.008 84); --surface-2: oklch(0.93 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.38 0.014 280); --muted: oklch(0.52 0.013 280);
+    --border: oklch(0.85 0.010 85);
+    --accent: oklch(0.55 0.155 55); --accent-bright: oklch(0.62 0.150 58); --accent-deep: oklch(0.46 0.150 52);
+    --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
+    --apple-bg: oklch(0.17 0.010 280); --apple-fg: oklch(0.98 0.004 85);
+    --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
+  }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
+
+  * { box-sizing: border-box; }
+  html { color-scheme: light dark; }
+  body { margin: 0; background: var(--page-bg); color: var(--page-ink);
+    font: 15px/1.55 Inter, -apple-system, BlinkMacSystemFont, sans-serif; padding: 30px 20px 64px;
+    transition: background .35s var(--ease), color .35s var(--ease); }
+  .stage { max-width: 520px; margin: 0 auto; }
+  .stage-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+  .stage-eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent-bright); margin: 0 0 7px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; margin: 0; color: var(--page-ink); }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin: 7px 0 0; max-width: 48ch; line-height: 1.5; }
+  .theme-toggle { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; font: 600 12px/1 Inter, sans-serif; color: var(--accent-bright);
+    background: transparent; border: 1px solid color-mix(in oklab, var(--accent-bright) 38%, var(--page-dim)); border-radius: 999px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease), background .2s; }
+  .theme-toggle svg { width: 15px; height: 15px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+  .theme-toggle:active { transform: scale(0.97); }
+
+  /* phone */
+  .phone-wrap { display: flex; flex-direction: column; align-items: center; }
+  .phone { width: 390px; height: 844px; border-radius: 52px; padding: 11px; flex: 0 0 auto;
+    background: linear-gradient(165deg, #23262f, #0c0d11); box-shadow: 0 40px 90px -34px rgba(0,0,0,0.6), 0 0 0 1.5px rgba(255,255,255,0.06) inset; }
+  .screen { width: 100%; height: 100%; border-radius: 42px; overflow: hidden; position: relative; background: var(--bg); color: var(--ink);
+    display: flex; flex-direction: column; transition: background .35s var(--ease), color .35s var(--ease); }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 122px; height: 32px; background: #07080b; border-radius: 18px; z-index: 6; }
+  .statusbar { display: flex; align-items: center; justify-content: space-between; padding: 14px 26px 0; font: 700 13px/1 Inter, sans-serif; color: var(--ink); }
+  .sb-icons { display: inline-flex; gap: 6px; align-items: center; }
+  .sb-icons svg { width: 17px; height: 12px; fill: var(--ink); }
+
+  /* auth layout */
+  .auth { flex: 1; display: flex; flex-direction: column; padding: 6px 28px 26px; }
+  .topbar { display: flex; align-items: center; gap: 10px; margin-top: 12px; }
+  .back { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); display: grid; place-items: center; cursor: pointer; color: var(--ink-soft); transition: transform .15s var(--ease), border-color .18s; }
+  .back:active { transform: scale(0.95); }
+  @media (hover:hover) and (pointer:fine) { .back:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+  .back svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.1; stroke-linecap: round; stroke-linejoin: round; }
+  .brand-mark { width: 26px; height: 26px; color: var(--accent); display: inline-flex; margin-left: 2px; }
+  .brand-mark svg { width: 100%; height: 100%; }
+  .brand-name { font: 700 15px/1 Inter, sans-serif; letter-spacing: -0.01em; color: var(--ink); }
+
+  .auth-body { display: flex; flex-direction: column; margin-top: 30px; }
+  .auth-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 28px; line-height: 1.08; letter-spacing: -0.015em; margin: 0; color: var(--ink); }
+  .auth-sub { font-size: 14px; line-height: 1.5; color: var(--ink-soft); margin: 9px 0 0; max-width: 36ch; }
+
+  /* what's-waiting teaser: endowment + unfinished-loop pull */
+  .resume { margin: 22px 0 4px; border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)); border-radius: 16px; background: color-mix(in oklab, var(--accent) 6%, var(--surface)); padding: 15px 16px; }
+  .resume-top { display: flex; align-items: center; gap: 11px; }
+  .resume-mark { flex: 0 0 auto; width: 40px; height: 40px; border-radius: 11px; background: color-mix(in oklab, var(--accent) 13%, var(--surface-2)); color: var(--accent-deep); display: grid; place-items: center; font: 800 13px/1 Inter, sans-serif; }
+  .resume-meta { flex: 1; min-width: 0; }
+  .resume-nm { font: 650 15px/1.1 Inter, sans-serif; color: var(--ink); }
+  .resume-cd { font: 600 11.5px/1 'Roboto Mono', monospace; color: var(--muted); margin-top: 3px; }
+  .resume-score { flex: 0 0 auto; text-align: right; }
+  .resume-num { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 22px; line-height: 1; color: var(--accent-deep); }
+  .resume-num span { font: 600 11px/1 'Roboto Mono', monospace; color: var(--muted); }
+  .resume-lbl { font: 700 9px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin-top: 4px; }
+  .track { height: 7px; border-radius: 999px; background: var(--track); margin-top: 13px; overflow: hidden; }
+  .track i { display: block; height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--accent-deep), var(--accent-bright)); width: 0; transition: width .8s var(--ease); }
+  .resume-line { font-size: 13px; line-height: 1.45; color: var(--ink-soft); margin: 12px 0 0; }
+  .resume-line b { color: var(--ink); font-weight: 650; }
+
+  .field { display: flex; flex-direction: column; gap: 6px; margin-top: 22px; }
+  .field label { font: 650 12px/1 Inter, sans-serif; color: var(--ink-soft); }
+  .field input { border: 1px solid var(--border); background: var(--surface); color: var(--ink); border-radius: 12px; padding: 13px 14px; font: 500 15px/1 Inter, sans-serif; transition: border-color .18s, box-shadow .18s; }
+  .field input::placeholder { color: var(--muted); }
+  .field input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 22%, transparent); }
+
+  .btn-primary { width: 100%; border: none; border-radius: 14px; padding: 15px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 15px/1 Inter, sans-serif;
+    box-shadow: 0 12px 26px -14px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; margin-top: 16px; }
+  .btn-primary:active { transform: scale(0.985); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+  .nopass { display: flex; align-items: center; justify-content: center; gap: 7px; margin: 12px 0 0; color: var(--muted); font-size: 12px; }
+  .nopass svg { width: 13px; height: 13px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+
+  .switch { margin-top: auto; padding-top: 22px; text-align: center; font-size: 12.5px; color: var(--muted); }
+  .switch button { background: none; border: none; cursor: pointer; font: 600 12.5px/1 Inter, sans-serif; color: var(--accent-bright); padding: 4px; transition: transform .15s var(--ease); }
+  .switch button:active { transform: scale(0.97); }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal { opacity: 0; transform: translateY(10px); animation: rise .5s var(--ease) forwards; }
+    .topbar { animation-delay: .02s; } .auth-title { animation-delay: .08s; } .auth-sub { animation-delay: .13s; }
+    .resume { animation-delay: .19s; } .field { animation-delay: .25s; } .btn-primary { animation-delay: .30s; }
+    .nopass { animation-delay: .35s; } .switch { animation-delay: .40s; }
+    @keyframes rise { to { opacity: 1; transform: none; } }
+  }
+  .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
+  @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="stage-head">
+      <div>
+        <p class="stage-eyebrow">Account · returning user</p>
+        <h1 class="stage-title">Welcome back</h1>
+        <p class="stage-sub">The sign-in entry for someone who already has an account, distinct from first-time signup. It shows what is waiting and asks only for an email, then sends a one-tap link.</p>
+      </div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+        <span id="themeLabel">Dark</span>
+      </button>
+    </div>
+
+    <div class="phone-wrap">
+      <div class="phone">
+        <div class="screen">
+          <div class="notch"></div>
+          <div class="statusbar">
+            <span>9:41</span>
+            <span class="sb-icons">
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="0" y="7" width="3" height="5" rx="1"/><rect x="5" y="4" width="3" height="8" rx="1"/><rect x="10" y="1" width="3" height="11" rx="1" opacity="0.4"/></svg>
+              <svg viewBox="0 0 18 12" aria-hidden="true"><rect x="1" y="2" width="14" height="8" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><rect x="2.6" y="3.6" width="9" height="4.8" rx="1.2"/><rect x="16" y="4.6" width="1.4" height="2.8" rx="0.7"/></svg>
+            </span>
+          </div>
+
+          <div class="auth">
+            <div class="topbar reveal">
+              <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 18l-6-6 6-6"></path></svg></button>
+              <span class="brand-mark" aria-hidden="true">
+                <svg viewBox="0 0 100 100" fill="none">
+                  <path class="ca-c" d="M58 12 C42 6, 16 16, 14 34 C12 52, 22 62, 42 64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+                  <line class="ca-slash" x1="30" y1="84" x2="70" y2="16" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+                  <path class="ca-a" d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+              <span class="brand-name">CertAnvil</span>
+            </div>
+
+            <div class="auth-body">
+              <h1 class="auth-title reveal">Welcome back</h1>
+              <p class="auth-sub reveal">Your progress is right where you left it. Sign in to keep going.</p>
+
+              <div class="resume reveal">
+                <div class="resume-top">
+                  <span class="resume-mark">N+</span>
+                  <div class="resume-meta">
+                    <div class="resume-nm">Network+</div>
+                    <div class="resume-cd">N10-009</div>
+                  </div>
+                  <div class="resume-score">
+                    <div class="resume-num">465<span> / 700</span></div>
+                    <div class="resume-lbl">Readiness</div>
+                  </div>
+                </div>
+                <div class="track" aria-hidden="true"><i id="bar"></i></div>
+                <p class="resume-line"><b>Network+ is at 465 readiness.</b> Pick up right where you left off.</p>
+              </div>
+
+              <div class="field reveal">
+                <label for="email">Email</label>
+                <input id="email" type="email" placeholder="you@gmail.com" autocomplete="email" inputmode="email" />
+              </div>
+
+              <button class="btn-primary reveal" type="button">Send my sign-in link</button>
+
+              <p class="nopass reveal">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg>
+                One-tap link, no password.
+              </p>
+            </div>
+
+            <p class="switch reveal">New here? <button type="button">Create an account</button></p>
+          </div>
+        </div>
+      </div>
+      <p class="hint">Returning-user sign in. Enter an email to receive a one-tap link.</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var sun = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
+      var moon = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
+      function paint(){ var dark = html.getAttribute('data-theme') !== 'light'; label.textContent = dark ? 'Light' : 'Dark'; icon.innerHTML = dark ? moon : sun; }
+      document.getElementById('themeToggle').addEventListener('click', function(){ html.setAttribute('data-theme', html.getAttribute('data-theme') === 'light' ? 'dark' : 'light'); paint(); });
+      paint();
+
+      // readiness bar fills toward 465 / 700 once painted in
+      var bar = document.getElementById('bar');
+      requestAnimationFrame(function(){ requestAnimationFrame(function(){ bar.style.width = (465 / 700 * 100) + '%'; }); });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Fills every gap from the onboarding flow-completeness audit so the Apple App Store onboarding flow is reviewable end to end.

## New screens (11) — all forged-bronze, light/dark, zero em-dashes
**Apple compliance (P1):**
- Pay with Apple (Pro) — IAP moment + StoreKit sheet representation + Restore link
- Restore purchases — Apple-required restore path (idle/checking/restored/not-found)
- Delete account — Apple-required in-app deletion (Settings, type-to-confirm, goodbye)
- Check your inbox — magic-link interstitial

**Activation + robustness (P2):**
- Turn on reminders — pre-permission prime + iOS alert representation
- Free home (day 0) — fresh free home, place-your-readiness invite
- First-run diagnostic — placement check + readiness reveal (the aha)
- Error states — card declined / renewal failed / link expired / account exists / email typo

**P3 + partials:**
- Manage subscription — Annual↔Monthly, Apple-managed billing
- Welcome back — returning-user sign-in with progress teaser
- Loading and offline — session-restore / content / offline skeletons

## Hub
`onboarding-sandbox.html`: all 11 wired into the MOCKS list, reordered into end-to-end flow order (rollout map kept last as reference). 20 tiles total.

Built via parallel sub-agents through the four-pass pipeline (design-taste-frontend, emil-design-eng, humanizer, marketing-psychology). Each screen verified rendering + interactions in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)