### PR TITLE
v7.36.0 — mockup lift-and-shift: cert-ios design language across the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.36.0 | Mockup lift: cert-ios design language on all app surfaces — centered column + tab bar chrome, quiz/results/review/settings/home/progress/analytics/SR-review lifts, net-new Drills tab, exam-date sheet, day-0 + capped states |
 | v7.35.0 | Mobile Home redesign (Start-first, collapsible Practice/Exam/Drill, readiness strip) + in-view signed-out prompt, top-strip update banner, 44px tap targets, sticky Results CTA; desktop readiness/PROD polish |
 | v7.34.0 | Desktop home polish — compress empty readiness hero (no-score state) + hide PROD badge from live users |
 | v7.33.0 | Free-tier cert lock: one cert until Pro (web + native) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.35.0
+// Network+ AI Quiz — app.js  v7.36.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.35.0';
+const APP_VERSION = '7.36.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/index.html
+++ b/index.html
@@ -756,7 +756,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.35.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.36.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/index.html
+++ b/index.html
@@ -1198,6 +1198,39 @@
 </div>
 
 <!-- ══════════════════════════════════════════
+     DRILLS PAGE (lift Phase 3 — net-new tab screen)
+     1:1 port of mockups/cert-ios-drills.html (cert-ios-e2e worktree).
+     Rendered by liftRenderDrills() in lift-shell.js from real data:
+     wrong bank (startWrongDrill), weak spots (computeWeakSpotScores →
+     focusTopic), DOMAIN_WEIGHTS domains (applyDomainPreset).
+══════════════════════════════════════════ -->
+<div id="page-drills" class="page">
+  <div class="drills-hdr">
+    <h1 class="drills-title">Drills</h1>
+    <span class="drills-plan-tag" id="drills-plan-tag">N10-009</span>
+  </div>
+  <p class="drills-lede">Short, repeat passes on the things you get wrong. Ten questions or fewer, scored like practice.</p>
+
+  <div class="drills-card" id="drills-mistakes-card">
+    <div class="drills-card-head"><span class="drills-card-title">Drill Mistakes</span><span class="drills-count-pill" id="drills-mistakes-pill">0 saved</span></div>
+    <p class="drills-card-note" id="drills-mistakes-note">Clear the wrong answers in your bank. Get one right twice in a row and it leaves the bank for good.</p>
+    <button type="button" class="drills-btn" id="drills-mistakes-btn" onclick="startWrongDrill()">Drill your mistakes</button>
+  </div>
+
+  <div class="drills-card" id="drills-weak-card">
+    <div class="drills-card-head"><span class="drills-card-title">Weakest topics</span></div>
+    <div class="drills-topic-chips" id="drills-weak-chips"></div>
+    <p class="drills-card-note">Your lowest-mastery topics right now. The drill leads with the weakest of them.</p>
+    <button type="button" class="drills-btn" id="drills-weak-btn">Drill weakest topics</button>
+  </div>
+
+  <div class="drills-sect">Drill by domain</div>
+  <div id="drills-domain-list"></div>
+
+  <p class="drills-foot-note">Drills don't touch your daily review queue — those cards stay scheduled.</p>
+</div>
+
+<!-- ══════════════════════════════════════════
      EXAM PAGE
 ══════════════════════════════════════════ -->
 <div id="page-exam" class="page">

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 <link rel="stylesheet" href="styles.css">
 <link rel="stylesheet" href="dg-system.css?v=7.33.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
+<link rel="stylesheet" href="lift-shell.css?v=7.36.0">
 <!-- v5.5.1 — Fraunces display face for the editorial system (Home v3
      reimagining + cross-surface). Body stays the app font; Fraunces is
      scoped to display moments in dg-system.css. preconnect + display=swap
@@ -1665,6 +1666,7 @@
 <script defer src="lib/onboarding-chrome.js"></script>
 <script defer src="lib/onboarding-home.js"></script>
 <script defer src="app.js"></script>
+<script defer src="lift-shell.js?v=7.36.0"></script>
 <!-- codex-home reveal animation. Purely presentational + additive: a
      staggered IntersectionObserver fade-up for #page-setup .reveal blocks,
      with a hard safety net so any conditionally-rendered card (NBM /

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 <link rel="stylesheet" href="dg-system.css?v=7.33.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <link rel="stylesheet" href="lift-shell.css?v=7.36.0">
+<link rel="stylesheet" href="lift-screens.css?v=7.36.0">
 <!-- v5.5.1 — Fraunces display face for the editorial system (Home v3
      reimagining + cross-surface). Body stays the app font; Fraunces is
      scoped to display moments in dg-system.css. preconnect + display=swap
@@ -948,7 +949,19 @@
 ══════════════════════════════════════════ -->
 <div id="page-quiz" class="page">
   <div class="quiz-topbar">
-    <button class="back-btn" onclick="confirmBack()" aria-label="Back to menu">&#8592; Menu</button>
+    <button class="back-btn" onclick="confirmBack()" aria-label="Back to menu" title="Exit session"><svg viewBox="0 0 24 24" aria-hidden="true" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M18 6L6 18"></path></svg><span class="back-btn-label">Menu</span></button>
+    <!-- lift Phase 1: progress track lives in the bar (mockup .qbar anatomy) -->
+    <div class="progress-wrap">
+      <div class="progress-label">
+        <button class="quiz-nav-arrow" id="quiz-prev-btn" onclick="prevQuestion()"
+                title="Previous question (←)" aria-label="Previous question" disabled>&#8249;</button>
+        <span id="q-label">Question 1 of 10</span>
+        <button class="quiz-nav-arrow" id="quiz-next-arrow-btn" onclick="nextQuestion()"
+                title="Next question (→)" aria-label="Next question" disabled>&#8250;</button>
+        <span id="q-pct">0%</span>
+      </div>
+      <div class="progress-bar"><div class="progress-fill" id="prog-fill" style="width:0%"></div></div>
+    </div>
     <div class="quiz-stats">
       <div class="stat-pill score" id="live-score" role="status" aria-live="polite" aria-label="Score">0 / 0</div>
       <div class="stat-pill streak" id="live-streak" role="status" aria-live="polite" aria-label="Current streak">Streak 0</div>
@@ -957,26 +970,10 @@
     </div>
   </div>
 
-  <div class="progress-wrap">
-    <div class="progress-label">
-      <!-- v4.82.0: Prev/Next nav arrows for revisiting previously answered
-           questions. Disabled appropriately based on current/total. Keyboard:
-           ArrowLeft / ArrowRight bound in the global keydown handler. -->
-      <button class="quiz-nav-arrow" id="quiz-prev-btn" onclick="prevQuestion()"
-              title="Previous question (←)" aria-label="Previous question" disabled>&#8249;</button>
-      <span id="q-label">Question 1 of 10</span>
-      <button class="quiz-nav-arrow" id="quiz-next-arrow-btn" onclick="nextQuestion()"
-              title="Next question (→)" aria-label="Next question" disabled>&#8250;</button>
-      <span id="q-pct">0%</span>
-    </div>
-    <div class="progress-bar"><div class="progress-fill" id="prog-fill" style="width:0%"></div></div>
-    <!-- v4.54.8: segmented per-question progress dots (prototype pattern).
-         One dot per question: moss-green=correct, red=wrong, tall ink=current,
-         grey=pending. Rendered by _renderQuizProgressDots() in render().
-         v4.82.0: dots are now clickable buttons. Click any answered dot to
-         revisit that question; click any pending dot to jump ahead. -->
-    <div class="quiz-prog-dots" id="quiz-prog-dots" role="progressbar" aria-label="Per-question progress"></div>
-  </div>
+  <!-- v4.54.8 dots (now styled as the mockup's numbered question pills; still
+       rendered + wired by _renderQuizProgressDots(): click to revisit/jump).
+       The progress track + label moved into .quiz-topbar (lift Phase 1). -->
+  <div class="quiz-prog-dots" id="quiz-prog-dots" role="progressbar" aria-label="Per-question progress"></div>
 
   <div class="q-card">
     <div class="q-meta">

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -1060,3 +1060,154 @@ html[data-theme] body #page-analytics .ana-empty-card {
   border: 1px solid var(--border) !important; border-radius: 17px !important;
   background: var(--surface) !important; padding: 26px 18px !important; text-align: center;
 }
+
+/* ─────────────────────────── SR DAILY REVIEW (Phase 3) ─────────────────────────── */
+/* Source: cert-ios-review.html (Daily Review session). Immersive (HIDE_ON).
+   hdr→.ed-pagehead · prog→.sr-progress-row · why chip→.sr-why-due ·
+   .q→.sr-question · .opt→.sr-option · .fb→.sr-explanation (ok/no derived via
+   :has on the revealed options) · recap→#sr-complete/#sr-empty. */
+
+#page-sr-review { --lift-ease: cubic-bezier(0.16, 1, 0.3, 1); }
+html[data-theme] body #page-sr-review { padding-top: 6px !important; }
+
+/* header → mockup .hdr (back chip + Fraunces title) */
+html[data-theme] body #page-sr-review .ed-pagehead { display: flex !important; align-items: center !important; gap: 11px !important; margin: 4px 0 10px !important; padding: 0 !important; background: none !important; border: 0 !important; }
+html[data-theme] body #page-sr-review .ed-pagehead-back {
+  flex: 0 0 auto; width: 36px !important; height: 36px !important; display: grid !important; place-items: center !important;
+  border: 1px solid var(--border) !important; border-radius: 10px !important;
+  background: var(--surface) !important; color: var(--text-mid) !important;
+  font-size: 0 !important; padding: 0 !important; cursor: pointer;
+  transition: transform .14s var(--lift-ease), border-color .18s !important; overflow: hidden; white-space: nowrap;
+}
+html[data-theme] body #page-sr-review .ed-pagehead-back::after { content: '\2190'; font: 700 16px/1 Inter, sans-serif; }
+html[data-theme] body #page-sr-review .ed-pagehead-back:active { transform: scale(0.94); }
+html[data-theme] body #page-sr-review .ed-pagehead-eyebrow { display: none !important; }
+html[data-theme] body #page-sr-review .ed-pagehead-display {
+  font: 600 20px/1.1 Fraunces, Georgia, serif !important; letter-spacing: -0.01em !important;
+  color: var(--text) !important; margin: 0 !important;
+  background: none !important; border: 0 !important; outline: 0 !important; box-shadow: none !important;
+  padding: 0 !important; text-decoration: none !important;
+}
+html[data-theme] body #page-sr-review .ed-pagehead-display::before, html[data-theme] body #page-sr-review .ed-pagehead-display::after { content: none !important; }
+html[data-theme] body #page-sr-review .ed-pagehead-display em {
+  font-style: normal !important; color: var(--accent) !important;
+  background: none !important; border: 0 !important; box-shadow: none !important; text-decoration: none !important;
+}
+html[data-theme] body #page-sr-review .sr-meta-interval, html[data-theme] body #page-sr-review .sr-meta-streak, html[data-theme] body #page-sr-review .sr-meta-sep { color: var(--text-dim) !important; }
+
+/* progress strip → mockup .prog */
+html[data-theme] body #page-sr-review .sr-progress-row { display: block !important; margin: 0 0 14px !important; padding: 0 !important; background: none !important; border: 0 !important; }
+html[data-theme] body #page-sr-review .sr-progress-text { font: 700 12px/1 Inter, sans-serif !important; color: var(--text-dim) !important; margin-bottom: 7px !important; }
+html[data-theme] body #page-sr-review .sr-progress-bar { height: 5px !important; border-radius: 999px !important; background: var(--surface3) !important; overflow: hidden; }
+html[data-theme] body #page-sr-review .sr-progress-fill { display: block; height: 100% !important; border-radius: 999px !important; background: var(--accent) !important; transition: width .4s var(--lift-ease); }
+
+/* card: flat flow (mockup .body has no card chrome) */
+html[data-theme] body #page-sr-review .sr-card { background: none !important; border: 0 !important; border-radius: 0 !important; box-shadow: none !important; padding: 0 !important; margin: 0 !important; }
+html[data-theme] body #page-sr-review .sr-card-meta {
+  display: flex; align-items: baseline; flex-wrap: wrap; gap: 6px;
+  font: 600 10.5px/1.3 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; margin: 0 0 10px !important;
+}
+html[data-theme] body #page-sr-review .sr-meta-topic { color: var(--text-mid) !important; }
+
+/* why-due chip → mockup .why */
+html[data-theme] body #page-sr-review .sr-why-due {
+  display: inline-flex !important; align-items: center !important; gap: 7px !important;
+  font: 600 11.5px/1 Inter, sans-serif !important; color: var(--text-dim) !important;
+  background: var(--surface3) !important; border: 1px solid var(--border) !important;
+  border-radius: 999px !important; padding: 7px 11px !important; margin: 0 0 16px !important;
+}
+html[data-theme] body #page-sr-review .sr-why-due.sr-why-rebuild { color: var(--red) !important; border-color: color-mix(in oklab, var(--red) 30%, var(--border)) !important; }
+html[data-theme] body #page-sr-review .sr-why-ico { width: 13px !important; height: 13px !important; stroke: var(--accent) !important; }
+
+/* retry pill */
+html[data-theme] body #page-sr-review .sr-retry-pill {
+  display: inline-flex !important; align-items: center !important; gap: 7px !important;
+  font: 600 11px/1.3 Inter, sans-serif !important; color: var(--accent) !important;
+  background: color-mix(in oklab, var(--accent) 10%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border)) !important;
+  border-radius: 999px !important; padding: 7px 11px !important; margin: 12px 0 0 !important;
+}
+html[data-theme] body #page-sr-review .sr-retry-pill .sr-why-ico { stroke: var(--accent) !important; }
+
+/* question stem → mockup .q */
+html[data-theme] body #page-sr-review .sr-question {
+  font: 600 21px/1.25 Fraunces, Georgia, serif !important; letter-spacing: -0.01em !important;
+  color: var(--text) !important; margin: 0 0 18px !important;
+}
+
+/* options → mockup .opt */
+html[data-theme] body #page-sr-review .sr-options { display: grid !important; gap: 9px !important; margin: 0 !important; }
+html[data-theme] body #page-sr-review .sr-option {
+  display: flex !important; align-items: center !important; gap: 12px !important; width: 100% !important; text-align: left !important;
+  cursor: pointer; font: 600 14.5px/1.3 Inter, sans-serif !important; color: var(--text) !important;
+  background: var(--surface) !important; border: 1.5px solid var(--border) !important;
+  border-radius: 13px !important; padding: 14px 15px !important; margin: 0 !important; box-shadow: none !important;
+  transition: border-color .16s var(--lift-ease), background .16s var(--lift-ease), transform .1s var(--lift-ease) !important;
+}
+html[data-theme] body #page-sr-review .sr-option:active { transform: scale(0.99); }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-sr-review .sr-option:not(:disabled):hover { border-color: color-mix(in oklab, var(--accent) 30%, var(--border)) !important; } }
+html[data-theme] body #page-sr-review .sr-option-letter {
+  flex: 0 0 auto; width: 24px !important; height: 24px !important; border-radius: 7px !important;
+  background: var(--surface3) !important; color: var(--text-dim) !important;
+  font: 800 12px/1 Inter, sans-serif !important; display: grid !important; place-items: center !important;
+  transition: background .16s, color .16s;
+}
+html[data-theme] body #page-sr-review .sr-option-text { flex: 1 1 auto; font: inherit !important; color: inherit !important; }
+html[data-theme] body #page-sr-review .sr-option.is-picked { border-color: color-mix(in oklab, var(--accent) 55%, var(--border)) !important; background: color-mix(in oklab, var(--accent) 7%, var(--surface)) !important; }
+html[data-theme] body #page-sr-review .sr-option.is-picked .sr-option-letter { background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important; }
+html[data-theme] body #page-sr-review .sr-option.is-correct { border-color: var(--green) !important; background: color-mix(in oklab, var(--green) 12%, var(--surface)) !important; }
+html[data-theme] body #page-sr-review .sr-option.is-correct .sr-option-letter { background: var(--green) !important; color: var(--on-accent, var(--bg)) !important; }
+html[data-theme] body #page-sr-review .sr-option.is-wrong { border-color: var(--red) !important; background: color-mix(in oklab, var(--red) 11%, var(--surface)) !important; }
+html[data-theme] body #page-sr-review .sr-option.is-wrong .sr-option-letter { background: var(--red) !important; color: #fff !important; }
+
+/* explanation → mockup .fb, ok/no tint derived from the revealed options */
+html[data-theme] body #page-sr-review .sr-explanation {
+  border-radius: 13px !important; padding: 13px 15px !important; margin: 16px 0 0 !important;
+  font-size: 13px !important; line-height: 1.45 !important; color: var(--text-mid) !important;
+  background: color-mix(in oklab, var(--green) 12%, var(--surface)) !important;
+  border: 1px solid color-mix(in oklab, var(--green) 30%, transparent) !important; box-shadow: none !important;
+}
+html[data-theme] body #page-sr-review .sr-explanation strong { color: var(--green) !important; font-weight: 800 !important; }
+html[data-theme] body #page-sr-review .sr-card:has(.sr-option.is-wrong) .sr-explanation {
+  background: color-mix(in oklab, var(--red) 11%, var(--surface)) !important;
+  border-color: color-mix(in oklab, var(--red) 28%, transparent) !important;
+}
+html[data-theme] body #page-sr-review .sr-card:has(.sr-option.is-wrong) .sr-explanation strong { color: var(--red) !important; }
+
+/* confidence row: calm full-width choice cards under the reveal */
+html[data-theme] body #page-sr-review .sr-confidence-row { display: grid !important; gap: 9px !important; margin: 14px 0 0 !important; padding: 0 !important; background: none !important; border: 0 !important; }
+html[data-theme] body #page-sr-review .sr-confidence-label {
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.1em !important; text-transform: uppercase !important;
+  color: var(--text-dim) !important; margin: 2px 0 0 !important;
+}
+html[data-theme] body #page-sr-review .sr-confidence-btn {
+  display: block !important; width: 100% !important; text-align: left !important; cursor: pointer;
+  font: 700 13.5px/1.3 Inter, sans-serif !important; color: var(--text) !important;
+  background: var(--surface) !important; border: 1.5px solid var(--border) !important;
+  border-radius: 13px !important; padding: 12px 14px !important; margin: 0 !important; box-shadow: none !important;
+  transition: transform .12s var(--lift-ease), border-color .16s !important;
+}
+html[data-theme] body #page-sr-review .sr-confidence-btn:active { transform: scale(0.985); }
+html[data-theme] body #page-sr-review .sr-confidence-confident { border-color: color-mix(in oklab, var(--green) 40%, var(--border)) !important; }
+html[data-theme] body #page-sr-review .sr-confidence-uncertain { border-color: color-mix(in oklab, var(--accent) 40%, var(--border)) !important; }
+html[data-theme] body #page-sr-review .sr-confidence-wrong { border-color: color-mix(in oklab, var(--red) 40%, var(--border)) !important; }
+html[data-theme] body #page-sr-review .sr-confidence-hint { display: block !important; font: 500 11px/1.4 Inter, sans-serif !important; color: var(--text-dim) !important; margin-top: 3px !important; }
+
+/* empty + complete recap → mockup .done */
+html[data-theme] body #page-sr-review .sr-empty {
+  text-align: center !important; border: 0 !important; background: none !important; padding: 36px 8px 8px !important; box-shadow: none !important;
+}
+html[data-theme] body #page-sr-review .sr-empty h2 {
+  font: 600 25px/1.15 Fraunces, Georgia, serif !important; letter-spacing: -0.015em !important;
+  color: var(--text) !important; margin: 0 0 6px !important;
+}
+html[data-theme] body #page-sr-review .sr-empty p { font-size: 14px !important; line-height: 1.5 !important; color: var(--text-mid) !important; margin: 0 0 22px !important; }
+html[data-theme] body #page-sr-review .sr-empty .btn-primary {
+  width: 100% !important; border: 0 !important; border-radius: 13px !important; padding: 15px !important;
+  background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important;
+  font: 800 15.5px/1 Inter, sans-serif !important; cursor: pointer;
+  box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent) !important;
+  transition: transform .15s var(--lift-ease), filter .2s !important;
+}
+html[data-theme] body #page-sr-review .sr-empty .btn-primary:active { transform: scale(0.985); }
+html[data-theme] body #page-sr-review #sr-forecast-complete { margin: 0 0 18px !important; font-size: 12.5px !important; color: var(--text-dim) !important; }

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -1211,3 +1211,89 @@ html[data-theme] body #page-sr-review .sr-empty .btn-primary {
 }
 html[data-theme] body #page-sr-review .sr-empty .btn-primary:active { transform: scale(0.985); }
 html[data-theme] body #page-sr-review #sr-forecast-complete { margin: 0 0 18px !important; font-size: 12.5px !important; color: var(--text-dim) !important; }
+
+/* ─────────────────────────── DRILLS TAB (Phase 3, net-new) ─────────────────────────── */
+/* Source: cert-ios-drills.html. The page markup is the lift's own
+   (#page-drills in index.html + liftRenderDrills in lift-shell.js), so the
+   class names mirror the mockup directly — no dg-system overrides needed,
+   but selectors stay in the same scoped pattern for consistency. */
+
+#page-drills { --lift-ease: cubic-bezier(0.16, 1, 0.3, 1); }
+html[data-theme] body #page-drills { padding-top: 10px !important; }
+
+/* showPage moves focus to the page h1 for screen readers — don't draw the
+   interactive focus ring on a static heading (mockups carry no ring) */
+html[data-theme] body .page h1[tabindex="-1"]:focus,
+html[data-theme] body .page h2[tabindex="-1"]:focus { outline: none !important; box-shadow: none !important; }
+
+html[data-theme] body #page-drills .drills-hdr { display: flex; align-items: center; gap: 11px; margin: 2px 0 4px; }
+html[data-theme] body #page-drills .drills-title {
+  flex: 1; font: 600 21px/1.1 Fraunces, Georgia, serif !important; letter-spacing: -0.01em;
+  color: var(--text) !important; margin: 0 !important;
+}
+html[data-theme] body #page-drills .drills-plan-tag {
+  flex: 0 0 auto; font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--text-dim); background: color-mix(in oklab, var(--text) 6%, transparent);
+  border: 1px solid var(--border); border-radius: 999px; padding: 6px 9px;
+}
+html[data-theme] body #page-drills .drills-lede { font: 500 12.5px/1.5 Inter, sans-serif; color: var(--text-dim); margin: 2px 2px 14px; }
+
+html[data-theme] body #page-drills .drills-card {
+  border: 1px solid var(--border); border-radius: 16px; background: var(--surface);
+  padding: 15px 16px; margin-bottom: 11px;
+}
+html[data-theme] body #page-drills .drills-card-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+html[data-theme] body #page-drills .drills-card-title { font: 650 14.5px/1.2 Inter, sans-serif; color: var(--text); }
+html[data-theme] body #page-drills .drills-card-note { font-size: 12px; line-height: 1.45; color: var(--text-dim); margin: 9px 0 0; }
+html[data-theme] body #page-drills .drills-card-note b { color: var(--text-mid); font-weight: 650; }
+html[data-theme] body #page-drills .drills-count-pill {
+  flex: 0 0 auto; font: 700 10.5px/1 'Roboto Mono', ui-monospace, monospace; color: var(--accent);
+  border: 1px solid color-mix(in oklab, var(--accent) 38%, var(--border));
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface));
+  border-radius: 999px; padding: 6px 10px;
+}
+html[data-theme] body #page-drills .drills-btn {
+  width: 100%; margin-top: 12px; border: none; border-radius: 12px; padding: 12px; cursor: pointer;
+  background: var(--accent); color: var(--on-accent, var(--bg)); font: 700 14px/1 Inter, sans-serif;
+  transition: transform .14s var(--lift-ease), filter .2s, opacity .2s;
+}
+html[data-theme] body #page-drills .drills-btn:active:not(:disabled) { transform: scale(0.985); }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-drills .drills-btn:hover:not(:disabled) { filter: brightness(1.06); } }
+html[data-theme] body #page-drills .drills-btn:disabled { opacity: 0.4; cursor: default; }
+
+html[data-theme] body #page-drills .drills-topic-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 11px; }
+html[data-theme] body #page-drills .drills-chip {
+  font: 600 11.5px/1.3 Inter, sans-serif; color: var(--text-mid);
+  border: 1px solid var(--border); background: var(--surface3); border-radius: 999px; padding: 7px 11px;
+}
+html[data-theme] body #page-drills .drills-chip b { color: var(--red); font-weight: 700; font-variant-numeric: tabular-nums; }
+html[data-theme] body #page-drills .drills-chip-empty { color: var(--text-dim); }
+
+html[data-theme] body #page-drills .drills-sect {
+  font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--text-dim); margin: 18px 2px 11px;
+}
+html[data-theme] body #page-drills .drills-domain {
+  display: block; width: 100%; text-align: left; cursor: pointer;
+  border: 1px solid var(--border); border-radius: 14px; background: var(--surface3);
+  padding: 12px 14px; margin-bottom: 9px;
+  transition: border-color .18s, transform .12s var(--lift-ease);
+}
+html[data-theme] body #page-drills .drills-domain:active { transform: scale(0.995); }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-drills .drills-domain:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)); } }
+html[data-theme] body #page-drills .drills-domain-top { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+html[data-theme] body #page-drills .drills-domain-top b { font: 650 13.5px/1.2 Inter, sans-serif; color: var(--text); }
+html[data-theme] body #page-drills .drills-domain-wt { flex: 0 0 auto; font: 600 10px/1 'Roboto Mono', ui-monospace, monospace; color: var(--text-dim); }
+html[data-theme] body #page-drills .drills-domain-bar {
+  display: block; height: 6px; border-radius: 999px; background: var(--surface3); overflow: hidden;
+  margin-top: 8px; position: relative; border: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+}
+html[data-theme] body #page-drills .drills-domain-bar i {
+  position: absolute; left: 0; top: 0; bottom: 0; display: block; border-radius: 999px;
+  background: var(--accent); transition: width .7s var(--lift-ease);
+}
+html[data-theme] body #page-drills .drills-domain-bar.full i { background: var(--green); }
+html[data-theme] body #page-drills .drills-domain-mast { display: block; font: 600 9.5px/1.3 Inter, sans-serif; color: var(--text-dim); margin-top: 6px; }
+html[data-theme] body #page-drills .drills-domain-mast b { color: var(--text-mid); font-weight: 700; }
+
+html[data-theme] body #page-drills .drills-foot-note { font: 500 11px/1.5 Inter, sans-serif; color: var(--text-dim); text-align: center; margin: 16px 8px 4px; }

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -1,0 +1,169 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   LIFT-SCREENS · Phase 1 of the mockup lift-and-shift (2026-06-10)
+   Per-screen 1:1 ports of the cert-ios mockups onto the REAL app pages.
+   Source of truth: mockups/cert-ios-quiz.html (this file: quiz session).
+   Loads LAST — selectors mirror dg-system's `html[data-theme] body #page-X`
+   pattern so later-order wins the specificity tie.
+   Token map (mockup → app): --ink→--text · --ink-soft→--text-mid ·
+   --muted→--text-dim · --surface-2→--surface3 · --track→--surface3 ·
+   --pass→--green · --miss→--red · --on-accent→var(--on-accent, var(--bg))
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ─────────────────────────── QUIZ SESSION ─────────────────────────── */
+
+#page-quiz { --lift-ease: cubic-bezier(0.16, 1, 0.3, 1); }
+html[data-theme] body #page-quiz { padding-top: 0 !important; }
+
+/* qbar: exit ✕ + track + flag (mockup .qbar) */
+html[data-theme] body #page-quiz .quiz-topbar {
+  display: flex !important; align-items: center !important; gap: 13px !important;
+  padding: 13px 0 12px !important; margin: 0 !important;
+  border: 0 !important; border-bottom: 0 !important; background: none !important;
+}
+html[data-theme] body #page-quiz .back-btn {
+  flex: 0 0 auto; width: 34px !important; height: 34px !important;
+  display: grid !important; place-items: center !important;
+  border: 1px solid var(--border) !important; border-radius: 10px !important;
+  background: var(--surface) !important; color: var(--text-mid) !important;
+  padding: 0 !important; cursor: pointer;
+  transition: transform .14s var(--lift-ease), border-color .18s !important;
+}
+html[data-theme] body #page-quiz .back-btn:active { transform: scale(0.94); }
+html[data-theme] body #page-quiz .back-btn:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)) !important; color: var(--text-mid) !important; }
+#page-quiz .back-btn .back-btn-label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+
+/* progress track inside the bar */
+html[data-theme] body #page-quiz .progress-wrap { flex: 1 1 auto; display: flex; flex-direction: column; max-width: none !important; margin: 0 !important; padding: 0 !important; background: none !important; border: 0 !important; }
+#page-quiz .progress-bar { height: 6px; border-radius: 999px; background: var(--surface3); overflow: hidden; order: 1; }
+#page-quiz .progress-fill { height: 100%; border-radius: 999px; background: var(--accent); transition: width .5s var(--lift-ease); }
+#page-quiz .progress-label { display: flex; align-items: center; gap: 8px; margin: 6px 0 0; order: 2; }
+#page-quiz #q-label { font: 700 11px/1 Inter, 'Segoe UI', sans-serif; color: var(--text-dim); letter-spacing: 0.02em; }
+#page-quiz #q-pct,
+html[data-theme] body #page-quiz .quiz-nav-arrow { display: none !important; }
+
+/* session chrome the mockup doesn't carry */
+html[data-theme] body #page-quiz .stat-pill { display: none !important; }
+html[data-theme] body #page-quiz .cache-notice, html[data-theme] body #page-quiz #cache-notice.show { display: none !important; }
+#page-quiz .quiz-kbd-hints { display: none !important; }
+html[data-theme] body #page-quiz .quiz-stats { gap: 0 !important; }
+html[data-theme] body #page-quiz .flag-btn {
+  width: 34px; height: 34px; display: grid !important; place-items: center !important;
+  border: 1px solid var(--border) !important; border-radius: 10px !important;
+  background: var(--surface) !important; color: var(--text-dim) !important;
+  font: 700 10px/1 Inter, sans-serif !important; padding: 0 !important;
+  transition: transform .14s var(--lift-ease), border-color .18s, color .18s !important;
+}
+html[data-theme] body #page-quiz .flag-btn:active { transform: scale(0.94); }
+html[data-theme] body #page-quiz .flag-btn.flagged { border-color: var(--accent) !important; color: var(--accent) !important; }
+
+/* numbered question pills (mockup .qpills) — dots renumbered via CSS counter */
+#page-quiz .quiz-prog-dots { display: flex; gap: 7px; margin: 2px 0 16px; padding: 0; overflow-x: auto; scrollbar-width: none; counter-reset: liftqp; background: none; border: 0; }
+#page-quiz .quiz-prog-dots::-webkit-scrollbar { display: none; }
+html[data-theme] body #page-quiz .qpd-cell {
+  flex: 0 0 auto; width: 28px !important; height: 28px !important;
+  border-radius: 9px !important; display: grid; place-items: center;
+  background: var(--surface3) !important; border: 1px solid transparent !important;
+  color: var(--text-dim) !important; font: 800 12px/1 Inter, sans-serif !important;
+  counter-increment: liftqp; cursor: pointer; padding: 0 !important;
+  transition: background .18s, color .18s, border-color .18s;
+}
+#page-quiz .qpd-cell::before { content: counter(liftqp); }
+html[data-theme] body #page-quiz .qpd-cell.qpd-done { color: var(--green) !important; background: color-mix(in oklab, var(--green) 12%, var(--surface3)) !important; border-color: color-mix(in oklab, var(--green) 30%, var(--border)) !important; }
+html[data-theme] body #page-quiz .qpd-cell.qpd-wrong { color: var(--red) !important; background: color-mix(in oklab, var(--red) 11%, var(--surface3)) !important; border-color: color-mix(in oklab, var(--red) 30%, var(--border)) !important; }
+html[data-theme] body #page-quiz .qpd-cell.qpd-now { color: var(--on-accent, var(--bg)) !important; background: var(--accent) !important; border-color: var(--accent) !important; }
+
+/* question block: flat typographic flow (mockup has no card) */
+html[data-theme] body #page-quiz .q-card { background: none !important; border: 0 !important; border-radius: 0 !important; box-shadow: none !important; padding: 0 !important; margin: 0 !important; max-width: none !important; }
+#page-quiz .q-meta { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+html[data-theme] body #page-quiz .q-num { font: 800 12px/1 Inter, sans-serif !important; letter-spacing: 0.04em; color: var(--text-mid) !important; background: none !important; border: 0 !important; padding: 0 !important; }
+html[data-theme] body #page-quiz .diff-badge, html[data-theme] body #page-quiz .pbq-badge {
+  font: 800 9.5px/1 Inter, sans-serif !important; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--accent) !important; background: color-mix(in oklab, var(--accent) 11%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)) !important;
+  border-radius: 999px !important; padding: 6px 10px !important;
+}
+html[data-theme] body #page-quiz .q-text {
+  font-family: Fraunces, Georgia, serif !important; font-weight: 600 !important;
+  font-size: 22px !important; line-height: 1.28 !important; letter-spacing: -0.01em !important;
+  color: var(--text) !important; margin: 0 0 16px !important;
+}
+#page-quiz .q-text .hl-keyword, #page-quiz .q-text .kw { color: var(--accent); font-style: italic; }
+
+/* scenario context (mockup .scenario) */
+html[data-theme] body #page-quiz .q-scenario {
+  border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border)) !important;
+  border-left: 3px solid var(--accent) !important;
+  border-radius: 12px !important;
+  background: color-mix(in oklab, var(--accent) 6%, var(--surface)) !important;
+  padding: 11px 13px !important; margin: 0 0 18px !important;
+  font: 500 13px/1.5 Inter, sans-serif !important; color: var(--text-mid) !important;
+}
+
+/* options (mockup .opt — app DOM is .option > .opt-letter + .opt-text) */
+html[data-theme] body #page-quiz .option {
+  display: flex !important; align-items: center !important; gap: 12px !important;
+  width: 100%; text-align: left;
+  border: 1px solid var(--border) !important; border-radius: 14px !important;
+  background: var(--surface) !important; padding: 13px 14px !important; margin: 0 0 10px !important;
+  color: var(--text) !important; box-shadow: none !important; cursor: pointer;
+  transition: border-color .18s, background .18s, opacity .2s, transform .12s var(--lift-ease) !important;
+}
+html[data-theme] body #page-quiz .option:active { transform: scale(0.99); }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-quiz .option:hover { border-color: color-mix(in oklab, var(--accent) 38%, var(--border)) !important; } }
+html[data-theme] body #page-quiz .option .opt-letter {
+  flex: 0 0 auto; width: 30px !important; height: 30px !important; border-radius: 9px !important;
+  background: var(--surface3) !important; color: var(--text-mid) !important;
+  display: grid !important; place-items: center !important;
+  font: 800 13px/1 Inter, sans-serif !important; transition: background .18s, color .18s;
+}
+html[data-theme] body #page-quiz .option .opt-text { flex: 1 1 auto; font: 500 14.5px/1.35 Inter, sans-serif !important; color: inherit !important; }
+/* answered states (mockup .answered .opt.*) — keep app's class hooks */
+html[data-theme] body #page-quiz .option.correct,
+html[data-theme] body #page-quiz .option.reveal-correct {
+  border-color: color-mix(in oklab, var(--green) 55%, var(--border)) !important;
+  background: color-mix(in oklab, var(--green) 9%, var(--surface)) !important;
+}
+html[data-theme] body #page-quiz .option.correct .opt-letter,
+html[data-theme] body #page-quiz .option.reveal-correct .opt-letter { background: var(--green) !important; color: var(--on-accent, var(--bg)) !important; }
+html[data-theme] body #page-quiz .option.wrong {
+  border-color: color-mix(in oklab, var(--red) 50%, var(--border)) !important;
+  background: color-mix(in oklab, var(--red) 8%, var(--surface)) !important;
+}
+html[data-theme] body #page-quiz .option.wrong .opt-letter { background: var(--red) !important; color: var(--on-accent, var(--bg)) !important; }
+html[data-theme] body #page-quiz .option.dimmed { opacity: .55; }
+
+/* explanation (mockup .why) */
+html[data-theme] body #page-quiz .explanation-box {
+  border: 1px solid color-mix(in oklab, var(--accent) 24%, var(--border)) !important;
+  border-radius: 15px !important;
+  background: color-mix(in oklab, var(--accent) 5%, var(--surface)) !important;
+  padding: 14px 15px !important; margin: 4px 0 0 !important;
+  font-size: 13px !important; line-height: 1.52 !important; color: var(--text-mid) !important;
+  box-shadow: none !important;
+}
+html[data-theme] body #page-quiz .explanation-box strong { display: block; font: 800 11px/1.3 Inter, sans-serif !important; letter-spacing: 0.04em; color: var(--accent) !important; margin-bottom: 9px; text-transform: none; }
+#page-quiz .exp-wrong-explain { margin-top: 9px; padding-top: 9px; border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent); }
+
+/* revisit banner: quiet pill */
+html[data-theme] body #page-quiz .quiz-revisit-banner {
+  display: flex; align-items: center; gap: 8px;
+  border: 1px solid var(--border) !important; border-radius: 11px !important;
+  background: var(--surface3) !important; color: var(--text-mid) !important;
+  font: 600 11.5px/1.4 Inter, sans-serif !important; padding: 9px 12px !important; margin: 10px 0 0 !important;
+}
+
+/* pinned footer action (mockup .qfoot + .btn-primary) */
+#page-quiz .next-btn-row {
+  position: sticky; bottom: 0; margin: 14px -20px 0; padding: 12px 20px calc(12px + env(safe-area-inset-bottom));
+  border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  background: var(--bg); z-index: 5;
+}
+html[data-theme] body #page-quiz .btn-next {
+  width: 100% !important; justify-content: center !important;
+  border: 0 !important; border-radius: 13px !important; padding: 14px !important;
+  background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important;
+  font: 700 15px/1 Inter, sans-serif !important; cursor: pointer;
+  transition: transform .14s var(--lift-ease), filter .2s !important; box-shadow: none !important;
+}
+html[data-theme] body #page-quiz .btn-next:active { transform: scale(0.985); }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-quiz .btn-next:hover { filter: brightness(1.05); } }

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -167,3 +167,253 @@ html[data-theme] body #page-quiz .btn-next {
 }
 html[data-theme] body #page-quiz .btn-next:active { transform: scale(0.985); }
 @media (hover:hover) and (pointer:fine) { html[data-theme] body #page-quiz .btn-next:hover { filter: brightness(1.05); } }
+
+/* ─────────────────────────── SESSION RESULTS ─────────────────────────── */
+/* Source: mockups/cert-ios-results.html (done-head, scaled card, stats
+   hairline rows, qrow review list, rfoot actions) onto #page-results. */
+
+html[data-theme] body #page-results { padding-top: 10px !important; }
+html[data-theme] body #page-results .results-v2 { max-width: none !important; margin: 0 !important; padding: 0 !important; }
+
+/* done-head */
+html[data-theme] body #page-results .results-v2-eyebrow {
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.14em !important; text-transform: uppercase;
+  color: var(--text-dim) !important; margin-bottom: 11px !important; background: none !important; border: 0 !important; padding: 0 !important;
+}
+html[data-theme] body #page-results .results-v2-display {
+  font: 600 30px/1.08 Fraunces, Georgia, serif !important; letter-spacing: -0.014em !important;
+  color: var(--text) !important; margin: 0 !important;
+}
+html[data-theme] body #page-results .results-v2-display em { font-style: normal !important; color: var(--accent) !important; }
+html[data-theme] body #page-results .results-v2-lede {
+  font-size: 13.5px !important; line-height: 1.5 !important; color: var(--text-mid) !important;
+  margin: 10px 0 0 !important; max-width: 34ch;
+}
+
+/* hero -> scaled card + stats card, stacked */
+html[data-theme] body #page-results .results-v2-hero {
+  display: flex !important; flex-direction: column !important; gap: 0 !important;
+  background: none !important; border: 0 !important; padding: 0 !important; margin-top: 18px !important;
+}
+html[data-theme] body #page-results .results-v2-big {
+  border: 1px solid color-mix(in oklab, var(--accent) 20%, var(--border)) !important;
+  border-radius: 18px !important;
+  background: color-mix(in oklab, var(--accent) 5%, var(--surface)) !important;
+  padding: 16px 17px !important; color: var(--text) !important; box-shadow: none !important;
+}
+html[data-theme] body #page-results .results-v2-big-label {
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.12em !important; text-transform: uppercase;
+  color: var(--text-dim) !important;
+}
+html[data-theme] body #page-results .results-v2-big-score {
+  display: flex; align-items: baseline; gap: 9px; margin: 11px 0 12px !important;
+  font: 600 52px/1 Fraunces, Georgia, serif !important; color: var(--text) !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+}
+html[data-theme] body #page-results .results-v2-big-score em {
+  font: 700 14px/1 Inter, sans-serif !important; font-style: normal !important; letter-spacing: 0.04em;
+  color: var(--text-dim) !important;
+}
+html[data-theme] body #page-results .results-v2-verdict {
+  display: inline-flex; align-items: center; gap: 7px;
+  font: 700 11.5px/1 Inter, sans-serif !important; border-radius: 999px !important; padding: 7px 11px !important;
+}
+html[data-theme] body #page-results .results-v2-verdict-pass {
+  color: var(--green) !important; background: color-mix(in oklab, var(--green) 12%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--green) 32%, transparent) !important;
+}
+html[data-theme] body #page-results .results-v2-verdict-fail {
+  color: var(--red) !important; background: color-mix(in oklab, var(--red) 12%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--red) 32%, transparent) !important;
+}
+html[data-theme] body #page-results .results-v2-side {
+  margin-top: 16px !important; border: 1px solid var(--border) !important; border-radius: 15px !important;
+  background: var(--surface) !important; overflow: hidden; padding: 0 !important; box-shadow: none !important;
+}
+html[data-theme] body #page-results .results-v2-row {
+  display: flex !important; align-items: center; justify-content: space-between;
+  padding: 12px 15px !important; margin: 0 !important; border: 0 !important;
+}
+html[data-theme] body #page-results .results-v2-row + .results-v2-row { border-top: 1px solid color-mix(in oklab, var(--border) 64%, transparent) !important; }
+html[data-theme] body #page-results .results-v2-row .k { font: 500 13.5px/1 Inter, sans-serif !important; color: var(--text-mid) !important; }
+html[data-theme] body #page-results .results-v2-row .v { font: 700 14px/1 Inter, sans-serif !important; color: var(--text) !important; font-variant-numeric: lining-nums tabular-nums; }
+html[data-theme] body #page-results #r-correct { color: var(--green) !important; }
+html[data-theme] body #page-results #r-wrong { color: var(--red) !important; }
+
+/* difficulty breakdown: quiet card */
+html[data-theme] body #page-results .diff-breakdown { margin-top: 11px !important; }
+
+/* review-this-session list */
+html[data-theme] body #page-results .results-v2-review { margin-top: 6px !important; background: none !important; border: 0 !important; padding: 0 !important; }
+html[data-theme] body #page-results .results-v2-review-eyebrow {
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.12em !important; text-transform: uppercase;
+  color: var(--text-dim) !important; margin: 22px 2px 7px !important;
+}
+html[data-theme] body #page-results .results-v2-review-title {
+  font: 600 22px/1.1 Fraunces, Georgia, serif !important; letter-spacing: -0.012em !important;
+  color: var(--text) !important; margin: 0 2px 12px !important;
+}
+html[data-theme] body #page-results .results-v2-review-title em { font-style: normal !important; color: var(--accent) !important; }
+html[data-theme] body #page-results .results-v2-review-row {
+  display: flex !important; align-items: flex-start; gap: 12px; width: 100%; text-align: left;
+  border: 1px solid var(--border) !important; border-radius: 13px !important;
+  background: var(--surface) !important; padding: 12px 13px !important; margin: 0 0 9px !important;
+  cursor: pointer; box-shadow: none !important; transition: border-color .18s;
+}
+html[data-theme] body #page-results .results-v2-review-row:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)) !important; }
+html[data-theme] body #page-results .results-v2-review-num { flex: 0 0 auto; font: 700 11px/1.4 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; padding-top: 1px; }
+html[data-theme] body #page-results .results-v2-review-body { flex: 1 1 auto; min-width: 0; }
+html[data-theme] body #page-results .results-v2-review-q {
+  font: 500 13px/1.4 Inter, sans-serif !important; color: var(--text) !important;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+html[data-theme] body #page-results .results-v2-review-meta { font: 500 10.5px/1.3 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; margin-top: 5px !important; }
+html[data-theme] body #page-results .results-v2-review-mark {
+  flex: 0 0 auto; align-self: center;
+  font: 800 9px/1 Inter, sans-serif !important; letter-spacing: 0.08em !important; text-transform: uppercase;
+  border-radius: 999px !important; padding: 5px 8px !important;
+}
+html[data-theme] body #page-results .results-v2-review-mark-ok {
+  color: var(--green) !important; background: color-mix(in oklab, var(--green) 12%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--green) 32%, transparent) !important;
+}
+html[data-theme] body #page-results .results-v2-review-mark-bad {
+  color: var(--red) !important; background: color-mix(in oklab, var(--red) 12%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--red) 32%, transparent) !important;
+}
+
+/* footer actions (mockup .rfoot): primary on top, ghost row under */
+html[data-theme] body #page-results .results-v2-cta-row {
+  position: sticky; bottom: 0; z-index: 5;
+  display: flex !important; flex-direction: column !important; gap: 9px !important;
+  margin: 14px -20px 0 !important; padding: 12px 20px calc(12px + env(safe-area-inset-bottom)) !important;
+  border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent) !important;
+  background: var(--bg) !important;
+}
+html[data-theme] body #page-results .results-v2-cta-right { display: flex !important; flex-wrap: wrap; gap: 9px !important; order: 1; }
+html[data-theme] body #page-results .results-v2-cta-right .btn-primary {
+  flex: 1 1 100%; order: -1;
+  border: 0 !important; border-radius: 13px !important; padding: 14px !important;
+  background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important;
+  font: 700 15px/1 Inter, sans-serif !important; cursor: pointer;
+  transition: transform .14s var(--lift-ease), filter .2s !important;
+}
+html[data-theme] body #page-results .results-v2-cta-right .btn-primary:active { transform: scale(0.985); }
+html[data-theme] body #page-results .results-v2-cta-row .btn-ghost {
+  flex: 1 1 0; display: inline-flex; align-items: center; justify-content: center;
+  font: 700 11.5px/1.1 Inter, sans-serif !important; color: var(--text-mid) !important;
+  background: var(--surface3) !important; border: 1px solid var(--border) !important;
+  border-radius: 11px !important; padding: 11px 8px !important; cursor: pointer;
+  transition: border-color .18s, color .18s, transform .12s var(--lift-ease) !important;
+}
+html[data-theme] body #page-results .results-v2-cta-row .btn-ghost:active { transform: scale(0.97); }
+html[data-theme] body #page-results .results-v2-cta-back { order: 2; }
+
+/* case fixes: mockup uses sentence case for stat labels + review title */
+html[data-theme] body #page-results .results-v2-row .k { text-transform: none !important; letter-spacing: 0 !important; }
+html[data-theme] body #page-results .results-v2-review-title { text-transform: none !important; }
+html[data-theme] body #page-results .results-v2-review-mark { text-transform: uppercase !important; }
+
+/* ─────────────────────────── REVIEW ANSWERS ─────────────────────────── */
+/* Source: cert-ios-review-answers.html (hdr, filter chips, .qa cards with
+   verdict badge, marked option rows, left-rule explanation) onto #page-review. */
+
+html[data-theme] body #page-review { padding-top: 10px !important; }
+
+/* header: back chip + kick + Fraunces display */
+html[data-theme] body #page-review .ed-pagehead { display: flex; align-items: flex-start; gap: 13px; margin: 4px 0 14px !important; background: none !important; border: 0 !important; padding: 0 !important; }
+html[data-theme] body #page-review .ed-pagehead-back {
+  flex: 0 0 auto; width: 34px; height: 34px; display: grid !important; place-items: center !important;
+  border: 1px solid var(--border) !important; border-radius: 10px !important;
+  background: var(--surface) !important; color: var(--text-mid) !important;
+  font: 700 14px/1 Inter, sans-serif !important; padding: 0 !important; cursor: pointer;
+  transition: transform .14s var(--lift-ease), border-color .18s !important; overflow: hidden; white-space: nowrap;
+}
+html[data-theme] body #page-review .ed-pagehead-back:active { transform: scale(0.94); }
+html[data-theme] body #page-review .ed-pagehead-eyebrow {
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.14em !important; text-transform: uppercase;
+  color: var(--text-dim) !important; margin-bottom: 9px !important;
+}
+html[data-theme] body #page-review .ed-pagehead-display {
+  font: 600 30px/1.08 Fraunces, Georgia, serif !important; letter-spacing: -0.014em !important;
+  color: var(--text) !important; margin: 0 !important;
+}
+html[data-theme] body #page-review .ed-pagehead-display em { font-style: normal !important; color: var(--accent) !important; }
+
+/* filter chips */
+html[data-theme] body #page-review .review-filter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; margin: 0 0 14px !important; background: none !important; border: 0 !important; padding: 0 !important; }
+html[data-theme] body #page-review .review-filter-eyebrow { font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim) !important; margin-right: 3px; }
+html[data-theme] body #page-review .review-filter-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font: 700 11.5px/1 Inter, sans-serif !important; color: var(--text-mid) !important;
+  background: var(--surface3) !important; border: 1px solid var(--border) !important;
+  border-radius: 999px !important; padding: 8px 11px !important; cursor: pointer;
+  transition: border-color .18s, color .18s, background .18s, transform .12s var(--lift-ease) !important; box-shadow: none !important;
+}
+html[data-theme] body #page-review .review-filter-chip:active { transform: scale(0.96); }
+html[data-theme] body #page-review .review-filter-chip.is-active {
+  color: var(--accent) !important; background: color-mix(in oklab, var(--accent) 11%, transparent) !important;
+  border-color: color-mix(in oklab, var(--accent) 34%, var(--border)) !important;
+}
+html[data-theme] body #page-review .review-filter-chip.is-disabled { opacity: .4; cursor: default; }
+html[data-theme] body #page-review .chip-count { font: 700 10px/1 'Roboto Mono', ui-monospace, monospace !important; color: inherit !important; opacity: .75; }
+html[data-theme] body #page-review .review-filter-meta { font: 500 11px/1 Inter, sans-serif !important; color: var(--text-dim) !important; margin-left: auto; }
+
+/* answer cards (mockup .qa) */
+html[data-theme] body #page-review .review-item {
+  border: 1px solid var(--border) !important; border-left: 1px solid var(--border) !important;
+  border-radius: 16px !important; background: var(--surface) !important;
+  padding: 15px 15px 14px !important; margin-bottom: 10px !important; box-shadow: none !important;
+}
+html[data-theme] body #page-review .review-q-meta-row { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; margin-bottom: 10px !important; }
+html[data-theme] body #page-review .q-num-pill {
+  font: 800 11px/1 Inter, sans-serif !important; letter-spacing: 0.04em; color: var(--text-dim) !important;
+  background: none !important; border: 0 !important; padding: 0 !important;
+}
+html[data-theme] body #page-review .q-tag {
+  display: inline-flex; align-items: center; gap: 5px;
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.05em !important; text-transform: uppercase;
+  padding: 5px 9px !important; border-radius: 999px !important; border: 0 !important;
+}
+html[data-theme] body #page-review .q-tag.tag-correct { color: var(--green) !important; background: color-mix(in oklab, var(--green) 13%, transparent) !important; margin-left: auto; order: 9; }
+html[data-theme] body #page-review .q-tag.tag-incorrect { color: var(--red) !important; background: color-mix(in oklab, var(--red) 12%, transparent) !important; margin-left: auto; order: 9; }
+html[data-theme] body #page-review .q-tag.tag-skipped { color: var(--text-dim) !important; background: var(--surface3) !important; margin-left: auto; order: 9; }
+html[data-theme] body #page-review .q-tag.tag-flagged { color: var(--accent) !important; background: color-mix(in oklab, var(--accent) 12%, transparent) !important; }
+html[data-theme] body #page-review .q-tag.tag-domain { color: var(--text-dim) !important; background: var(--surface3) !important; text-transform: none !important; letter-spacing: 0 !important; }
+html[data-theme] body #page-review .review-q { font: 650 14.5px/1.4 Inter, sans-serif !important; color: var(--text) !important; margin: 0 0 11px !important; }
+
+/* option rows (mockup .qa-opt) */
+html[data-theme] body #page-review .review-options { display: grid; gap: 7px; margin: 0 0 11px !important; }
+html[data-theme] body #page-review .review-opt {
+  display: flex; align-items: center; gap: 9px;
+  font: 500 13px/1.3 Inter, sans-serif !important; color: var(--text-mid) !important;
+  border: 1.5px solid var(--border) !important; border-radius: 11px !important;
+  background: none !important; padding: 10px 12px !important; margin: 0 !important;
+}
+html[data-theme] body #page-review .review-opt .r-letter { flex: 0 0 auto; font: 800 11px/1 Inter, sans-serif !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-review .review-opt.is-correct {
+  border-color: var(--green) !important; background: color-mix(in oklab, var(--green) 10%, var(--surface)) !important; color: var(--text) !important;
+}
+html[data-theme] body #page-review .review-opt.is-correct .r-letter { color: var(--green) !important; }
+html[data-theme] body #page-review .review-opt.was-chosen {
+  border-color: var(--red) !important; background: color-mix(in oklab, var(--red) 9%, var(--surface)) !important; color: var(--text) !important;
+}
+html[data-theme] body #page-review .review-opt.was-chosen .r-letter { color: var(--red) !important; }
+
+/* explanation: left-rule note (mockup .qa-ex) */
+html[data-theme] body #page-review .review-exp {
+  font-size: 12.5px !important; line-height: 1.45 !important; color: var(--text-dim) !important;
+  background: none !important; border-radius: 0 !important;
+  padding: 0 0 0 12px !important; border-left: 2px solid color-mix(in oklab, var(--accent) 40%, var(--border)) !important;
+}
+html[data-theme] body #page-review .resource-dive-btn {
+  display: inline-flex; align-items: center; gap: 7px; margin-top: 4px;
+  font: 700 12px/1 Inter, sans-serif !important; color: var(--accent) !important;
+  background: color-mix(in oklab, var(--accent) 10%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border)) !important;
+  border-radius: 999px !important; padding: 8px 12px !important; cursor: pointer;
+}
+
+/* back chip: arrow glyph only (the 'Back' word doesn't fit the 34px chip) */
+html[data-theme] body #page-review .ed-pagehead-back { font-size: 0 !important; }
+html[data-theme] body #page-review .ed-pagehead-back::after { content: '\2190'; font: 700 15px/1 Inter, sans-serif; }

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -1297,3 +1297,169 @@ html[data-theme] body #page-drills .drills-domain-mast { display: block; font: 6
 html[data-theme] body #page-drills .drills-domain-mast b { color: var(--text-mid); font-weight: 700; }
 
 html[data-theme] body #page-drills .drills-foot-note { font: 500 11px/1.5 Inter, sans-serif; color: var(--text-dim); text-align: center; margin: 16px 8px 4px; }
+
+/* ─────────────────────── EXAM-DATE BOTTOM SHEET (Phase 2 leftover) ─────────────────────── */
+/* Source: cert-ios-settings.html .sheet block. Injected by lift-shell.js;
+   fixed to the viewport and width-capped to the app column. */
+
+html[data-theme] body .lift-sheet-scrim {
+  position: fixed; inset: 0; z-index: 130;
+  background: color-mix(in oklab, #000 44%, transparent);
+  opacity: 0; pointer-events: none; transition: opacity .32s cubic-bezier(0.16, 1, 0.3, 1);
+}
+html[data-theme] body .lift-sheet-scrim.on { opacity: 1; pointer-events: auto; }
+html[data-theme] body .lift-sheet {
+  position: fixed; left: 50%; bottom: 0; z-index: 131;
+  width: min(430px, 100vw); box-sizing: border-box;
+  background: var(--surface); border: 1px solid var(--border); border-bottom: none;
+  border-radius: 22px 22px 0 0;
+  padding: 10px 18px calc(16px + env(safe-area-inset-bottom));
+  transform: translate(-50%, 104%); transition: transform .42s cubic-bezier(0.32, 0.72, 0, 1);
+  box-shadow: 0 -18px 50px -18px color-mix(in oklab, #000 50%, transparent);
+}
+html[data-theme] body .lift-sheet.on { transform: translate(-50%, 0); }
+html[data-theme] body .lift-sheet-grab { width: 38px; height: 5px; border-radius: 999px; background: color-mix(in oklab, var(--text) 18%, var(--surface)); margin: 0 auto 13px; }
+html[data-theme] body .lift-sheet-title { font: 600 18px/1.2 Fraunces, Georgia, serif; color: var(--text); margin: 0 0 2px; }
+html[data-theme] body .lift-sheet-sub { font: 500 12.5px/1.45 Inter, sans-serif; color: var(--text-mid); margin: 0 0 13px; }
+html[data-theme] body .lift-cal-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+html[data-theme] body .lift-cal-month { font: 700 13.5px/1 Inter, sans-serif; color: var(--text); }
+html[data-theme] body .lift-cal-nav { display: inline-flex; gap: 6px; }
+html[data-theme] body .lift-cal-nav button {
+  width: 30px; height: 30px; border-radius: 9px; border: 1px solid var(--border); background: transparent;
+  color: var(--text); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; padding: 0;
+}
+html[data-theme] body .lift-cal-nav button:disabled { opacity: .35; cursor: default; }
+html[data-theme] body .lift-cal-nav svg { width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+html[data-theme] body .lift-cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 3px; }
+html[data-theme] body .lift-cal-dow { text-align: center; font: 700 10px/1 Inter, sans-serif; letter-spacing: .08em; color: var(--text-dim); padding: 5px 0 7px; text-transform: uppercase; }
+html[data-theme] body .lift-cal-day {
+  aspect-ratio: 1; border: none; background: transparent; border-radius: 10px;
+  font: 600 13px/1 Inter, sans-serif; color: var(--text); cursor: pointer;
+  font-variant-numeric: lining-nums tabular-nums; padding: 0;
+}
+html[data-theme] body .lift-cal-day:disabled { color: color-mix(in oklab, var(--text) 26%, transparent); cursor: default; }
+html[data-theme] body .lift-cal-day.sel { background: var(--accent); color: var(--on-accent, var(--bg)); font-weight: 800; }
+html[data-theme] body .lift-cal-day.today { box-shadow: inset 0 0 0 1.5px color-mix(in oklab, var(--accent) 65%, transparent); }
+html[data-theme] body .lift-sheet-save {
+  width: 100%; margin-top: 12px; border: none; border-radius: 12px; padding: 13px; cursor: pointer;
+  background: var(--accent); color: var(--on-accent, var(--bg)); font: 700 14px/1 Inter, sans-serif;
+  transition: transform .14s cubic-bezier(0.16, 1, 0.3, 1), filter .2s, opacity .2s;
+}
+html[data-theme] body .lift-sheet-save:disabled { opacity: .45; cursor: default; }
+html[data-theme] body .lift-sheet-save:active:not(:disabled) { transform: scale(0.985); }
+html[data-theme] body .lift-sheet-clear { width: 100%; margin-top: 9px; background: none; border: none; font: 600 12.5px/1 Inter, sans-serif; color: var(--text-mid); cursor: pointer; padding: 9px; }
+
+/* ─────────────────── HOME DAY-0: locked readiness hero (Phase 2 leftover) ─────────────────── */
+/* Source: cert-ios-home.html .rd.locked (new-user state). The real pending
+   card (.readiness-card.is-pending) becomes the mockup's locked hero:
+   eyebrow + Locked chip, big em-dash score, empty bar, unlock line. */
+
+html[data-theme] body #page-setup .readiness-card.is-pending {
+  border: 1px solid var(--border) !important; border-radius: 18px !important;
+  background: var(--surface) !important; padding: 16px 17px !important; box-shadow: none !important;
+  display: flex !important; flex-direction: column !important;
+}
+/* mockup order: eyebrow+chip · score · bar · range · unlock line */
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-eyebrow { order: 1; }
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-score { order: 2; flex-direction: row !important; }
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-bar-track { order: 3; }
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-range { order: 4; }
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-strip-line { order: 5; }
+html[data-theme] body #page-setup .readiness-card.is-pending .rc-v2-numwrap { display: inline-flex !important; align-items: baseline !important; }
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-eyebrow {
+  display: flex !important; align-items: center !important; justify-content: space-between !important;
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.13em !important; text-transform: uppercase !important;
+  color: var(--text-dim) !important; margin: 0 0 4px !important; background: none !important; border: 0 !important;
+}
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-eyebrow::after {
+  content: 'Locked'; font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-dim); background: var(--surface3); border: 1px solid var(--border);
+  border-radius: 999px; padding: 5px 9px;
+}
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-score {
+  display: flex !important; align-items: center !important; gap: 8px !important; margin: 8px 0 9px !important;
+}
+html[data-theme] body #page-setup .readiness-card.is-pending .rc-v2-ring,
+html[data-theme] body #page-setup .readiness-card.is-pending .rc-v2-glow,
+html[data-theme] body #page-setup .readiness-card.is-pending .rc-v2-stamp { display: none !important; }
+html[data-theme] body #page-setup .readiness-card.is-pending #rc-v2-num {
+  font: 600 40px/1 Fraunces, Georgia, serif !important; color: var(--text) !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+  background: none !important; -webkit-text-fill-color: currentColor;
+}
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-score > span:last-child {
+  font: 700 11px/1 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0.1em !important;
+  text-transform: uppercase !important; color: var(--text-dim) !important;
+}
+/* empty track (mockup locked hero keeps the bar, unfilled) */
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-bar-track {
+  display: block !important; height: 8px !important; border-radius: 999px !important;
+  background: var(--surface3) !important; overflow: hidden; margin: 0 0 9px !important;
+}
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-bar-track > span { display: none !important; }
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-range {
+  font: 600 10.5px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important;
+}
+/* the compressed strip carries the unlock copy — surface it as the rd-insight line */
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-strip-line {
+  display: block !important; font: 400 12.5px/1.45 Inter, sans-serif !important;
+  color: var(--text-mid) !important; margin: 10px 0 0 !important; background: none !important;
+  border: 0 !important; padding: 0 !important; cursor: default !important;
+}
+html[data-theme] body #page-setup .readiness-card.is-pending .readiness-strip-go { display: none !important; }
+
+/* ─────────────────── FREE-TIER CAP: quota-exceeded modal (Phase 2 leftover) ─────────────────── */
+/* Source: cert-ios-daily-limit.html (free-tier gate). The real
+   #quota-exceeded-modal becomes the mockup's calm centered gate:
+   lockmark, Fraunces headline, lede, accent CTA + ghost + quiet dismiss. */
+
+html[data-theme] body .quota-exceeded-modal {
+  position: fixed !important; inset: 0 !important; z-index: 140 !important;
+  display: flex !important; align-items: center !important; justify-content: center !important;
+  background: color-mix(in oklab, #000 44%, transparent) !important; padding: 20px;
+}
+html[data-theme] body .quota-exceeded-card {
+  width: min(394px, 100%) !important; box-sizing: border-box;
+  background: var(--bg) !important; border: 1px solid var(--border) !important;
+  border-radius: 22px !important; padding: 26px 20px 18px !important; text-align: center !important;
+  box-shadow: 0 24px 60px -24px color-mix(in oklab, #000 55%, transparent) !important;
+}
+html[data-theme] body .quota-exceeded-icon {
+  width: 46px !important; height: 46px !important; margin: 0 auto 12px !important;
+  display: grid !important; place-items: center !important; overflow: visible !important;
+  font-size: 22px !important; line-height: 1 !important; background: var(--surface3) !important;
+  border: 1px solid var(--border) !important; border-radius: 13px !important;
+}
+html[data-theme] body .quota-exceeded-card::before, html[data-theme] body .quota-exceeded-card::after { content: none !important; }
+html[data-theme] body .quota-exceeded-title {
+  font: 600 22px/1.15 Fraunces, Georgia, serif !important; letter-spacing: -0.012em !important;
+  color: var(--text) !important; margin: 0 0 8px !important;
+}
+html[data-theme] body .quota-exceeded-sub {
+  font: 400 13px/1.5 Inter, sans-serif !important; color: var(--text-mid) !important; margin: 0 0 16px !important;
+}
+html[data-theme] body .quota-exceeded-sub strong { color: var(--text) !important; font-weight: 650 !important; }
+html[data-theme] body .quota-exceeded-actions { display: flex !important; flex-direction: column !important; gap: 9px !important; }
+/* upgrade link = the accent CTA (mockup .cta) */
+html[data-theme] body a.quota-exceeded-cta {
+  display: block; width: 100%; box-sizing: border-box; border: 0 !important; border-radius: 13px !important;
+  padding: 15px !important; cursor: pointer; text-decoration: none !important;
+  background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important;
+  font: 800 15px/1 Inter, sans-serif !important; letter-spacing: -0.005em;
+  box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 70%, transparent) !important;
+  transition: transform .15s cubic-bezier(0.16, 1, 0.3, 1), filter .2s !important;
+}
+html[data-theme] body a.quota-exceeded-cta:active { transform: scale(0.985); }
+/* SR-review escape hatch = the ghost (mockup .ghost) */
+html[data-theme] body button.quota-exceeded-cta {
+  display: block; width: 100%; box-sizing: border-box; cursor: pointer;
+  background: transparent !important; border: 1.5px solid var(--border) !important;
+  color: var(--text) !important; border-radius: 13px !important; padding: 13px !important;
+  font: 700 14px/1 Inter, sans-serif !important;
+  transition: transform .14s cubic-bezier(0.16, 1, 0.3, 1), border-color .18s !important;
+}
+html[data-theme] body button.quota-exceeded-cta:active { transform: scale(0.985); }
+html[data-theme] body .quota-exceeded-dismiss {
+  background: none !important; border: 0 !important; cursor: pointer;
+  font: 600 12.5px/1 Inter, sans-serif !important; color: var(--text-mid) !important; padding: 9px !important;
+}

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -488,3 +488,311 @@ html[data-theme] body #page-setup .home-grid { gap: 11px !important; padding-top
 /* settings page header: the topbar crumb + Account tab already say where we
    are (mockup has no in-page header) */
 html[data-theme] body #page-settings > .ed-pagehead { display: none !important; }
+
+/* ─────────────────────────── PROGRESS (Phase 3) ─────────────────────────── */
+/* Source: cert-ios-progress.html — the swipe pager is FLATTENED to one scroll
+   (locked: app pages are single scrolls). Mockup blocks map to the real bento:
+   .hero→.t-spot · .stand→.t-cov · .domain→.t-dom · .listcard→.t-weak ·
+   .cloud→.t-untouched/.t-strong chips · .strip→.t-recent. The pm/dr summary,
+   rec card, page header and search duplicate mockup-absent surfaces — hidden. */
+
+#page-progress { --lift-ease: cubic-bezier(0.16, 1, 0.3, 1); }
+html[data-theme] body #page-progress { padding-top: 10px !important; }
+
+/* surfaces the mockup doesn't carry */
+html[data-theme] body #page-progress .ed-pagehead { display: none !important; }
+html[data-theme] body #page-progress #progress-rec-host { display: none !important; }
+html[data-theme] body #page-progress #progress-summary { display: none !important; }
+html[data-theme] body #page-progress .progress-search { display: none !important; }
+
+/* toolbar → mockup .controls (fchips + sort pill) */
+html[data-theme] body #page-progress .progress-toolbar {
+  display: flex !important; align-items: center !important; flex-wrap: wrap !important; gap: 7px !important;
+  margin: 2px 0 14px !important; padding: 0 !important; background: none !important; border: 0 !important;
+}
+html[data-theme] body #page-progress .progress-filters { display: contents !important; }
+html[data-theme] body #page-progress .prog-filter-btn {
+  border: 1px solid var(--border) !important; border-radius: 999px !important;
+  background: var(--surface) !important; color: var(--text-mid) !important;
+  font: 700 11.5px/1 Inter, sans-serif !important; padding: 8px 12px !important; cursor: pointer;
+  transition: transform .14s var(--lift-ease), border-color .18s, background .18s, color .18s !important;
+}
+html[data-theme] body #page-progress .prog-filter-btn:active { transform: scale(0.96); }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-progress .prog-filter-btn:hover { border-color: color-mix(in oklab, var(--accent) 36%, var(--border)) !important; } }
+html[data-theme] body #page-progress .prog-filter-btn.prog-filter-active {
+  background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important; border-color: var(--accent) !important;
+}
+html[data-theme] body #page-progress .progress-sort { margin-left: auto !important; display: inline-flex !important; align-items: center; }
+html[data-theme] body #page-progress .prog-sort-label { display: none !important; }
+html[data-theme] body #page-progress .prog-sort-select {
+  appearance: none; -webkit-appearance: none;
+  border: 1px solid var(--border) !important; border-radius: 999px !important;
+  background: var(--surface) !important; color: var(--text-dim) !important;
+  font: 700 11px/1 Inter, sans-serif !important; padding: 8px 11px !important; cursor: pointer;
+}
+
+/* bento grid → single mockup column (viewport-media-query trap) */
+html[data-theme] body #page-progress .progress-bento,
+html[data-theme] body #page-progress #progress-topic-grid {
+  display: block !important; column-count: auto !important; grid-template-columns: none !important;
+}
+html[data-theme] body #page-progress .progress-bento .tile {
+  width: auto !important; margin: 0 0 12px !important; box-shadow: none !important;
+}
+/* shared eyebrow → mockup .sect kicker */
+html[data-theme] body #page-progress .tile-eyebrow {
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.12em !important; text-transform: uppercase !important;
+  color: var(--text-dim) !important; margin: 0 0 11px !important; display: flex; align-items: baseline; gap: 6px;
+}
+html[data-theme] body #page-progress .tile-count { font: 600 10px/1 Inter, sans-serif !important; letter-spacing: 0 !important; text-transform: none !important; color: var(--text-dim) !important; opacity: .85; }
+
+/* spotlight → mockup .hero (drill this next) */
+html[data-theme] body #page-progress .t-spot {
+  display: block !important; width: 100% !important; text-align: left !important; cursor: pointer;
+  border: 1px solid color-mix(in oklab, var(--accent) 24%, var(--border)) !important;
+  border-radius: 18px !important;
+  background: color-mix(in oklab, var(--accent) 6%, var(--surface)) !important;
+  padding: 16px 17px !important;
+}
+html[data-theme] body #page-progress .t-spot::before, html[data-theme] body #page-progress .t-spot::after { content: none !important; }
+html[data-theme] body #page-progress .spot-top { display: block !important; }
+html[data-theme] body #page-progress .spot-eyebrow {
+  display: inline-flex !important; align-items: center; gap: 6px;
+  font: 800 9.5px/1 Inter, sans-serif !important; letter-spacing: 0.12em !important; text-transform: uppercase !important;
+  color: var(--accent) !important; background: none !important; border: 0 !important; padding: 0 !important; margin: 0 !important;
+}
+html[data-theme] body #page-progress .spot-flag { display: none !important; }
+html[data-theme] body #page-progress .spot-name {
+  display: block !important; font: 600 21px/1.12 Fraunces, Georgia, serif !important; letter-spacing: -0.01em !important;
+  color: var(--text) !important; margin: 10px 0 3px !important;
+}
+html[data-theme] body #page-progress .spot-domain {
+  display: block !important; font: 600 11px/1.3 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important;
+}
+html[data-theme] body #page-progress .spot-why {
+  display: block !important; font: 400 12.5px/1.45 Inter, sans-serif !important; color: var(--text-mid) !important;
+  margin: 11px 0 13px !important; max-width: none !important;
+}
+html[data-theme] body #page-progress .spot-foot { display: flex !important; align-items: center !important; gap: 12px !important; margin: 0 !important; }
+html[data-theme] body #page-progress .spot-mastery { flex: 0 0 auto; display: flex !important; flex-direction: column !important; gap: 3px !important; }
+html[data-theme] body #page-progress .spot-mastery .num {
+  font: 600 22px/1 Fraunces, Georgia, serif !important; color: var(--red) !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+}
+html[data-theme] body #page-progress .spot-mastery .lbl {
+  font: 700 8.5px/1 Inter, sans-serif !important; letter-spacing: 0.1em !important; text-transform: uppercase !important; color: var(--text-dim) !important;
+}
+html[data-theme] body #page-progress .spot-mastery-lbl { flex: 0 0 auto; font: 700 10px/1.3 Inter, sans-serif !important; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim) !important; max-width: 9ch; }
+html[data-theme] body #page-progress .spot-cta {
+  flex: 1 1 auto !important; display: inline-flex !important; align-items: center !important; justify-content: center !important; gap: 7px !important;
+  border: 0 !important; border-radius: 13px !important;
+  background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important;
+  font: 700 14px/1 Inter, sans-serif !important; padding: 13px 16px !important; margin: 0 !important;
+  box-shadow: 0 10px 22px -12px color-mix(in oklab, var(--accent) 72%, transparent) !important;
+  transition: transform .15s var(--lift-ease), filter .2s !important;
+}
+html[data-theme] body #page-progress .t-spot:active .spot-cta { transform: scale(0.985); }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-progress .t-spot:hover .spot-cta { filter: brightness(1.04); } }
+
+/* coverage → mockup .stand (ring + pair + counts) */
+html[data-theme] body #page-progress .t-cov {
+  border: 1px solid var(--border) !important; border-radius: 17px !important;
+  background: var(--surface) !important; padding: 15px 16px !important;
+}
+html[data-theme] body #page-progress .cov-rings { display: flex !important; align-items: center !important; gap: 15px !important; }
+html[data-theme] body #page-progress .t-cov .ring { flex: 0 0 auto; position: relative; width: 64px !important; height: 64px !important; }
+html[data-theme] body #page-progress .t-cov .ring svg { width: 64px !important; height: 64px !important; display: block; transform: rotate(-90deg); }
+html[data-theme] body #page-progress .t-cov .ring-c-bg { stroke: var(--surface3) !important; }
+html[data-theme] body #page-progress .t-cov .ring-c-cov { stroke: var(--accent) !important; stroke-linecap: round; }
+html[data-theme] body #page-progress .t-cov .ring-mid { position: absolute; inset: 0; display: grid !important; place-items: center; text-align: center; }
+html[data-theme] body #page-progress .t-cov .ring-mid .num {
+  font: 600 15px/1 Fraunces, Georgia, serif !important; color: var(--text) !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+}
+html[data-theme] body #page-progress .t-cov .ring-mid .pcsym { font-size: 11px !important; }
+html[data-theme] body #page-progress .t-cov .ring-mid .lbl {
+  display: block; font: 700 7.5px/1 Inter, sans-serif !important; letter-spacing: 0.1em !important; text-transform: uppercase !important;
+  color: var(--text-dim) !important; margin-top: 3px;
+}
+html[data-theme] body #page-progress .cov-legend { flex: 1 1 auto; display: flex !important; flex-direction: row !important; gap: 10px !important; border: 0 !important; }
+html[data-theme] body #page-progress .cov-legend .row { flex: 1 1 0; display: flex !important; flex-direction: column-reverse !important; justify-content: flex-end; gap: 4px; border: 0 !important; padding: 0 !important; }
+html[data-theme] body #page-progress .cov-legend .row .v {
+  font: 600 24px/1 Fraunces, Georgia, serif !important; color: var(--text) !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+}
+html[data-theme] body #page-progress .cov-legend .row .k { font: 600 10.5px/1.3 Inter, sans-serif !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-progress .cov-legend .row:nth-child(3) { display: none !important; } /* "Solid" — mockup pair is 2-up */
+html[data-theme] body #page-progress .cov-split { display: flex !important; gap: 8px !important; margin-top: 15px !important; border: 0 !important; padding: 0 !important; }
+html[data-theme] body #page-progress .cov-split .cell {
+  flex: 1 1 0 !important; border-radius: 12px !important; padding: 10px 11px !important;
+  border: 1px solid var(--border) !important; background: var(--surface3) !important; text-align: left !important;
+}
+html[data-theme] body #page-progress .cov-split .cell .n {
+  font: 600 18px/1 Fraunces, Georgia, serif !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+}
+html[data-theme] body #page-progress .cov-split .cell:nth-child(1) .n { color: var(--red) !important; }
+html[data-theme] body #page-progress .cov-split .cell:nth-child(2) .n { color: var(--text-mid) !important; }
+html[data-theme] body #page-progress .cov-split .cell:nth-child(3) .n { color: var(--green) !important; }
+html[data-theme] body #page-progress .cov-split .cell .t {
+  font: 700 9px/1 Inter, sans-serif !important; letter-spacing: 0.08em !important; text-transform: uppercase !important;
+  color: var(--text-dim) !important; margin-top: 5px !important;
+}
+
+/* domain accordions → mockup .domain cards */
+html[data-theme] body #page-progress .t-dom {
+  border: 1px solid var(--border) !important; border-radius: 16px !important;
+  background: var(--surface) !important; padding: 0 !important; margin: 0 0 11px !important; overflow: hidden;
+}
+html[data-theme] body #page-progress .progress-domain-head {
+  display: grid !important; grid-template-columns: 1fr auto 26px !important; align-items: center !important;
+  gap: 4px 8px !important; padding: 14px 15px !important; margin: 0 !important; cursor: pointer;
+  background: none !important; border: 0 !important; list-style: none !important;
+}
+html[data-theme] body #page-progress .progress-domain-head::-webkit-details-marker { display: none; }
+@media (hover:hover) and (pointer:fine) { html[data-theme] body #page-progress .progress-domain-head:hover { background: color-mix(in oklab, var(--accent) 4%, transparent) !important; } }
+html[data-theme] body #page-progress .pd-name {
+  grid-column: 1; grid-row: 1; font: 650 15px/1.15 Inter, sans-serif !important; color: var(--text) !important;
+}
+html[data-theme] body #page-progress .pd-weight {
+  grid-column: 2; grid-row: 1; font: 600 10px/1 'Roboto Mono', ui-monospace, monospace !important;
+  color: var(--text-dim) !important; white-space: nowrap; text-align: right; text-transform: none !important;
+}
+html[data-theme] body #page-progress .pd-bar {
+  grid-column: 1 !important; grid-row: 2 !important; display: block !important; width: auto !important;
+  height: 8px !important; border-radius: 999px !important;
+  background: var(--surface3) !important; position: relative; overflow: hidden; margin-top: 5px !important;
+}
+html[data-theme] body #page-progress .pd-bar-fill {
+  position: absolute; left: 0; top: 0; bottom: 0; display: block; border-radius: 999px !important;
+  background: var(--accent) !important; transition: width .8s var(--lift-ease);
+}
+html[data-theme] body #page-progress .pd-bar-fill.s { background: var(--green) !important; }
+html[data-theme] body #page-progress .pd-bar-fill.w { background: var(--red) !important; }
+html[data-theme] body #page-progress .pd-avg {
+  grid-column: 2; grid-row: 2; font: 600 11px/1 'Roboto Mono', ui-monospace, monospace !important;
+  color: var(--text-dim) !important; text-align: right; margin-top: 5px !important;
+}
+html[data-theme] body #page-progress .pd-avg.s { color: var(--green) !important; }
+html[data-theme] body #page-progress .pd-avg.w { color: var(--red) !important; }
+html[data-theme] body #page-progress .pd-count {
+  grid-column: 1 / 3 !important; grid-row: 3 !important; font: 600 10.5px/1 Inter, sans-serif !important;
+  color: var(--text-dim) !important; margin-top: 4px !important;
+  background: none !important; padding: 0 !important; border-radius: 0 !important; border: 0 !important;
+}
+/* chevron in the right rail, rotates on open (mockup .dchev) */
+html[data-theme] body #page-progress .progress-domain-head::after {
+  content: '\2304' !important; display: block !important; position: static !important;
+  grid-column: 3 !important; grid-row: 1 / 4 !important; place-self: center;
+  width: auto !important; height: auto !important; border: 0 !important; background: none !important;
+  font: 700 16px/1 Inter, sans-serif !important; color: var(--text-dim) !important;
+  transition: transform .25s var(--lift-ease); margin: -4px 0 0 !important;
+}
+html[data-theme] body #page-progress .t-dom[open] > .progress-domain-head::after { transform: rotate(180deg) !important; margin: 4px 0 0 !important; }
+html[data-theme] body #page-progress .progress-domain-rows { padding: 0 15px 6px !important; background: none !important; }
+
+/* topic rows → mockup .trow (dot + name + short bar + pct) */
+html[data-theme] body #page-progress .t-row:not(.t-spot) {
+  display: flex !important; align-items: center !important; gap: 11px !important; width: 100% !important;
+  padding: 10px 0 !important; margin: 0 !important; text-align: left !important; cursor: pointer;
+  background: none !important; border: 0 !important;
+  border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent) !important;
+  border-radius: 0 !important; box-shadow: none !important;
+}
+html[data-theme] body #page-progress .t-row:not(.t-spot)::after { content: none !important; }
+html[data-theme] body #page-progress .t-row:not(.t-spot)::before {
+  content: ''; flex: 0 0 auto; width: 9px; height: 9px; border-radius: 999px; background: var(--surface3);
+}
+html[data-theme] body #page-progress .t-row:has(.tpc.s)::before { background: var(--green); }
+html[data-theme] body #page-progress .t-row:has(.tpc.o)::before { background: var(--accent); }
+html[data-theme] body #page-progress .t-row:has(.tpc.w)::before { background: var(--red); }
+html[data-theme] body #page-progress .t-row.untouched::before { background: var(--text-dim); opacity: 0.4; }
+html[data-theme] body #page-progress .t-row .tn { flex: 1 1 auto; min-width: 0; display: block !important; }
+html[data-theme] body #page-progress .t-row .tnm {
+  display: block !important; font: 600 13.5px/1.25 Inter, sans-serif !important; color: var(--text) !important;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+html[data-theme] body #page-progress .t-row.untouched .tnm { color: var(--text-mid) !important; }
+html[data-theme] body #page-progress .t-row .tsub { display: none !important; } /* verdict·date — mockup rows are name+bar+pct only */
+html[data-theme] body #page-progress .t-row .tbar {
+  flex: 0 0 58px !important; display: block !important; height: 8px !important; border-radius: 999px !important;
+  background: var(--surface3) !important; position: relative; overflow: hidden;
+}
+html[data-theme] body #page-progress .t-row .tbar i {
+  position: absolute; left: 0; top: 0; bottom: 0; display: block; border-radius: 999px !important; background: var(--accent) !important;
+}
+html[data-theme] body #page-progress .t-row .tbar i.s { background: var(--green) !important; }
+html[data-theme] body #page-progress .t-row .tbar i.w { background: var(--red) !important; }
+html[data-theme] body #page-progress .t-row .tpc {
+  flex: 0 0 auto !important; font: 600 11px/1 'Roboto Mono', ui-monospace, monospace !important;
+  color: var(--text-dim) !important; min-width: 30px; text-align: right;
+}
+html[data-theme] body #page-progress .t-row .tpc.s { color: var(--green) !important; }
+html[data-theme] body #page-progress .t-row .tpc.o { color: var(--accent) !important; }
+html[data-theme] body #page-progress .t-row .tpc.w { color: var(--red) !important; }
+
+/* weakest list → mockup .listcard .lrow */
+html[data-theme] body #page-progress .t-weak,
+html[data-theme] body #page-progress .t-scoped {
+  border: 1px solid var(--border) !important; border-radius: 16px !important;
+  background: var(--surface) !important; padding: 13px 15px 6px !important;
+}
+html[data-theme] body #page-progress .weak-list, html[data-theme] body #page-progress .scoped-list { display: block !important; }
+html[data-theme] body #page-progress .weak-row {
+  display: flex !important; align-items: center !important; gap: 12px !important; width: 100% !important;
+  padding: 11px 0 !important; margin: 0 !important; text-align: left !important; cursor: pointer;
+  background: none !important; border: 0 !important;
+  border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent) !important;
+  border-radius: 0 !important; box-shadow: none !important;
+}
+html[data-theme] body #page-progress .weak-row:first-child { border-top: 0 !important; }
+html[data-theme] body #page-progress .weak-row::before, html[data-theme] body #page-progress .weak-row::after { content: none !important; }
+html[data-theme] body #page-progress .weak-rank { flex: 0 0 auto; font: 600 11px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-progress .weak-name { flex: 1 1 auto; min-width: 0; display: block !important; }
+html[data-theme] body #page-progress .weak-name .n { display: block !important; font: 600 14px/1.15 Inter, sans-serif !important; color: var(--text) !important; }
+html[data-theme] body #page-progress .weak-name .d { display: block !important; font: 500 11px/1.2 Inter, sans-serif !important; color: var(--text-dim) !important; margin-top: 2px !important; }
+html[data-theme] body #page-progress .weak-pct { flex: 0 0 auto; font: 600 12px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--red) !important; }
+
+/* untouched cloud → mockup .tag · strong chips → mockup .lchip */
+html[data-theme] body #page-progress .t-untouched, html[data-theme] body #page-progress .t-strong, html[data-theme] body #page-progress .t-recent {
+  border: 0 !important; background: none !important; padding: 0 !important; border-radius: 0 !important;
+}
+html[data-theme] body #page-progress .t-untouched .tile-eyebrow, html[data-theme] body #page-progress .t-strong .tile-eyebrow,
+html[data-theme] body #page-progress .t-recent .tile-eyebrow, html[data-theme] body #page-progress .t-weak .tile-eyebrow { margin: 8px 2px 11px !important; }
+html[data-theme] body #page-progress .chips { display: flex !important; flex-wrap: wrap !important; gap: 7px !important; }
+html[data-theme] body #page-progress .chips .chip {
+  display: inline-flex !important; align-items: center; gap: 6px; width: auto !important;
+  font: 600 11px/1 Inter, sans-serif !important; color: var(--text-dim) !important;
+  background: var(--surface) !important; border: 1px solid var(--border) !important;
+  border-radius: 999px !important; padding: 7px 10px !important; margin: 0 !important; cursor: pointer;
+  box-shadow: none !important;
+}
+html[data-theme] body #page-progress .chips .chip::before, html[data-theme] body #page-progress .chips .chip::after { content: none !important; }
+html[data-theme] body #page-progress .chips .chip.good {
+  color: var(--green) !important; background: color-mix(in oklab, var(--green) 13%, transparent) !important;
+  border-color: color-mix(in oklab, var(--green) 32%, transparent) !important; font-weight: 800 !important;
+}
+html[data-theme] body #page-progress .chips .chip .m { font: 700 10px/1 'Roboto Mono', ui-monospace, monospace !important; color: inherit !important; opacity: .85; }
+
+/* recently studied → mockup .strip of .rcard */
+html[data-theme] body #page-progress .recent-track {
+  display: flex !important; gap: 10px !important; overflow-x: auto !important;
+  padding: 2px 18px 6px !important; margin: 0 -18px !important; scrollbar-width: none;
+}
+html[data-theme] body #page-progress .recent-track::-webkit-scrollbar { display: none; }
+html[data-theme] body #page-progress .recent-card {
+  flex: 0 0 138px !important; width: 138px !important; min-width: 0 !important; max-width: 138px !important;
+  display: flex !important; flex-direction: column !important; align-items: stretch !important;
+  justify-content: space-between !important; text-align: left !important;
+  border: 1px solid var(--border) !important; border-radius: 14px !important;
+  background: var(--surface) !important; padding: 12px 13px !important; margin: 0 !important; cursor: pointer;
+  box-shadow: none !important;
+}
+html[data-theme] body #page-progress .recent-card::before, html[data-theme] body #page-progress .recent-card::after { content: none !important; }
+html[data-theme] body #page-progress .recent-card .rn { display: block !important; font: 650 13px/1.2 Inter, sans-serif !important; color: var(--text) !important; min-height: 32px; }
+html[data-theme] body #page-progress .recent-card .rb { display: flex !important; align-items: center !important; justify-content: space-between !important; margin-top: 9px !important; }
+html[data-theme] body #page-progress .recent-card .rm { font: 600 10.5px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--accent) !important; }
+html[data-theme] body #page-progress .recent-card .rt { font: 500 10px/1 Inter, sans-serif !important; color: var(--text-dim) !important; }
+
+/* scoped (filter/search) rows reuse the .t-row treatment above */
+html[data-theme] body #page-progress .empty-note { font: 500 12.5px/1.5 Inter, sans-serif !important; color: var(--text-dim) !important; padding: 6px 0 12px; }

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -796,3 +796,267 @@ html[data-theme] body #page-progress .recent-card .rt { font: 500 10px/1 Inter, 
 
 /* scoped (filter/search) rows reuse the .t-row treatment above */
 html[data-theme] body #page-progress .empty-note { font: 500 12.5px/1.5 Inter, sans-serif !important; color: var(--text-dim) !important; padding: 6px 0 12px; }
+
+/* ─────────────────────────── ANALYTICS (Phase 3) ─────────────────────────── */
+/* Source: cert-ios-analytics.html — pager flattened to one scroll. The v7.16
+   .ana-bento tiles map 1:1 onto the mockup blocks: s-read→.rd+.tiles ·
+   s-const→.const · s-trend→acc card · s-why→.lev · s-domains→.mrow card ·
+   s-streak→streak card · s-diff→diff card · s-evq→.pvt · s-heat→heatmap ·
+   s-wrong→.slip card · s-miles→milestones · s-exam→full-exams. */
+
+#page-analytics { --lift-ease: cubic-bezier(0.16, 1, 0.3, 1); }
+html[data-theme] body #page-analytics { padding-top: 10px !important; }
+html[data-theme] body #page-analytics > .ed-pagehead { display: none !important; }
+
+/* bento → single mockup column */
+html[data-theme] body #page-analytics .ana-bento {
+  display: block !important; column-count: auto !important; grid-template-columns: none !important;
+}
+html[data-theme] body #page-analytics .ana-bento .tile {
+  width: auto !important; margin: 0 0 12px !important; box-shadow: none !important;
+  border: 1px solid var(--border) !important; border-radius: 17px !important;
+  background: var(--surface) !important; padding: 15px 16px !important;
+}
+
+/* eyebrow → mockup .card-kick (mono, accent) · count → .card-meta */
+html[data-theme] body #page-analytics .tile-eyebrow {
+  font: 700 9.5px/1 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0.11em !important;
+  text-transform: uppercase !important; color: var(--accent) !important; margin-bottom: 6px !important;
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+}
+html[data-theme] body #page-analytics .tile-eyebrow .count {
+  font: 600 10.5px/1 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0 !important;
+  text-transform: none !important; color: var(--text-dim) !important; white-space: nowrap;
+}
+/* tile titles → mockup .card-title (Fraunces) */
+html[data-theme] body #page-analytics .ana-bento .tile h2 {
+  font: 600 17px/1.15 Fraunces, Georgia, serif !important; letter-spacing: -0.01em !important;
+  color: var(--text) !important; margin: 0 !important;
+}
+html[data-theme] body #page-analytics .ana-bento .tile h2 em { font-style: normal !important; color: var(--accent) !important; }
+
+/* readiness hero → mockup .rd */
+html[data-theme] body #page-analytics .s-read {
+  border-color: color-mix(in oklab, var(--accent) 22%, var(--border)) !important; border-radius: 18px !important;
+  background: color-mix(in oklab, var(--accent) 5%, var(--surface)) !important; padding: 16px 17px !important;
+}
+html[data-theme] body #page-analytics .read-top { display: flex !important; align-items: center !important; justify-content: space-between !important; gap: 10px; }
+html[data-theme] body #page-analytics .read-top .tile-eyebrow { color: var(--text-dim) !important; letter-spacing: 0.13em !important; }
+html[data-theme] body #page-analytics .read-tier {
+  font: 800 9.5px/1 Inter, sans-serif !important; letter-spacing: 0.08em !important; text-transform: uppercase !important;
+  color: var(--accent) !important; background: color-mix(in oklab, var(--accent) 13%, transparent) !important;
+  border: 1px solid color-mix(in oklab, var(--accent) 32%, transparent) !important;
+  border-radius: 999px !important; padding: 5px 9px !important;
+}
+html[data-theme] body #page-analytics .read-score { display: flex !important; align-items: baseline !important; gap: 8px !important; margin: 12px 0 9px !important; }
+html[data-theme] body #page-analytics .read-score .big {
+  font: 600 44px/1 Fraunces, Georgia, serif !important; color: var(--text) !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+}
+html[data-theme] body #page-analytics .read-score .of {
+  font: 700 11px/1 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0.1em !important;
+  text-transform: uppercase !important; color: var(--text-dim) !important;
+}
+html[data-theme] body #page-analytics .read-cap { font: 400 12.5px/1.45 Inter, sans-serif !important; color: var(--text-mid) !important; margin: 0 0 11px !important; }
+html[data-theme] body #page-analytics .read-cap b { color: var(--text) !important; font-weight: 650 !important; }
+html[data-theme] body #page-analytics .read-bar {
+  height: 8px !important; border-radius: 999px !important; background: var(--surface3) !important;
+  position: relative; overflow: visible !important;
+}
+html[data-theme] body #page-analytics .read-bar i {
+  position: absolute; left: 0; top: 0; bottom: 0; display: block; border-radius: 999px !important;
+  background: var(--accent) !important; transition: width .9s var(--lift-ease);
+}
+html[data-theme] body #page-analytics .read-tick {
+  position: absolute; top: -2px !important; bottom: -2px !important; width: 2px !important;
+  background: color-mix(in oklab, var(--text) 45%, var(--surface3)) !important; border-radius: 0 !important;
+}
+html[data-theme] body #page-analytics .read-fore { display: flex !important; gap: 9px !important; margin-top: 12px !important; }
+html[data-theme] body #page-analytics .read-fore > span {
+  flex: 1 1 0 !important; display: flex !important; flex-direction: column !important; justify-content: flex-start; gap: 5px;
+  border: 1px solid var(--border) !important; border-radius: 12px !important;
+  background: color-mix(in oklab, var(--surface3) 60%, var(--surface)) !important; padding: 10px 11px !important;
+  font: 700 8.5px/1.25 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0.08em !important;
+  text-transform: uppercase !important; color: var(--text-dim) !important;
+}
+html[data-theme] body #page-analytics .read-fore .fv { font: 600 17px/1 Fraunces, Georgia, serif !important; color: var(--text) !important; letter-spacing: 0 !important; }
+/* stat tiles 2-up → mockup .tiles/.tile */
+html[data-theme] body #page-analytics .read-stats { display: grid !important; grid-template-columns: 1fr 1fr !important; gap: 10px !important; margin-top: 12px !important; }
+html[data-theme] body #page-analytics .rstat {
+  border: 1px solid var(--border) !important; border-radius: 14px !important;
+  background: var(--surface) !important; padding: 12px 13px !important; display: block !important;
+}
+html[data-theme] body #page-analytics .rstat .n {
+  display: block !important; font: 600 26px/1 Fraunces, Georgia, serif !important; color: var(--text) !important;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum";
+}
+html[data-theme] body #page-analytics .rstat .l {
+  display: block !important; font: 600 10.5px/1.2 'Roboto Mono', ui-monospace, monospace !important;
+  letter-spacing: 0.04em !important; text-transform: uppercase !important; color: var(--text-dim) !important; margin-top: 5px !important;
+}
+html[data-theme] body #page-analytics .rstat svg { display: block !important; width: 100% !important; height: 22px !important; margin-top: 8px !important; overflow: visible; }
+html[data-theme] body #page-analytics .rstat svg path { fill: none !important; stroke: var(--accent) !important; stroke-width: 2 !important; stroke-linecap: round; stroke-linejoin: round; }
+
+/* constellation: keep the navy sky, normalize chrome (mockup .const) */
+html[data-theme] body #page-analytics .s-const { border-radius: 17px !important; }
+html[data-theme] body #page-analytics .s-const .const-sub { font-size: 12px !important; line-height: 1.5 !important; margin: 8px 0 12px !important; }
+html[data-theme] body #page-analytics .s-const .const-legend { display: flex !important; flex-wrap: wrap !important; gap: 10px 14px !important; margin-top: 13px !important; }
+
+/* accuracy trend → mockup acc card + .rangeseg */
+html[data-theme] body #page-analytics .trend-head { display: flex !important; align-items: flex-start !important; justify-content: space-between !important; gap: 10px !important; }
+html[data-theme] body #page-analytics .trend-verdict { font: 600 11px/1.35 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; margin: 6px 0 0 !important; }
+html[data-theme] body #page-analytics .acc-tabs {
+  display: inline-flex !important; border: 1px solid var(--border) !important; border-radius: 999px !important;
+  padding: 2px !important; background: var(--surface3) !important; gap: 0 !important; flex: 0 0 auto;
+}
+html[data-theme] body #page-analytics .acc-tab {
+  border: 0 !important; background: none !important; cursor: pointer;
+  font: 700 10px/1 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0.04em !important;
+  text-transform: uppercase !important; color: var(--text-dim) !important; padding: 6px 10px !important;
+  border-radius: 999px !important; transition: color .18s, background .18s !important; box-shadow: none !important;
+}
+html[data-theme] body #page-analytics .acc-tab.on, html[data-theme] body #page-analytics .acc-tab[aria-pressed="true"] {
+  color: var(--on-accent, var(--bg)) !important; background: var(--accent) !important;
+}
+html[data-theme] body #page-analytics .acc-wrap { margin-top: 12px !important; }
+
+/* highest-leverage → mockup .lev */
+html[data-theme] body #page-analytics .s-why {
+  border-color: color-mix(in oklab, var(--accent) 26%, var(--border)) !important; border-radius: 18px !important;
+  background: color-mix(in oklab, var(--accent) 6%, var(--surface)) !important; padding: 16px !important;
+}
+html[data-theme] body #page-analytics .why-lev { display: flex !important; align-items: baseline !important; gap: 7px !important; margin-top: 2px; }
+html[data-theme] body #page-analytics .why-lev .v { font: 600 26px/1.05 Fraunces, Georgia, serif !important; color: var(--accent) !important; letter-spacing: -0.01em !important; }
+html[data-theme] body #page-analytics .why-lev .l { font: 700 12px/1.3 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-analytics .why-head { font: 700 14px/1.3 Inter, sans-serif !important; color: var(--text) !important; margin: 8px 0 0 !important; }
+html[data-theme] body #page-analytics .why-body { font: 400 12.5px/1.55 Inter, sans-serif !important; color: var(--text-mid) !important; margin: 9px 0 13px !important; }
+html[data-theme] body #page-analytics .why-factors { display: flex !important; flex-direction: column !important; gap: 9px !important; }
+html[data-theme] body #page-analytics .why-f { display: flex !important; align-items: flex-start !important; gap: 9px !important; font: 400 12px/1.4 Inter, sans-serif !important; color: var(--text-mid) !important; }
+html[data-theme] body #page-analytics .why-f .ar { flex: 0 0 auto; font-size: 11px !important; margin-top: 1px; }
+html[data-theme] body #page-analytics .why-f .ar.down { color: var(--red) !important; }
+html[data-theme] body #page-analytics .why-f .ar.up { color: var(--green) !important; }
+html[data-theme] body #page-analytics .why-f .ft { color: var(--text) !important; font-weight: 650 !important; }
+
+/* mastery by domain → mockup .mrow */
+html[data-theme] body #page-analytics .dom-list { display: block !important; }
+html[data-theme] body #page-analytics .dom-row { display: block !important; margin: 0 0 13px !important; padding: 0 !important; border: 0 !important; background: none !important; }
+html[data-theme] body #page-analytics .dom-row:last-child { margin-bottom: 0 !important; }
+html[data-theme] body #page-analytics .dom-row .dl { display: flex !important; align-items: baseline !important; gap: 7px !important; float: left; }
+html[data-theme] body #page-analytics .dom-row .dl .obj { font: 600 10.5px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-analytics .dom-row .dl .txt { font: 650 13.5px/1.2 Inter, sans-serif !important; color: var(--text) !important; }
+html[data-theme] body #page-analytics .dom-row .dm { float: right; font: 700 12px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; font-variant-numeric: lining-nums tabular-nums; }
+html[data-theme] body #page-analytics .dom-bar {
+  clear: both; height: 8px !important; border-radius: 999px !important; background: var(--surface3) !important;
+  position: relative; overflow: hidden; margin-top: 7px !important;
+}
+html[data-theme] body #page-analytics .dom-bar i { position: absolute; left: 0; top: 0; bottom: 0; display: block; border-radius: 999px !important; transition: width .9s var(--lift-ease); }
+html[data-theme] body #page-analytics .dom-meta { font: 400 11px/1.4 Inter, sans-serif !important; color: var(--text-dim) !important; margin-top: 6px !important; }
+html[data-theme] body #page-analytics .dom-meta .tag { color: var(--red) !important; font-weight: 600 !important; background: none !important; border: 0 !important; padding: 0 !important; }
+
+/* streak → mockup streak card */
+html[data-theme] body #page-analytics .streak-main { display: flex !important; align-items: baseline !important; gap: 10px !important; }
+html[data-theme] body #page-analytics .streak-main .v { font: 600 36px/1 Fraunces, Georgia, serif !important; color: var(--text) !important; font-variant-numeric: lining-nums; }
+html[data-theme] body #page-analytics .streak-main .l {
+  font: 700 11px/1 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0.06em !important;
+  text-transform: uppercase !important; color: var(--text-dim) !important;
+}
+html[data-theme] body #page-analytics .streak-sub { font: 400 11.5px/1.5 Inter, sans-serif !important; color: var(--text-mid) !important; margin: 9px 0 12px !important; }
+html[data-theme] body #page-analytics .week-dots { display: flex !important; gap: 7px !important; }
+html[data-theme] body #page-analytics .week-dots .wd { flex: 1 1 0 !important; display: flex !important; flex-direction: column !important; align-items: center !important; gap: 6px !important; }
+html[data-theme] body #page-analytics .week-dots .dot {
+  width: 100% !important; height: auto !important; aspect-ratio: 1 !important; border-radius: 9px !important;
+  background: var(--surface3) !important; border: 1px solid var(--border) !important;
+}
+html[data-theme] body #page-analytics .week-dots .wd.on .dot {
+  background: color-mix(in oklab, var(--accent) 30%, var(--surface)) !important;
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--border)) !important;
+}
+html[data-theme] body #page-analytics .week-dots .wl { font: 700 9px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-analytics .week-dots .wd.on .wl { color: var(--accent) !important; }
+
+/* difficulty → mockup diff rows */
+html[data-theme] body #page-analytics .diff-list { display: block !important; }
+html[data-theme] body #page-analytics .s-diff .diff-row { margin: 0 0 13px !important; padding: 0 !important; border: 0 !important; background: none !important; }
+html[data-theme] body #page-analytics .s-diff .diff-row:last-child { margin-bottom: 0 !important; }
+html[data-theme] body #page-analytics .diff-top { display: flex !important; align-items: baseline !important; justify-content: space-between !important; margin-bottom: 7px !important; }
+html[data-theme] body #page-analytics .diff-top .dk { font: 650 13px/1 Inter, sans-serif !important; color: var(--text) !important; }
+html[data-theme] body #page-analytics .diff-top .dv { font: 700 12px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--accent) !important; font-variant-numeric: lining-nums tabular-nums; }
+html[data-theme] body #page-analytics .diff-top .dc { font: 600 10.5px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; margin-left: 7px; }
+html[data-theme] body #page-analytics .diff-bar { height: 8px !important; border-radius: 999px !important; background: var(--surface3) !important; position: relative; overflow: hidden; }
+html[data-theme] body #page-analytics .diff-bar i { position: absolute; left: 0; top: 0; bottom: 0; display: block; border-radius: 999px !important; background: var(--accent) !important; transition: width .9s var(--lift-ease); }
+
+/* practice vs timed → mockup .pvt */
+html[data-theme] body #page-analytics .evq-nums { display: flex !important; gap: 10px !important; margin-top: 4px; }
+html[data-theme] body #page-analytics .evq-cell {
+  flex: 1 1 0 !important; border: 1px solid var(--border) !important; border-radius: 13px !important;
+  background: var(--surface3) !important; padding: 12px 13px !important; text-align: center !important;
+}
+html[data-theme] body #page-analytics .evq-cell .n { font: 600 16px/1.2 Fraunces, Georgia, serif !important; color: var(--text-mid) !important; }
+html[data-theme] body #page-analytics .evq-cell .t {
+  font: 700 9px/1 'Roboto Mono', ui-monospace, monospace !important; letter-spacing: 0.08em !important;
+  text-transform: uppercase !important; color: var(--text-dim) !important; margin-top: 6px !important;
+}
+html[data-theme] body #page-analytics .evq-cell .s { font: 500 10px/1.3 Inter, sans-serif !important; color: var(--text-dim) !important; margin-top: 3px !important; }
+html[data-theme] body #page-analytics .evq-note { font: 400 12px/1.5 Inter, sans-serif !important; color: var(--text-mid) !important; margin: 10px 0 0 !important; }
+
+/* heatmap foot → mockup .heat-legend */
+html[data-theme] body #page-analytics .heat-wrap { margin-top: 8px; }
+html[data-theme] body #page-analytics .heat-foot {
+  display: flex !important; align-items: center !important; justify-content: space-between !important;
+  margin-top: 11px !important; font: 700 9px/1 'Roboto Mono', ui-monospace, monospace !important;
+  letter-spacing: 0.05em !important; text-transform: uppercase !important; color: var(--text-dim) !important;
+}
+html[data-theme] body #page-analytics .heat-scale { display: inline-flex !important; align-items: center; gap: 3px !important; }
+html[data-theme] body #page-analytics .heat-scale .heat-cell { width: 10px !important; height: 10px !important; border-radius: 2.5px !important; }
+
+/* where you slip → mockup .slip rows */
+html[data-theme] body #page-analytics .wrong-list { display: block !important; }
+html[data-theme] body #page-analytics .wrong-row {
+  display: flex !important; align-items: center !important; gap: 12px !important;
+  padding: 11px 0 !important; margin: 0 !important; border: 0 !important; background: none !important;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 60%, transparent) !important; border-radius: 0 !important;
+}
+html[data-theme] body #page-analytics .wrong-row:last-child { border-bottom: 0 !important; padding-bottom: 2px !important; }
+html[data-theme] body #page-analytics .wrong-row .rank, html[data-theme] body #page-analytics .wrong-rank {
+  flex: 0 0 auto; width: 24px !important; height: 24px !important; border-radius: 8px !important;
+  background: color-mix(in oklab, var(--red) 14%, var(--surface3)) !important; color: var(--red) !important;
+  display: grid !important; place-items: center !important; font: 700 12px/1 'Roboto Mono', ui-monospace, monospace !important;
+}
+html[data-theme] body #page-analytics .wrong-mid { flex: 1 1 auto; min-width: 0; }
+html[data-theme] body #page-analytics .wrong-mid .n { font: 650 13px/1.2 Inter, sans-serif !important; color: var(--text) !important; }
+html[data-theme] body #page-analytics .wrong-mid .d { font: 500 11px/1.4 Inter, sans-serif !important; color: var(--text-dim) !important; margin-top: 2px !important; }
+html[data-theme] body #page-analytics .wrong-row .miss, html[data-theme] body #page-analytics .wrong-miss { flex: 0 0 auto; font: 700 11px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--red) !important; }
+
+/* milestones → mockup .mile rows */
+html[data-theme] body #page-analytics .mile-count { font: 600 24px/1 Fraunces, Georgia, serif !important; color: var(--text) !important; text-transform: none !important; letter-spacing: 0 !important; }
+html[data-theme] body #page-analytics .mile-count small { font: 700 13px/1 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-analytics .mile-prog { height: 8px !important; border-radius: 999px !important; background: var(--surface3) !important; position: relative; overflow: hidden; margin: 10px 0 4px !important; }
+html[data-theme] body #page-analytics .mile-prog i { position: absolute; left: 0; top: 0; bottom: 0; display: block; border-radius: 999px !important; background: var(--accent) !important; transition: width .9s var(--lift-ease); }
+html[data-theme] body #page-analytics .mile-list { display: block !important; margin-top: 4px; }
+html[data-theme] body #page-analytics .mile-row {
+  display: flex !important; align-items: center !important; gap: 11px !important; padding: 10px 0 !important;
+  margin: 0 !important; border: 0 !important; background: none !important;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 60%, transparent) !important; border-radius: 0 !important;
+}
+html[data-theme] body #page-analytics .mile-row:last-child { border-bottom: 0 !important; padding-bottom: 2px !important; }
+html[data-theme] body #page-analytics .mile-ic {
+  flex: 0 0 auto; width: 32px !important; height: 32px !important; border-radius: 10px !important;
+  display: grid !important; place-items: center !important;
+  background: color-mix(in oklab, var(--accent) 14%, var(--surface3)) !important; color: var(--accent) !important;
+}
+html[data-theme] body #page-analytics .mile-ic svg { width: 16px !important; height: 16px !important; }
+html[data-theme] body #page-analytics .mile-txt { flex: 1 1 auto; min-width: 0; }
+html[data-theme] body #page-analytics .mile-txt .n { font: 650 13px/1.2 Inter, sans-serif !important; color: var(--text) !important; }
+html[data-theme] body #page-analytics .mile-txt .d { font: 500 10.5px/1.3 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; margin-top: 3px !important; }
+
+/* full exams */
+html[data-theme] body #page-analytics .exam-list { display: block !important; }
+html[data-theme] body #page-analytics .exam-row { padding: 8px 0 2px !important; margin: 0 !important; border: 0 !important; background: none !important; }
+html[data-theme] body #page-analytics .exam-row .el { font: 650 13px/1.3 Inter, sans-serif !important; color: var(--text) !important; }
+html[data-theme] body #page-analytics .exam-row .ed { font: 500 10.5px/1.4 'Roboto Mono', ui-monospace, monospace !important; color: var(--text-dim) !important; margin-top: 3px !important; }
+
+/* analytics empty state: calm centered card */
+html[data-theme] body #page-analytics .ana-empty-card {
+  border: 1px solid var(--border) !important; border-radius: 17px !important;
+  background: var(--surface) !important; padding: 26px 18px !important; text-align: center;
+}

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -499,6 +499,21 @@ html[data-theme] body #page-settings > .ed-pagehead { display: none !important; 
 #page-progress { --lift-ease: cubic-bezier(0.16, 1, 0.3, 1); }
 html[data-theme] body #page-progress { padding-top: 10px !important; }
 
+/* Progress ⇄ Analytics seg switcher (lift-shell injects; mockup .seg chips) */
+html[data-theme] body .lift-seg { display: flex; gap: 8px; margin: 2px 0 12px; }
+html[data-theme] body .lift-seg-chip {
+  font: 700 12px/1 Inter, sans-serif; padding: 8px 13px; border-radius: 999px;
+  border: 1px solid var(--border); background: var(--surface); color: var(--text-mid);
+  cursor: pointer; white-space: nowrap;
+  transition: background .2s, color .2s, border-color .2s, transform .14s cubic-bezier(0.16, 1, 0.3, 1);
+}
+html[data-theme] body .lift-seg-chip:active { transform: scale(.96); }
+html[data-theme] body .lift-seg-chip.on {
+  background: color-mix(in oklab, var(--accent) 12%, var(--surface));
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
+  color: var(--accent);
+}
+
 /* surfaces the mockup doesn't carry */
 html[data-theme] body #page-progress .ed-pagehead { display: none !important; }
 html[data-theme] body #page-progress #progress-rec-host { display: none !important; }

--- a/lift-screens.css
+++ b/lift-screens.css
@@ -417,3 +417,74 @@ html[data-theme] body #page-review .resource-dive-btn {
 /* back chip: arrow glyph only (the 'Back' word doesn't fit the 34px chip) */
 html[data-theme] body #page-review .ed-pagehead-back { font-size: 0 !important; }
 html[data-theme] body #page-review .ed-pagehead-back::after { content: '\2190'; font: 700 15px/1 Inter, sans-serif; }
+
+/* ─────────────────────────── SETTINGS (Phase 2) ─────────────────────────── */
+/* Source: cert-ios-settings.html — sect labels, calm cards, seg chips, full-
+   width save buttons — onto #page-settings. The v7.18 12-col control-center
+   bento collapses to the mockup's single scrollable column at EVERY viewport. */
+
+html[data-theme] body #page-settings { max-width: none !important; margin: 0 auto !important; padding: 10px 0 90px !important; }
+html[data-theme] body #page-settings .settings-group { display: flex !important; flex-direction: column !important; gap: 11px !important; margin-top: 26px !important; }
+html[data-theme] body #page-settings .settings-group .settings-section { grid-column: auto !important; }
+
+/* group head → mockup .sect kicker (small caps over the cards) */
+html[data-theme] body #page-settings .settings-group-head { display: block !important; margin-bottom: 0 !important; padding-bottom: 0 !important; border: 0 !important; }
+html[data-theme] body #page-settings .settings-group-num { display: none !important; }
+html[data-theme] body #page-settings .settings-group-h {
+  font: 800 10px/1 Inter, sans-serif !important; letter-spacing: 0.12em !important; text-transform: uppercase !important;
+  color: var(--text-dim) !important; margin: 0 2px 4px !important;
+}
+html[data-theme] body #page-settings .settings-group-h em { color: var(--text-dim) !important; }
+html[data-theme] body #page-settings .settings-group-sub { font-size: 12px !important; color: var(--text-dim) !important; margin: 0 2px 7px !important; line-height: 1.45 !important; }
+
+/* cards (mockup .card) */
+html[data-theme] body #page-settings .settings-section {
+  border: 1px solid var(--border) !important; border-radius: 16px !important;
+  background: var(--surface) !important; padding: 15px 16px !important;
+  margin: 0 !important; box-shadow: none !important;
+}
+html[data-theme] body #page-settings .settings-section-title {
+  font: 650 14.5px/1.2 Inter, sans-serif !important; letter-spacing: 0 !important; text-transform: none !important;
+  color: var(--text) !important; margin: 0 0 6px !important;
+}
+html[data-theme] body #page-settings .settings-section-hint { font-size: 12px !important; line-height: 1.45 !important; color: var(--text-dim) !important; margin-top: 9px !important; }
+
+/* health/at-a-glance grid → single column rows */
+html[data-theme] body #page-settings .settings-health-grid { grid-template-columns: 1fr !important; gap: 0 !important; margin-top: 4px !important; }
+
+/* segmented chips (mockup .seg) */
+html[data-theme] body #page-settings .settings-daily-chip {
+  font: 700 12.5px/1 Inter, sans-serif !important; border-radius: 10px !important; padding: 10px 12px !important;
+  background: var(--surface3) !important; border: 1px solid var(--border) !important; color: var(--text-mid) !important;
+  cursor: pointer; transition: background .18s, color .18s, border-color .18s, transform .12s var(--lift-ease) !important;
+}
+html[data-theme] body #page-settings .settings-daily-chip:active { transform: scale(0.97); }
+html[data-theme] body #page-settings .settings-daily-chip.is-active {
+  background: color-mix(in oklab, var(--accent) 14%, transparent) !important;
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--border)) !important; color: var(--accent) !important;
+}
+
+/* buttons inside settings: full-width accent saves, quiet ghosts */
+html[data-theme] body #page-settings .settings-section .btn {
+  border-radius: 12px !important; font: 700 13px/1 Inter, sans-serif !important; padding: 12px 14px !important;
+  transition: transform .14s var(--lift-ease), filter .2s !important; box-shadow: none !important;
+}
+html[data-theme] body #page-settings .settings-section .btn:active { transform: scale(0.985); }
+html[data-theme] body #page-settings .settings-section .btn-primary { width: 100%; background: var(--accent) !important; color: var(--on-accent, var(--bg)) !important; border: 0 !important; }
+html[data-theme] body #page-settings .settings-section .btn-ghost { background: var(--surface3) !important; border: 1px solid var(--border) !important; color: var(--text-mid) !important; }
+
+/* ─────────────────────────── HOME tune (Phase 2) ─────────────────────────── */
+/* The v7.17 bento already descends from an approved mockup; in the column it
+   just needs mockup-scale cards + type (cert-ios-home rhythm). */
+html[data-theme] body #page-setup .tile, html[data-theme] body #page-setup .cell-hero, html[data-theme] body #page-setup .cmd-bar {
+  border-radius: 16px !important; box-shadow: none !important;
+}
+html[data-theme] body #page-setup .tile { padding: 15px 16px !important; }
+html[data-theme] body #page-setup .tile-title { font: 650 15px/1.25 Fraunces, Georgia, serif !important; letter-spacing: -0.008em !important; }
+html[data-theme] body #page-setup .tile-sub { font-size: 12px !important; line-height: 1.45 !important; color: var(--text-dim) !important; }
+html[data-theme] body #page-setup .bento { gap: 11px !important; }
+html[data-theme] body #page-setup .home-grid { gap: 11px !important; padding-top: 12px !important; }
+
+/* settings page header: the topbar crumb + Account tab already say where we
+   are (mockup has no in-page header) */
+html[data-theme] body #page-settings > .ed-pagehead { display: none !important; }

--- a/lift-shell.css
+++ b/lift-shell.css
@@ -79,3 +79,6 @@ body.lift-no-tabbar .page { padding-bottom: calc(24px + env(safe-area-inset-bott
 #page-setup .bento > * { grid-column: auto !important; grid-row: auto !important; }
 #page-setup #setup-domain-grid.dgh-dom-grid { grid-template-columns: 1fr !important; }
 #page-setup .stat-row { grid-template-columns: 1fr !important; }
+/* bento drill-by-domain quick-pick: 5-up never fits the column */
+#page-setup .ld-grid { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+#page-setup .ld-grid > * { min-width: 0; }

--- a/lift-shell.css
+++ b/lift-shell.css
@@ -68,3 +68,14 @@ html[data-theme] body {
 /* immersive session pages own the whole screen — no tab bar */
 body.lift-no-tabbar #lift-tabbar { display: none; }
 body.lift-no-tabbar .page { padding-bottom: calc(24px + env(safe-area-inset-bottom)) !important; }
+
+/* ─ Phase-0 interim: un-lifted pages built desktop grids whose narrow-viewport
+   collapses key on @media viewport width, which never fires on desktop now
+   that the app lives in a 430px column. Force the narrow collapse at every
+   viewport. Each rule dies when its screen's real lift lands. ─ */
+#page-setup .home-grid { grid-template-columns: minmax(0, 1fr) !important; }
+#page-setup .col-side { order: 2; }
+#page-setup .bento { grid-template-columns: 1fr !important; }
+#page-setup .bento > * { grid-column: auto !important; grid-row: auto !important; }
+#page-setup #setup-domain-grid.dgh-dom-grid { grid-template-columns: 1fr !important; }
+#page-setup .stat-row { grid-template-columns: 1fr !important; }

--- a/lift-shell.css
+++ b/lift-shell.css
@@ -1,0 +1,70 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   LIFT-SHELL · Phase 0 of the mockup lift-and-shift (2026-06-10)
+   The whole app renders as the cert-ios mockups' centered phone column on
+   EVERY viewport (decision: 1:1, desktop = centered ~430px app column).
+   Source of truth: mockups/cert-ios-*.html in feat/cert-ios-e2e.
+   Plan: docs/superpowers/specs/2026-06-10-mockup-lift-and-shift-plan.md
+   Load order: after dg-system.css + dg-depurple.css. CSS-only chrome —
+   per-screen lifts land in later phases.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+:root { --lift-col-w: 430px; --lift-tab-h: 64px; }
+
+/* styles.css has no universal border-box; the column math needs it */
+.page, #app-topbar, .app-topbar, #lift-tabbar { box-sizing: border-box; }
+
+/* backdrop outside the column (mockups' --page-bg: a step away from --bg) */
+html[data-theme] body {
+  background: color-mix(in oklab, var(--bg) 90%, var(--text) 10%) !important;
+  padding-left: 0 !important;
+}
+
+/* sidebar retires — the bottom tab bar owns primary navigation */
+#app-sidebar, .app-sidebar, #sb-mobile-toggle, .sb-mobile-toggle { display: none !important; }
+
+/* dev/preview env badge: clear the tab bar */
+#env-badge { bottom: calc(var(--lift-tab-h) + 16px + env(safe-area-inset-bottom)) !important; }
+
+/* the column: topbar + active page share one centered track */
+#app-topbar, .app-topbar {
+  width: min(var(--lift-col-w), 100%);
+  margin: 0 auto;
+  background: var(--bg) !important;
+}
+.page {
+  width: min(var(--lift-col-w), 100%);
+  max-width: min(var(--lift-col-w), 100%) !important;
+  margin: 0 auto;
+  background: var(--bg);
+  min-height: calc(100dvh - 48px);
+  padding-bottom: calc(24px + var(--lift-tab-h) + env(safe-area-inset-bottom)) !important;
+}
+
+/* desktop-era topbar extras have no place in the phone column */
+#topbar-time, .topbar-version-pill, #topbar-toggle { display: none !important; }
+
+/* ─ bottom tab bar (mockup tabbar: Home / Drills / Progress / Account) ─ */
+#lift-tabbar {
+  position: fixed; bottom: 0; left: 50%; transform: translateX(-50%);
+  width: min(var(--lift-col-w), 100%);
+  z-index: 96;
+  display: flex;
+  border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  background: color-mix(in oklab, var(--bg) 86%, var(--surface3));
+  padding: 8px 8px calc(8px + env(safe-area-inset-bottom));
+}
+#lift-tabbar .lift-tab {
+  flex: 1 1 0;
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  background: none; border: none; cursor: pointer; padding: 5px 0;
+  color: var(--text-dim);
+  transition: color .18s, transform .14s cubic-bezier(0.16, 1, 0.3, 1);
+}
+#lift-tabbar .lift-tab:active { transform: scale(0.94); }
+#lift-tabbar .lift-tab svg { width: 22px; height: 22px; stroke: currentColor; fill: none; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+#lift-tabbar .lift-tab span { font: 700 10px/1 Inter, 'Segoe UI', system-ui, sans-serif; letter-spacing: 0.01em; }
+#lift-tabbar .lift-tab.on { color: var(--accent); }
+
+/* immersive session pages own the whole screen — no tab bar */
+body.lift-no-tabbar #lift-tabbar { display: none; }
+body.lift-no-tabbar .page { padding-bottom: calc(24px + env(safe-area-inset-bottom)) !important; }

--- a/lift-shell.css
+++ b/lift-shell.css
@@ -40,8 +40,10 @@ html[data-theme] body {
   padding-bottom: calc(24px + var(--lift-tab-h) + env(safe-area-inset-bottom)) !important;
 }
 
-/* desktop-era topbar extras have no place in the phone column */
-#topbar-time, .topbar-version-pill, #topbar-toggle { display: none !important; }
+/* desktop-era topbar extras have no place in the phone column.
+   The version pill STAYS — it's the triple-tap production-monitor entry. */
+#topbar-time, #topbar-toggle { display: none !important; }
+.topbar-version-pill { font-size: 9px !important; opacity: .7; }
 
 /* ─ bottom tab bar (mockup tabbar: Home / Drills / Progress / Account) ─ */
 #lift-tabbar {

--- a/lift-shell.css
+++ b/lift-shell.css
@@ -65,8 +65,10 @@ html[data-theme] body {
 #lift-tabbar .lift-tab span { font: 700 10px/1 Inter, 'Segoe UI', system-ui, sans-serif; letter-spacing: 0.01em; }
 #lift-tabbar .lift-tab.on { color: var(--accent); }
 
-/* immersive session pages own the whole screen — no tab bar */
+/* immersive session pages own the whole screen — no tab bar, no app topbar
+   (the session screens carry their own mockup header, e.g. the quiz qbar) */
 body.lift-no-tabbar #lift-tabbar { display: none; }
+body.lift-no-tabbar #app-topbar { display: none !important; }
 body.lift-no-tabbar .page { padding-bottom: calc(24px + env(safe-area-inset-bottom)) !important; }
 
 /* ─ Phase-0 interim: un-lifted pages built desktop grids whose narrow-viewport

--- a/lift-shell.js
+++ b/lift-shell.js
@@ -1,7 +1,7 @@
 /* LIFT-SHELL · Phase 0 — bottom tab bar + showPage hook.
    Companion to lift-shell.css; see the plan doc for the phase map.
-   Drills tab routes to Home (its drill section) until the dedicated Drills
-   screen lands in Phase 3. */
+   Phase 3: the Drills tab routes to the dedicated #page-drills screen,
+   rendered here from real app data (wrong bank, weak spots, domains). */
 (function () {
   'use strict';
 
@@ -38,13 +38,7 @@
       var b = e.target.closest('.lift-tab');
       if (!b || typeof window.showPage !== 'function') return;
       var page = b.getAttribute('data-page');
-      if (page === 'drills') {
-        window.showPage('setup');
-        /* until Phase 3: land on Home's drill entry points */
-        var drill = document.getElementById('btn-drill-mistakes');
-        if (drill) { try { drill.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (_) {} }
-        return;
-      }
+      if (page === 'drills') liftRenderDrills();
       window.showPage(page);
     });
 
@@ -65,6 +59,90 @@
   function currentPage() {
     var el = document.querySelector('.page.active');
     return el ? el.id.replace(/^page-/, '') : 'setup';
+  }
+
+  function esc(s) { var d = document.createElement('i'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+
+  /* Drills tab screen — 1:1 of mockups/cert-ios-drills.html fed by real data.
+     Reads the same sources as the app's own surfaces: loadWrongBank (mistakes
+     count behind startWrongDrill), computeWeakSpotScores (weak chips →
+     focusTopic launches a 10-Q drill), DOMAIN_WEIGHTS/DOMAIN_LABELS +
+     history-aggregated mastery (identical math to renderBentoDomains) →
+     applyDomainPreset. Must never block navigation. */
+  function liftRenderDrills() {
+    try {
+      var bank = (typeof loadWrongBank === 'function') ? loadWrongBank() : [];
+      var n = bank.length;
+      var pill = document.getElementById('drills-mistakes-pill');
+      var note = document.getElementById('drills-mistakes-note');
+      var mbtn = document.getElementById('drills-mistakes-btn');
+      if (pill) pill.textContent = n + ' saved';
+      if (note) note.innerHTML = n
+        ? 'Clear the <b>' + n + ' wrong answer' + (n === 1 ? '' : 's') + '</b> in your bank. Get one right twice in a row and it leaves the bank for good.'
+        : 'No wrong answers saved yet. Miss a question in practice and it lands here for a repeat pass.';
+      if (mbtn) { mbtn.disabled = !n; mbtn.textContent = n ? 'Drill the ' + n + ' you missed' : 'Nothing to drill yet'; }
+
+      /* per-topic accuracy from history (chip percentages) */
+      var acc = {};
+      try {
+        ((typeof loadHistory === 'function') ? loadHistory() : []).forEach(function (e) {
+          if (!e.topic) return;
+          var a = acc[e.topic] || (acc[e.topic] = { s: 0, t: 0 });
+          a.s += e.score || 0; a.t += e.total || 0;
+        });
+      } catch (_) {}
+
+      var weak = [];
+      try { weak = ((typeof computeWeakSpotScores === 'function') ? computeWeakSpotScores() : []) || []; } catch (_) {}
+      var top = weak.slice(0, 3);
+      var chipsHost = document.getElementById('drills-weak-chips');
+      var wbtn = document.getElementById('drills-weak-btn');
+      if (chipsHost) {
+        chipsHost.innerHTML = top.length ? top.map(function (w) {
+          var a = acc[w.topic], pct = (a && a.t) ? Math.round((a.s / a.t) * 100) : 0;
+          return '<span class="drills-chip">' + esc(w.topic) + ' <b>' + pct + '%</b></span>';
+        }).join('') : '<span class="drills-chip drills-chip-empty">No weak topics yet — keep practising</span>';
+      }
+      if (wbtn) {
+        wbtn.disabled = !top.length;
+        wbtn.onclick = top.length
+          ? function () { if (typeof focusTopic === 'function') focusTopic(top[0].topic); }
+          : null;
+      }
+
+      var host = document.getElementById('drills-domain-list');
+      if (host && typeof DOMAIN_WEIGHTS === 'object' && DOMAIN_WEIGHTS) {
+        var order = Object.keys(DOMAIN_WEIGHTS);
+        var stats = {};
+        order.forEach(function (d) { stats[d] = { s: 0, t: 0 }; });
+        try {
+          ((typeof loadHistory === 'function') ? loadHistory() : []).forEach(function (e) {
+            var dk = (typeof TOPIC_DOMAINS !== 'undefined' && TOPIC_DOMAINS) ? TOPIC_DOMAINS[e.topic] : null;
+            if (!dk || !stats[dk]) return;
+            stats[dk].s += e.score || 0; stats[dk].t += e.total || 0;
+          });
+        } catch (_) {}
+        host.innerHTML = order.map(function (dk) {
+          var weight = Math.round((DOMAIN_WEIGHTS[dk] || 0) * 100);
+          var st = stats[dk];
+          var m = st.t ? Math.round((st.s / st.t) * 100) : 0;
+          var name = (typeof DOMAIN_LABELS === 'object' && DOMAIN_LABELS && DOMAIN_LABELS[dk]) || dk;
+          return '<button type="button" class="drills-domain" onclick="applyDomainPreset(\'' + String(dk).replace(/'/g, "\\'") + '\')">'
+            + '<span class="drills-domain-top"><b>' + esc(name) + '</b><span class="drills-domain-wt">' + weight + '% of exam</span></span>'
+            + '<span class="drills-domain-bar' + (m >= 100 ? ' full' : '') + '"><i style="width:' + m + '%"></i></span>'
+            + '<span class="drills-domain-mast">Mastery <b>' + m + '%</b>' + (st.t ? '' : ', untouched') + ' &middot; 10 Q</span>'
+            + '</button>';
+        }).join('');
+      }
+
+      var tag = document.getElementById('drills-plan-tag');
+      if (tag) {
+        try {
+          var pk = (typeof CERT_PACK === 'object' && CERT_PACK) ? (CERT_PACK.examCode || CERT_PACK.code || null) : null;
+          if (pk) tag.textContent = pk;
+        } catch (_) {}
+      }
+    } catch (_) { /* drills render must never block navigation */ }
   }
 
   function sync(name) {

--- a/lift-shell.js
+++ b/lift-shell.js
@@ -63,6 +63,13 @@
 
   function esc(s) { var d = document.createElement('i'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
 
+  function certCode() {
+    try {
+      var m = (typeof CERT_PACK === 'object' && CERT_PACK && CERT_PACK.meta) || null;
+      return m ? (m.code || m.examCode || null) : null;
+    } catch (_) { return null; }
+  }
+
   /* Drills tab screen — 1:1 of mockups/cert-ios-drills.html fed by real data.
      Reads the same sources as the app's own surfaces: loadWrongBank (mistakes
      count behind startWrongDrill), computeWeakSpotScores (weak chips →
@@ -136,12 +143,7 @@
       }
 
       var tag = document.getElementById('drills-plan-tag');
-      if (tag) {
-        try {
-          var pk = (typeof CERT_PACK === 'object' && CERT_PACK) ? (CERT_PACK.examCode || CERT_PACK.code || null) : null;
-          if (pk) tag.textContent = pk;
-        } catch (_) {}
-      }
+      if (tag) { var pk = certCode(); if (pk) tag.textContent = pk; }
     } catch (_) { /* drills render must never block navigation */ }
   }
 
@@ -153,6 +155,123 @@
       tabs[i].classList.toggle('on', tabs[i].getAttribute('data-page') === lit);
     }
   }
+
+  /* ── Exam-date bottom sheet (Phase 2 leftover, mockup cert-ios-settings) ──
+     Replaces the native showPicker() date input on the Settings exam chip
+     with the mockup's scrim + calendar sheet. Saves through the app's own
+     updateExamDate() so the chip, topbar countdown, Home and Analytics all
+     re-sync. Sheet DOM is lazy-built on first open; the chip's inline
+     onclick is intercepted in capture phase (clear × stays native). */
+  var MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+  var DOWS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+  var sheetBuilt = false, selISO = '', viewY = 0, viewM = 0;
+
+  function dayStart(d) { var x = new Date(d); x.setHours(0, 0, 0, 0); return x; }
+  function isoOf(d) { return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0'); }
+
+  function buildExamSheet() {
+    if (sheetBuilt) return;
+    sheetBuilt = true;
+    var scrim = document.createElement('div');
+    scrim.className = 'lift-sheet-scrim';
+    scrim.id = 'lift-exam-scrim';
+    var sheet = document.createElement('div');
+    sheet.className = 'lift-sheet';
+    sheet.id = 'lift-exam-sheet';
+    sheet.setAttribute('role', 'dialog');
+    sheet.setAttribute('aria-modal', 'true');
+    sheet.setAttribute('aria-label', 'Set your exam date');
+    var cert = certCode() || '';
+    sheet.innerHTML = '<div class="lift-sheet-grab"></div>'
+      + '<h2 class="lift-sheet-title">Set your exam date</h2>'
+      + '<p class="lift-sheet-sub">Pick the day you sit ' + (cert ? esc(cert) : 'your exam') + '. You can change it any time.</p>'
+      + '<div class="lift-cal-head">'
+      + '<span class="lift-cal-month" id="lift-cal-month"></span>'
+      + '<span class="lift-cal-nav">'
+      + '<button type="button" id="lift-cal-prev" aria-label="Previous month"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg></button>'
+      + '<button type="button" id="lift-cal-next" aria-label="Next month"><svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></svg></button>'
+      + '</span></div>'
+      + '<div class="lift-cal-grid" id="lift-cal-grid"></div>'
+      + '<button class="lift-sheet-save" id="lift-exam-save" type="button" disabled>Save exam date</button>'
+      + '<button class="lift-sheet-clear" id="lift-exam-clear" type="button" hidden>Remove exam date</button>';
+    document.body.appendChild(scrim);
+    document.body.appendChild(sheet);
+
+    scrim.addEventListener('click', closeExamSheet);
+    document.getElementById('lift-cal-prev').addEventListener('click', function () { if (--viewM < 0) { viewM = 11; viewY--; } renderCal(); });
+    document.getElementById('lift-cal-next').addEventListener('click', function () { if (++viewM > 11) { viewM = 0; viewY++; } renderCal(); });
+    document.getElementById('lift-cal-grid').addEventListener('click', function (e) {
+      var b = e.target.closest('.lift-cal-day');
+      if (!b || b.disabled) return;
+      selISO = b.getAttribute('data-iso');
+      renderCal();
+    });
+    document.getElementById('lift-exam-save').addEventListener('click', function () {
+      if (!selISO) return;
+      if (typeof updateExamDate === 'function') updateExamDate(selISO);
+      closeExamSheet();
+    });
+    document.getElementById('lift-exam-clear').addEventListener('click', function () {
+      if (typeof updateExamDate === 'function') updateExamDate('');
+      closeExamSheet();
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && sheet.classList.contains('on')) closeExamSheet();
+    });
+  }
+
+  function renderCal() {
+    var today = dayStart(new Date());
+    var monthEl = document.getElementById('lift-cal-month');
+    var prevBtn = document.getElementById('lift-cal-prev');
+    var grid = document.getElementById('lift-cal-grid');
+    var save = document.getElementById('lift-exam-save');
+    monthEl.textContent = MONTHS[viewM] + ' ' + viewY;
+    prevBtn.disabled = (viewY === today.getFullYear() && viewM === today.getMonth());
+    var html = DOWS.map(function (d) { return '<span class="lift-cal-dow">' + d + '</span>'; }).join('');
+    var lead = (new Date(viewY, viewM, 1).getDay() + 6) % 7; /* Monday-start offset */
+    for (var i = 0; i < lead; i++) html += '<span></span>';
+    var days = new Date(viewY, viewM + 1, 0).getDate();
+    for (var d = 1; d <= days; d++) {
+      var dt = new Date(viewY, viewM, d), dISO = isoOf(dt);
+      var cls = 'lift-cal-day' + (dISO === selISO ? ' sel' : '') + (dt.getTime() === today.getTime() ? ' today' : '');
+      html += '<button type="button" class="' + cls + '" data-iso="' + dISO + '"' + (dt < today ? ' disabled' : '') + '>' + d + '</button>';
+    }
+    grid.innerHTML = html;
+    save.disabled = !selISO;
+  }
+
+  function openExamSheet() {
+    buildExamSheet();
+    var today = dayStart(new Date());
+    selISO = '';
+    try { selISO = (typeof getExamDate === 'function' && getExamDate()) || ''; } catch (_) {}
+    if (selISO) { var p = selISO.split('-'); viewY = +p[0]; viewM = +p[1] - 1; }
+    else { viewY = today.getFullYear(); viewM = today.getMonth(); }
+    renderCal();
+    document.getElementById('lift-exam-clear').hidden = !selISO;
+    document.getElementById('lift-exam-save').textContent = selISO ? 'Save exam date' : 'Save exam date';
+    document.getElementById('lift-exam-scrim').classList.add('on');
+    document.getElementById('lift-exam-sheet').classList.add('on');
+  }
+
+  function closeExamSheet() {
+    var scrim = document.getElementById('lift-exam-scrim'), sheet = document.getElementById('lift-exam-sheet');
+    if (scrim) scrim.classList.remove('on');
+    if (sheet) sheet.classList.remove('on');
+  }
+
+  /* capture-phase intercept: the chip's inline onclick (native showPicker)
+     never fires; the clear × keeps its native updateExamDate('') path */
+  document.addEventListener('click', function (ev) {
+    if (!ev.target.closest) return;
+    var row = ev.target.closest('#settings-exam-row');
+    if (!row) return;
+    if (ev.target.closest('.ana-ready-datechip-clear')) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    openExamSheet();
+  }, true);
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);

--- a/lift-shell.js
+++ b/lift-shell.js
@@ -1,0 +1,82 @@
+/* LIFT-SHELL · Phase 0 — bottom tab bar + showPage hook.
+   Companion to lift-shell.css; see the plan doc for the phase map.
+   Drills tab routes to Home (its drill section) until the dedicated Drills
+   screen lands in Phase 3. */
+(function () {
+  'use strict';
+
+  var TABS = [
+    { page: 'setup',    label: 'Home',     icon: '<path d="M4 11l8-7 8 7"></path><path d="M6 10v9h12v-9"></path>' },
+    { page: 'drills',   label: 'Drills',   icon: '<path d="M4 6h16M4 12h16M4 18h10"></path>' },
+    { page: 'progress', label: 'Progress', icon: '<path d="M5 19V9M12 19V4M19 19v-7"></path>' },
+    { page: 'settings', label: 'Account',  icon: '<circle cx="12" cy="8" r="4"></circle><path d="M4 21a8 8 0 0 1 16 0"></path>' }
+  ];
+
+  /* session/immersive pages render without the tab bar (mockup behaviour) */
+  var HIDE_ON = {
+    'quiz': 1, 'exam': 1, 'diagnostic-quiz': 1, 'loading': 1, 'review': 1,
+    'sr-review': 1, 'session-transition': 1, 'acl-pbq': 1, 'guided-lab': 1
+  };
+
+  /* tab to light when a non-tab page is active */
+  var LIGHT_AS = { 'analytics': 'progress', 'topic-dive': 'progress', 'diagnostic-result': 'setup', 'session-complete': 'setup', 'results': 'setup', 'exam-results': 'setup' };
+
+  function init() {
+    if (document.getElementById('lift-tabbar')) return;
+    var bar = document.createElement('nav');
+    bar.id = 'lift-tabbar';
+    bar.setAttribute('aria-label', 'Primary');
+    bar.innerHTML = TABS.map(function (t) {
+      return '<button type="button" class="lift-tab" data-page="' + t.page + '" aria-label="' + t.label + '">' +
+        '<svg viewBox="0 0 24 24" aria-hidden="true">' + t.icon + '</svg><span>' + t.label + '</span></button>';
+    }).join('');
+    document.body.appendChild(bar);
+
+    bar.addEventListener('click', function (e) {
+      var b = e.target.closest('.lift-tab');
+      if (!b || typeof window.showPage !== 'function') return;
+      var page = b.getAttribute('data-page');
+      if (page === 'drills') {
+        window.showPage('setup');
+        /* until Phase 3: land on Home's drill entry points */
+        var drill = document.getElementById('btn-drill-mistakes');
+        if (drill) { try { drill.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (_) {} }
+        return;
+      }
+      window.showPage(page);
+    });
+
+    /* keep tab state + tab bar visibility in sync with navigation */
+    if (typeof window.showPage === 'function' && !window.showPage.__liftWrapped) {
+      var orig = window.showPage;
+      var wrapped = function (name) {
+        var r = orig.apply(this, arguments);
+        try { sync(name); } catch (_) {}
+        return r;
+      };
+      wrapped.__liftWrapped = true;
+      window.showPage = wrapped;
+    }
+    sync(currentPage());
+  }
+
+  function currentPage() {
+    var el = document.querySelector('.page.active');
+    return el ? el.id.replace(/^page-/, '') : 'setup';
+  }
+
+  function sync(name) {
+    document.body.classList.toggle('lift-no-tabbar', !!HIDE_ON[name]);
+    var lit = LIGHT_AS[name] || name;
+    var tabs = document.querySelectorAll('#lift-tabbar .lift-tab');
+    for (var i = 0; i < tabs.length; i++) {
+      tabs[i].classList.toggle('on', tabs[i].getAttribute('data-page') === lit);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/lift-shell.js
+++ b/lift-shell.js
@@ -37,10 +37,9 @@
     bar.addEventListener('click', function (e) {
       var b = e.target.closest('.lift-tab');
       if (!b || typeof window.showPage !== 'function') return;
-      var page = b.getAttribute('data-page');
-      if (page === 'drills') liftRenderDrills();
-      window.showPage(page);
+      navTo(b.getAttribute('data-page'));
     });
+    injectSeg();
 
     /* keep tab state + tab bar visibility in sync with navigation */
     if (typeof window.showPage === 'function' && !window.showPage.__liftWrapped) {
@@ -59,6 +58,46 @@
   function currentPage() {
     var el = document.querySelector('.page.active');
     return el ? el.id.replace(/^page-/, '') : 'setup';
+  }
+
+  /* showPage() only swaps pages — content renderers were historically invoked
+     by the (now retired) sidebar item handlers. Mirror that dispatch here so
+     tab/seg navigation always lands on fresh content. */
+  var RENDER = {
+    drills: function () { liftRenderDrills(); },
+    progress: function () { if (typeof renderProgressPage === 'function') renderProgressPage(); },
+    analytics: function () { if (typeof renderAnalytics === 'function') renderAnalytics(); },
+    settings: function () { if (typeof renderSettingsPage === 'function') renderSettingsPage(); }
+  };
+
+  function navTo(page) {
+    if (page === 'setup' && typeof window.goSetup === 'function') { window.goSetup(); return; }
+    try { if (RENDER[page]) RENDER[page](); } catch (_) { /* render must never block nav */ }
+    window.showPage(page);
+  }
+
+  /* Progress ⇄ Analytics segmented switcher (mockup .seg chip language).
+     Analytics lost its only entry point when the sidebar retired — this
+     restores it inside the lift's own chrome, on both pages. */
+  function injectSeg() {
+    ['progress', 'analytics'].forEach(function (pid) {
+      var page = document.getElementById('page-' + pid);
+      if (!page || page.querySelector('.lift-seg')) return;
+      var seg = document.createElement('div');
+      seg.className = 'lift-seg';
+      seg.setAttribute('role', 'tablist');
+      seg.setAttribute('aria-label', 'Progress and analytics');
+      seg.innerHTML = [['progress', 'Progress'], ['analytics', 'Analytics']].map(function (t) {
+        var on = t[0] === pid;
+        return '<button type="button" class="lift-seg-chip' + (on ? ' on' : '') + '" data-page="' + t[0] + '" role="tab" aria-selected="' + on + '">' + t[1] + '</button>';
+      }).join('');
+      seg.addEventListener('click', function (e) {
+        var b = e.target.closest('.lift-seg-chip');
+        if (!b || b.classList.contains('on')) return;
+        navTo(b.getAttribute('data-page'));
+      });
+      page.insertBefore(seg, page.firstChild);
+    });
   }
 
   function esc(s) { var d = document.createElement('i'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }

--- a/lift-shell.js
+++ b/lift-shell.js
@@ -15,11 +15,13 @@
   /* session/immersive pages render without the tab bar (mockup behaviour) */
   var HIDE_ON = {
     'quiz': 1, 'exam': 1, 'diagnostic-quiz': 1, 'loading': 1, 'review': 1,
-    'sr-review': 1, 'session-transition': 1, 'acl-pbq': 1, 'guided-lab': 1
+    'sr-review': 1, 'session-transition': 1, 'acl-pbq': 1, 'guided-lab': 1,
+    /* session-end screens carry their own mockup footer (rfoot) */
+    'results': 1, 'exam-results': 1, 'session-complete': 1
   };
 
   /* tab to light when a non-tab page is active */
-  var LIGHT_AS = { 'analytics': 'progress', 'topic-dive': 'progress', 'diagnostic-result': 'setup', 'session-complete': 'setup', 'results': 'setup', 'exam-results': 'setup' };
+  var LIGHT_AS = { 'analytics': 'progress', 'topic-dive': 'progress', 'diagnostic-result': 'setup' };
 
   function init() {
     if (document.getElementById('lift-tabbar')) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.35.0",
+  "version": "7.36.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.35.0
+   Network+ AI Quiz — styles.css  v7.36.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.35.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.35.0';
+// Service Worker v7.36.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.36.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -151,34 +151,39 @@ test.describe('Navigation', () => {
   test('navigates to analytics and back', async ({ page }) => {
     await page.goto('/');
 
-    // v4.53.0: nav via sidebar
-    await page.locator('.sb-item[data-sb-page="analytics"]').click();
+    // v7.36.0 (mockup lift): sidebar retired — nav via the bottom tab bar,
+    // then the Progress ⇄ Analytics seg switcher.
+    await page.locator('#lift-tabbar .lift-tab[data-page="progress"]').click();
+    await expect(page.locator('#page-progress')).toHaveClass(/active/);
+    await page.locator('#page-progress .lift-seg-chip[data-page="analytics"]').click();
     await expect(page.locator('#page-analytics')).toHaveClass(/active/);
 
-    await page.locator('.sb-item[data-sb-page="setup"]').click();
+    await page.locator('#lift-tabbar .lift-tab[data-page="setup"]').click();
     await expect(page.locator('#page-setup')).toHaveClass(/active/);
   });
 
   test('navigates to topic progress and back', async ({ page }) => {
     await page.goto('/');
 
-    // v4.53.0: nav via sidebar
-    await page.locator('.sb-item[data-sb-page="progress"]').click();
+    // v7.36.0 (mockup lift): nav via the bottom tab bar
+    await page.locator('#lift-tabbar .lift-tab[data-page="progress"]').click();
     await expect(page.locator('#page-progress')).toHaveClass(/active/);
 
-    await page.locator('.sb-item[data-sb-page="setup"]').click();
+    await page.locator('#lift-tabbar .lift-tab[data-page="setup"]').click();
     await expect(page.locator('#page-setup')).toHaveClass(/active/);
   });
 });
 
-// v4.54.1: Settings moved to its own page — navigate via sidebar first.
+// v7.36.0 (mockup lift): Settings is the Account tab in the bottom tab bar.
 async function gotoSettings(page) {
-  await page.locator('.sb-item[data-sb-page="settings"]').click();
+  await page.locator('#lift-tabbar .lift-tab[data-page="settings"]').click();
   await expect(page.locator('#page-settings')).toHaveClass(/active/);
 }
-// v4.54.1: Recent Performance moved to Analytics — navigate via sidebar first.
+// v7.36.0 (mockup lift): Analytics sits behind the Progress tab's seg switcher.
 async function gotoAnalytics(page) {
-  await page.locator('.sb-item[data-sb-page="analytics"]').click();
+  await page.locator('#lift-tabbar .lift-tab[data-page="progress"]').click();
+  await expect(page.locator('#page-progress')).toHaveClass(/active/);
+  await page.locator('#page-progress .lift-seg-chip[data-page="analytics"]').click();
   await expect(page.locator('#page-analytics')).toHaveClass(/active/);
 }
 
@@ -732,8 +737,10 @@ test.describe('Streak Badge', () => {
     await page.evaluate(() => localStorage.removeItem('nplus_streak'));
     await page.reload();
 
-    // v4.54.0: empty state rendered as .sb-streak-empty inside the sidebar footer
-    await expect(page.locator('.sb-streak-empty')).toBeVisible();
+    // v7.36.0 (mockup lift): sidebar retired — the streak signal lives in the
+    // Home console chip (#cb-streak), which reads 0 in the empty state.
+    await expect(page.locator('#cb-streak')).toBeVisible();
+    await expect(page.locator('#cb-streak')).toHaveText('0');
   });
 });
 
@@ -761,8 +768,9 @@ test.describe('Production Monitor', () => {
   test('triple-tap version badge opens monitor', async ({ page }) => {
     await page.goto('/');
 
-    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
-    const badge = page.locator('.sb-brand-version');
+    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
+    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
+    const badge = page.locator('#topbar-version-pill');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -775,8 +783,9 @@ test.describe('Production Monitor', () => {
     await page.goto('/');
     await page.evaluate(() => localStorage.removeItem('nplus_error_log'));
 
-    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
-    const badge = page.locator('.sb-brand-version');
+    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
+    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
+    const badge = page.locator('#topbar-version-pill');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -797,8 +806,9 @@ test.describe('Production Monitor', () => {
       localStorage.setItem('nplus_error_log', JSON.stringify(log));
     });
 
-    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
-    const badge = page.locator('.sb-brand-version');
+    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
+    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
+    const badge = page.locator('#topbar-version-pill');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -816,8 +826,9 @@ test.describe('Production Monitor', () => {
       localStorage.setItem('nplus_error_log', JSON.stringify(log));
     });
 
-    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
-    const badge = page.locator('.sb-brand-version');
+    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
+    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
+    const badge = page.locator('#topbar-version-pill');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -1180,7 +1191,7 @@ test.describe('Quiz Revisit — editable navigation', () => {
     await expect(page.locator('#quiz-next-arrow-btn')).toBeEnabled();
 
     // Click next-arrow → advance to Q2.
-    await page.locator('#quiz-next-arrow-btn').click();
+    await page.locator('#btn-next').click(); // v7.36.0 lift: arrows hidden, footer Next advances
     await expect(page.locator('#q-label')).toContainText('Question 2 of 3');
     await expect(page.locator('#quiz-revisit-banner')).toHaveClass(/is-hidden/);
     // Prev should be enabled now.
@@ -1220,7 +1231,7 @@ test.describe('Quiz Revisit — editable navigation', () => {
     await expect(page.locator('#live-streak')).toContainText('Streak 1');
 
     // Advance to Q2 via next-arrow.
-    await page.locator('#quiz-next-arrow-btn').click();
+    await page.locator('#btn-next').click(); // v7.36.0 lift: arrows hidden, footer Next advances
     await expect(page.locator('#q-label')).toContainText('Question 2 of 3');
 
     // Click dot for Q1 → revisit.
@@ -1392,7 +1403,7 @@ test.describe('Quiz Hot-Area — click-on-diagram PBQs', () => {
     await expect(page.locator('#live-score')).toContainText('0 / 1');
 
     // Advance to Q2
-    await page.locator('#quiz-next-arrow-btn').click();
+    await page.locator('#btn-next').click(); // v7.36.0 lift: arrows hidden, footer Next advances
     await expect(page.locator('#q-label')).toContainText('Question 2 of 2');
 
     // Click dot back to Q1


### PR DESCRIPTION
## What

The approved cert-ios mockup design language, lifted 1:1 onto the real app — every signed-in surface renders as a centered ~430px phone-proportioned column with a bottom tab bar, identical on mobile Safari and desktop (locked decision).

**Phase 0** — chrome swap: centered column + bottom tab bar (`lift-shell.css/js`), immersive-page map, overlap fixes.
**Phase 1** — quiz session, results, review-answers lifted (`lift-screens.css`, CSS-first, app DOM untouched).
**Phase 2** — Settings + Home lifted; exam-date bottom sheet replacing the native date picker; Home day-0 locked readiness hero; free-quota gate restyled.
**Phase 3** — Progress + Analytics lifted (mockup pagers flattened to single scrolls), SR Daily Review lifted, net-new **Drills tab screen** fed by real data (wrong bank → startWrongDrill, weak spots → focusTopic, domains → applyDomainPreset).

## How

CSS-first, DOM-minimal: scoped `html[data-theme] body #page-X` overrides in `lift-screens.css` (loads last). All existing ids/onclick contracts preserved. Net-new code (Drills page, exam sheet) lives in lift-owned files — zero `app.js` changes. v7.36.0 bump via `bump-version.js` (SW cache included).

## Verification

- UAT 4109/4109 on every commit (pre-commit hook)
- tech-debt exit 0 (no new breaches)
- Per-screen live verification on localhost: programmatic spill scans (zero elements outside the column), dark+light themes, behavioral smokes (mistakes drill launches a session, exam-date save/remove round-trip syncs topbar countdown)

Landing page, pricing, privacy, terms: untouched (frozen per locked scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)