### PR TITLE
Hub cert-switch gate: free users locked to one cert, Pro can switch

### DIFF
--- a/mockups/cert-ios-hub.html
+++ b/mockups/cert-ios-hub.html
@@ -25,7 +25,7 @@
     --on-accent: oklch(0.99 0.008 85); --pass: oklch(0.52 0.13 150); --track: oklch(0.88 0.010 85);
     --page-bg: oklch(0.93 0.010 84); --page-ink: oklch(0.28 0.015 280); --page-dim: oklch(0.46 0.013 280);
   }
-  :root { --ease: cubic-bezier(0.16,1,0.3,1); }
+  :root { --ease: cubic-bezier(0.16,1,0.3,1); --ease-drawer: cubic-bezier(0.32,0.72,0,1); }
 
   * { box-sizing: border-box; }
   html { color-scheme: light dark; }
@@ -182,6 +182,55 @@
   }
   .hint { text-align: center; color: var(--page-dim); font-size: 12px; margin-top: 18px; }
   @media (max-width: 440px) { .phone { transform: scale(.92); transform-origin: top center; } }
+
+  /* ── sandbox plan toggle (preview Free vs Pro) ── */
+  .stage-controls { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 9px; }
+  .plan-toggle { display: inline-flex; padding: 3px; border-radius: 999px; background: var(--surface); border: 1px solid var(--border); }
+  .plan-toggle button { appearance: none; border: none; background: transparent; cursor: pointer; border-radius: 999px; padding: 7px 14px; font: 700 12px/1 Inter, sans-serif; color: var(--page-dim); transition: color .18s var(--ease), background .18s var(--ease), transform .16s var(--ease); }
+  .plan-toggle button.is-on { color: var(--on-accent); background: var(--accent); }
+  .plan-toggle button:active { transform: scale(.97); }
+  @media (max-width: 460px) { .stage-head { flex-wrap: wrap; } .stage-controls { width: 100%; justify-content: flex-start; margin-top: 4px; } }
+
+  /* ── plan-conditional visibility (driven by data-plan on .screen) ── */
+  .screen[data-plan="free"] .pro-only { display: none !important; }
+  .screen[data-plan="pro"] .free-only { display: none !important; }
+
+  /* ── locked cert teaser rows (free) ── */
+  .cert-row.locked { appearance: none; width: 100%; text-align: left; font-family: inherit; background: color-mix(in oklab, var(--surface) 92%, transparent); }
+  .cert-row.locked .mark { background: var(--surface-2); color: var(--muted); }
+  .cert-row.locked .nm { color: var(--ink-soft); }
+  .cert-row .lockwrap { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 8px; }
+  .cert-row .lock { width: 15px; height: 15px; stroke: var(--muted); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .lock-pill { font: 800 8.5px/1 Inter, sans-serif; letter-spacing: 0.09em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 12%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 30%, transparent); border-radius: 999px; padding: 4px 7px; }
+
+  /* ── upsell sheet (tap a locked cert / Pro feature on Free) ── */
+  .scrim { position: absolute; inset: 0; z-index: 8; background: color-mix(in oklab, var(--bg) 55%, transparent); opacity: 0; pointer-events: none; transition: opacity .18s var(--ease); }
+  .scrim.open { opacity: 1; pointer-events: auto; transition: opacity .28s var(--ease); }
+  .sheet { position: absolute; left: 0; right: 0; bottom: 0; z-index: 9; background: var(--surface); border-top-left-radius: 22px; border-top-right-radius: 22px; border-top: 1px solid var(--border); padding: 10px 20px 22px; transform: translateY(102%); pointer-events: none; transition: transform .22s var(--ease-drawer); box-shadow: 0 -20px 50px -24px rgba(0,0,0,.5); }
+  .sheet.open { transform: none; pointer-events: auto; transition: transform .34s var(--ease-drawer); }
+  .sheet-grab { width: 38px; height: 4px; border-radius: 999px; background: var(--border); margin: 2px auto 14px; }
+  .sheet-lock { width: 40px; height: 40px; border-radius: 12px; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 14%, var(--surface-2)); margin-bottom: 12px; }
+  .sheet-lock svg { width: 20px; height: 20px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .sheet h2 { font: 600 18px/1.2 Fraunces, serif; letter-spacing: -0.01em; color: var(--ink); margin: 0 0 7px; }
+  .sheet p { font: 500 12.5px/1.5 Inter, sans-serif; color: var(--ink-soft); margin: 0 0 15px; }
+  .sheet p b { color: var(--ink); font-weight: 650; }
+  .sheet-cta { width: 100%; border: none; border-radius: 12px; padding: 13px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 14.5px/1 Inter, sans-serif; box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent); transition: transform .15s var(--ease), filter .2s; }
+  .sheet-cta:active { transform: scale(.985); }
+  @media (hover:hover) and (pointer:fine) { .sheet-cta:hover { filter: brightness(1.05); } }
+  .sheet-dismiss { width: 100%; margin-top: 8px; border: none; background: transparent; cursor: pointer; padding: 11px; font: 600 13px/1 Inter, sans-serif; color: var(--muted); transition: opacity .15s var(--ease); }
+  .sheet-dismiss:active { opacity: .6; }
+
+  /* pro card draws the eye when an upsell routes to it */
+  @media (prefers-reduced-motion: no-preference) {
+    .pro.flash { animation: proFlash 1.1s var(--ease); }
+    @keyframes proFlash { 30% { border-color: var(--accent); background: color-mix(in oklab, var(--accent) 14%, var(--surface)); } }
+  }
+
+  /* reduced motion: keep the upsell readable, drop the slide */
+  @media (prefers-reduced-motion: reduce) {
+    .sheet { transform: none; opacity: 0; transition: opacity .15s ease; }
+    .sheet.open { opacity: 1; transition: opacity .15s ease; }
+  }
 </style>
 </head>
 <body>
@@ -190,17 +239,23 @@
       <div>
         <p class="stage-eyebrow">Cert app · iOS</p>
         <h1 class="stage-title">Hub</h1>
-        <p class="stage-sub">The lobby above any single cert. Pick which exam to study, manage your account, and go Pro. Free and Pro users both land here to switch and explore certs.</p>
+        <p class="stage-sub">The lobby above any single cert. On Free you study the one cert you picked, and switching to another exam is a Pro feature. Flip the toggle to preview each.</p>
       </div>
-      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
-        <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
-        <span id="themeLabel">Dark</span>
-      </button>
+      <div class="stage-controls">
+        <div class="plan-toggle" role="group" aria-label="Preview plan">
+          <button id="planFree" type="button" class="is-on" aria-pressed="true">Free</button>
+          <button id="planPro" type="button" aria-pressed="false">Pro</button>
+        </div>
+        <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light and dark">
+          <svg id="themeIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+          <span id="themeLabel">Dark</span>
+        </button>
+      </div>
     </div>
 
     <div class="phone-wrap">
       <div class="phone">
-        <div class="screen">
+        <div class="screen" id="screen" data-plan="free">
           <div class="notch"></div>
           <div class="statusbar">
             <span>9:41</span>
@@ -227,16 +282,24 @@
           </div>
 
           <div class="body">
-            <!-- GREETING + STAT STRIP -->
+            <!-- GREETING -->
             <p class="greeting reveal">Morning, Simi. <b>Three cards</b> are due on Security+.</p>
-            <div class="stats reveal">
+
+            <!-- STAT STRIP: free is single-cert focused, pro spans the library -->
+            <div class="stats reveal free-only">
+              <div class="stat"><b>612</b><span>Readiness</span></div>
+              <div class="stat"><b>3</b><span>Due today</span></div>
+              <div class="stat"><b class="flame"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3c1.5 3 4 4.5 4 8a4 4 0 0 1-8 0c0-1 .3-1.8.8-2.5C9 10 9 11 10 11.5 9.5 9 11 5.5 12 3z"></path></svg>12</b><span>Day streak</span></div>
+            </div>
+            <div class="stats reveal pro-only">
               <div class="stat"><b>8</b><span>Certs</span></div>
               <div class="stat pass"><b>2</b><span>Passed</span></div>
               <div class="stat"><b class="flame"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3c1.5 3 4 4.5 4 8a4 4 0 0 1-8 0c0-1 .3-1.8.8-2.5C9 10 9 11 10 11.5 9.5 9 11 5.5 12 3z"></path></svg>12</b><span>Day streak</span></div>
             </div>
 
-            <!-- MY CERTS -->
-            <div class="sect reveal"><b>My certs</b><span class="count">8 total</span></div>
+            <!-- MY CERTS header -->
+            <div class="sect reveal free-only"><b>Your cert</b><span class="count">Free plan</span></div>
+            <div class="sect reveal pro-only"><b>My certs</b><span class="count">all certs</span></div>
 
             <div class="active-card reveal">
               <div class="ac-top">
@@ -251,64 +314,108 @@
               <button class="btn-primary" type="button">Continue Security+</button>
             </div>
 
-            <div class="sect reveal"><b>Passed</b><span class="count">2</span></div>
-            <div class="cert-row scored reveal">
-              <span class="mark is-pass">N+</span>
-              <div class="meta"><div class="nm">Network+</div><div class="cd">N10-009</div></div>
-              <div class="right">
-                <span class="state"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>Passed</span>
-                <span class="score"><b>767</b> / 900</span>
-              </div>
-            </div>
-            <div class="cert-row scored reveal">
-              <span class="mark is-pass">AZ</span>
-              <div class="meta"><div class="nm">Azure Fundamentals</div><div class="cd">AZ-900</div></div>
-              <div class="right">
-                <span class="state"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>Passed</span>
-                <span class="score"><b>812</b> / 1000</span>
-              </div>
-            </div>
-
-            <div class="sect reveal"><b>In progress</b><span class="count">5</span></div>
-            <div class="cert-row reveal">
-              <span class="mark">A+</span>
-              <div class="meta"><div class="nm">A+ Core 1</div><div class="cd">220-1101</div></div>
-              <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
-            </div>
-            <div class="cert-row reveal">
-              <span class="mark">A+</span>
-              <div class="meta"><div class="nm">A+ Core 2</div><div class="cd">220-1102</div></div>
-              <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
-            </div>
-            <div class="cert-row reveal">
-              <span class="mark">AI</span>
-              <div class="meta"><div class="nm">Azure AI Fundamentals</div><div class="cd">AI-900</div></div>
-              <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
-            </div>
-            <div class="cert-row reveal">
-              <span class="mark">SC</span>
-              <div class="meta"><div class="nm">Security Fundamentals</div><div class="cd">SC-900</div></div>
-              <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
-            </div>
-            <div class="cert-row reveal">
-              <span class="mark">CLF</span>
-              <div class="meta"><div class="nm">AWS Cloud Practitioner</div><div class="cd">CLF-C02</div></div>
-              <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
+            <!-- FREE: every other cert is a locked teaser; tapping opens the upsell -->
+            <div class="sect reveal free-only"><b>Unlock with Pro</b><span class="count">every cert</span></div>
+            <div class="free-only">
+              <button class="cert-row locked reveal" type="button" data-cert="Network+">
+                <span class="mark">N+</span>
+                <div class="meta"><div class="nm">Network+</div><div class="cd">N10-009</div></div>
+                <span class="lockwrap"><span class="lock-pill">Pro</span><svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+              </button>
+              <button class="cert-row locked reveal" type="button" data-cert="Azure Fundamentals">
+                <span class="mark">AZ</span>
+                <div class="meta"><div class="nm">Azure Fundamentals</div><div class="cd">AZ-900</div></div>
+                <span class="lockwrap"><span class="lock-pill">Pro</span><svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+              </button>
+              <button class="cert-row locked reveal" type="button" data-cert="A+ Core 1">
+                <span class="mark">A+</span>
+                <div class="meta"><div class="nm">A+ Core 1</div><div class="cd">220-1101</div></div>
+                <span class="lockwrap"><span class="lock-pill">Pro</span><svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+              </button>
+              <button class="cert-row locked reveal" type="button" data-cert="A+ Core 2">
+                <span class="mark">A+</span>
+                <div class="meta"><div class="nm">A+ Core 2</div><div class="cd">220-1102</div></div>
+                <span class="lockwrap"><span class="lock-pill">Pro</span><svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+              </button>
+              <button class="cert-row locked reveal" type="button" data-cert="Azure AI Fundamentals">
+                <span class="mark">AI</span>
+                <div class="meta"><div class="nm">Azure AI Fundamentals</div><div class="cd">AI-900</div></div>
+                <span class="lockwrap"><span class="lock-pill">Pro</span><svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+              </button>
+              <button class="cert-row locked reveal" type="button" data-cert="Security Fundamentals">
+                <span class="mark">SC</span>
+                <div class="meta"><div class="nm">Security Fundamentals</div><div class="cd">SC-900</div></div>
+                <span class="lockwrap"><span class="lock-pill">Pro</span><svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+              </button>
+              <button class="cert-row locked reveal" type="button" data-cert="AWS Cloud Practitioner">
+                <span class="mark">CLF</span>
+                <div class="meta"><div class="nm">AWS Cloud Practitioner</div><div class="cd">CLF-C02</div></div>
+                <span class="lockwrap"><span class="lock-pill">Pro</span><svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+              </button>
             </div>
 
-            <button class="add reveal" type="button">
-              <span class="ai"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14"></path></svg></span>
-              <span class="at"><b>Add a cert</b><span>Browse the exams you can study</span></span>
-              <span class="ag"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span>
-            </button>
+            <!-- PRO: the full multi-cert library, switchable -->
+            <div class="pro-only">
+              <div class="sect reveal"><b>Passed</b><span class="count">2</span></div>
+              <div class="cert-row scored reveal">
+                <span class="mark is-pass">N+</span>
+                <div class="meta"><div class="nm">Network+</div><div class="cd">N10-009</div></div>
+                <div class="right">
+                  <span class="state"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>Passed</span>
+                  <span class="score"><b>767</b> / 900</span>
+                </div>
+              </div>
+              <div class="cert-row scored reveal">
+                <span class="mark is-pass">AZ</span>
+                <div class="meta"><div class="nm">Azure Fundamentals</div><div class="cd">AZ-900</div></div>
+                <div class="right">
+                  <span class="state"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>Passed</span>
+                  <span class="score"><b>812</b> / 1000</span>
+                </div>
+              </div>
+
+              <div class="sect reveal"><b>In progress</b><span class="count">5</span></div>
+              <div class="cert-row reveal">
+                <span class="mark">A+</span>
+                <div class="meta"><div class="nm">A+ Core 1</div><div class="cd">220-1101</div></div>
+                <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
+              </div>
+              <div class="cert-row reveal">
+                <span class="mark">A+</span>
+                <div class="meta"><div class="nm">A+ Core 2</div><div class="cd">220-1102</div></div>
+                <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
+              </div>
+              <div class="cert-row reveal">
+                <span class="mark">AI</span>
+                <div class="meta"><div class="nm">Azure AI Fundamentals</div><div class="cd">AI-900</div></div>
+                <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
+              </div>
+              <div class="cert-row reveal">
+                <span class="mark">SC</span>
+                <div class="meta"><div class="nm">Security Fundamentals</div><div class="cd">SC-900</div></div>
+                <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
+              </div>
+              <div class="cert-row reveal">
+                <span class="mark">CLF</span>
+                <div class="meta"><div class="nm">AWS Cloud Practitioner</div><div class="cd">CLF-C02</div></div>
+                <div class="right"><span class="state">Resume <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span><span class="score">Active</span></div>
+              </div>
+
+              <button class="add reveal" type="button">
+                <span class="ai"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14"></path></svg></span>
+                <span class="at"><b>Add a cert</b><span>Browse the exams you can study</span></span>
+                <span class="ag"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span>
+              </button>
+            </div>
 
             <!-- QUICK LINKS -->
             <div class="sect reveal"><b>More</b></div>
             <div class="links reveal">
-              <button class="link" type="button">
+              <button class="link" id="xcertLink" type="button">
                 <span class="li"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V9M12 19V4M19 19v-7"></path></svg></span>
-                <span class="lt"><b>Cross-cert analytics</b><span>Compare readiness across all your exams</span></span>
-                <span class="pro-pill">Pro</span>
+                <span class="lt"><b>Cross-cert analytics</b><span>Compare readiness across every exam you study</span></span>
+                <span class="pro-pill free-only">Pro</span>
+                <span class="lg pro-only"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span>
               </button>
               <button class="link" type="button">
                 <span class="li"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"></circle><path d="M19 12a7 7 0 0 0-.1-1l2-1.5-2-3.5-2.4 1a7 7 0 0 0-1.7-1L16.5 2h-4l-.3 2.6a7 7 0 0 0-1.7 1l-2.4-1-2 3.5 2 1.5a7 7 0 0 0 0 2l-2 1.5 2 3.5 2.4-1a7 7 0 0 0 1.7 1l.3 2.6h4l.3-2.6a7 7 0 0 0 1.7-1l2.4 1 2-3.5-2-1.5a7 7 0 0 0 .1-1z"></path></svg></span>
@@ -317,16 +424,16 @@
               </button>
               <button class="link" type="button">
                 <span class="li"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4"></circle><path d="M4 21a8 8 0 0 1 16 0"></path></svg></span>
-                <span class="lt"><b>Account</b><span>Sign-in, subscription, sync</span></span>
+                <span class="lt"><b>Account</b><span>Sign-in, subscription, plan</span></span>
                 <span class="lg"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"></path></svg></span>
               </button>
             </div>
 
             <!-- GO PRO (free users only) -->
-            <div class="pro reveal" id="proCard">
+            <div class="pro reveal free-only" id="proCard">
               <p class="pro-eyebrow">On Free, you study one cert</p>
               <h2 class="pro-title">Study every cert with Pro</h2>
-              <p class="pro-body">All eight exams unlocked, unlimited questions a day, and cross-cert analytics. Your <b>Security+</b> progress stays exactly where it is.</p>
+              <p class="pro-body">Every cert unlocked, no daily question cap, and analytics across all of them. Your <b>Security+</b> progress comes with you.</p>
               <div class="price-row">
                 <div class="price best">
                   <span class="save">Save 26%</span>
@@ -343,17 +450,30 @@
               <button class="pro-cta" type="button">Go Pro</button>
               <span class="pro-reassure">Cancel anytime. Apple Pay supported.</span>
             </div>
-            <p class="pro-note">This card is hidden for Pro users.</p>
           </div>
+
+          <!-- upsell sheet: opens when a locked cert (or a Pro feature) is tapped on Free -->
+          <div class="scrim" id="scrim"></div>
+          <aside class="sheet" id="sheet" role="dialog" aria-modal="true" aria-labelledby="sheetTitle" aria-hidden="true">
+            <div class="sheet-grab"></div>
+            <span class="sheet-lock"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></span>
+            <h2 id="sheetTitle">Network+ is a Pro exam</h2>
+            <p id="sheetBody">You're studying <b>Security+</b>. Pro adds <b>Network+</b> and every other exam, and your Security+ progress stays exactly where it is. From $7.42 a month.</p>
+            <button class="sheet-cta" id="sheetGoPro" type="button">Unlock with Pro</button>
+            <button class="sheet-dismiss" id="sheetClose" type="button">Keep studying Security+</button>
+          </aside>
         </div>
       </div>
-      <p class="hint">Hub mockup. The top-level lobby, above any single cert. Tap the theme button to switch light and dark.</p>
+      <p class="hint">Hub mockup. Use the Free and Pro toggle to preview each plan. Only Pro can switch between certs.</p>
     </div>
   </div>
 
   <script>
     (function () {
-      var html = document.documentElement, label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
+      var html = document.documentElement, screen = document.getElementById('screen');
+
+      /* ── theme ── */
+      var label = document.getElementById('themeLabel'), icon = document.getElementById('themeIcon');
       var appIcon = document.getElementById('appThemeIcon');
       var SUN = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path>';
       var MOON = '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>';
@@ -373,6 +493,49 @@
       document.getElementById('themeToggle').addEventListener('click', toggleTheme);
       document.getElementById('appTheme').addEventListener('click', toggleTheme);
       paint();
+
+      /* ── plan preview toggle (Free / Pro) ── */
+      var bFree = document.getElementById('planFree'), bPro = document.getElementById('planPro');
+      function setPlan(plan){
+        var free = plan !== 'pro';
+        screen.setAttribute('data-plan', free ? 'free' : 'pro');
+        bFree.classList.toggle('is-on', free); bFree.setAttribute('aria-pressed', String(free));
+        bPro.classList.toggle('is-on', !free); bPro.setAttribute('aria-pressed', String(!free));
+        try { localStorage.setItem('ca-hub-plan', free ? 'free' : 'pro'); } catch (e) {}
+      }
+      var savedPlan = 'free';
+      try { savedPlan = localStorage.getItem('ca-hub-plan') || 'free'; } catch (e) {}
+      setPlan(savedPlan);
+      bFree.addEventListener('click', function(){ setPlan('free'); });
+      bPro.addEventListener('click', function(){ setPlan('pro'); });
+
+      /* ── upsell sheet ── */
+      var scrim = document.getElementById('scrim'), sheet = document.getElementById('sheet');
+      var sTitle = document.getElementById('sheetTitle'), sBody = document.getElementById('sheetBody');
+      function openSheet(name){
+        var feature = name === 'Cross-cert analytics';
+        sTitle.textContent = feature ? 'Cross-cert analytics is a Pro feature' : (name + ' is a Pro exam');
+        sBody.innerHTML = feature
+          ? 'See how ready you are across every exam in one place. It comes with Pro, from $7.42 a month.'
+          : 'You\'re studying <b>Security+</b>. Pro adds <b>' + name + '</b> and every other exam, and your Security+ progress stays exactly where it is. From $7.42 a month.';
+        scrim.classList.add('open'); sheet.classList.add('open'); sheet.setAttribute('aria-hidden', 'false');
+      }
+      function closeSheet(){
+        scrim.classList.remove('open'); sheet.classList.remove('open'); sheet.setAttribute('aria-hidden', 'true');
+      }
+      scrim.addEventListener('click', closeSheet);
+      document.getElementById('sheetClose').addEventListener('click', closeSheet);
+      document.getElementById('sheetGoPro').addEventListener('click', function(){
+        closeSheet();
+        var pro = document.getElementById('proCard');
+        if (pro){ pro.scrollIntoView({ behavior: 'smooth', block: 'center' }); pro.classList.remove('flash'); void pro.offsetWidth; pro.classList.add('flash'); }
+      });
+
+      Array.prototype.forEach.call(document.querySelectorAll('.cert-row.locked'), function(row){
+        row.addEventListener('click', function(){ openSheet(row.getAttribute('data-cert')); });
+      });
+      var xc = document.getElementById('xcertLink');
+      if (xc) xc.addEventListener('click', function(){ if (screen.getAttribute('data-plan') === 'free') openSheet('Cross-cert analytics'); });
     })();
   </script>
 </body>


### PR DESCRIPTION
## What
The iOS-sandbox **Hub** (\`mockups/cert-ios-hub.html\`) is the cert picker, so this gates the *switch* instead of adding a screen.

- **Free:** active cert (Security+) stays usable; every other cert is a **locked teaser** (muted mark + \`Pro\` pill + padlock) that opens a Pro upsell sheet on tap. Free users can no longer pick another cert.
- **Pro:** full switchable library (Passed / In progress / Add a cert), no locks, Go Pro card hidden.
- A **Free / Pro preview toggle** (defaults Free) in the sandbox chrome lets you flip between both states.
- **No "sync now"** control; also removed the stray "sync" label from the Account row.

Matches the shipped \`v7.33.0\` free-tier cert lock, so the mockup and live behaviour now agree.

## How it was built (4-pass pipeline)
1. **design-taste-frontend** — redesign-preserve on the forged-bronze / Fraunces+Inter system; "all certs" over hardcoded counts; zero em-dashes; contrast/shape locks.
2. **emil-design-eng** — upsell sheet on the iOS drawer curve, asymmetric enter (.34s) / exit (.22s), pointer-events hygiene, press feedback, \`prefers-reduced-motion\` fade path.
3. **humanizer** — naturalised the microcopy.
4. **marketing-psychology** — endowment + loss-aversion framing ("your Security+ progress stays exactly where it is"), names the tapped cert, plants the "from \$7.42/mo" anchor, action CTA ("Unlock with Pro") with a friendly status-quo dismiss.

## Verified
Free = 7 locked rows + Go Pro + free stats; Pro = 7-row switchable library, no locks, no Go Pro. Sheet injects the tapped cert name and routes to the revealed Pro card. Em-dash count: 0. Lane: fast (mockup-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)