### PR TITLE
v7.36.1 — viewport-gate the cert-ios lift (desktop keeps classic layout)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.36.1 | Viewport-gate the cert-ios lift — mobile keeps the new look, desktop restores the classic layout |
 | v7.36.0 | Mockup lift: cert-ios design language on all app surfaces — centered column + tab bar chrome, quiz/results/review/settings/home/progress/analytics/SR-review lifts, net-new Drills tab, exam-date sheet, day-0 + capped states |
 | v7.35.0 | Mobile Home redesign (Start-first, collapsible Practice/Exam/Drill, readiness strip) + in-view signed-out prompt, top-strip update banner, 44px tap targets, sticky Results CTA; desktop readiness/PROD polish |
 | v7.34.0 | Desktop home polish — compress empty readiness hero (no-score state) + hide PROD badge from live users |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.36.0
+// Network+ AI Quiz — app.js  v7.36.1
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.36.0';
+const APP_VERSION = '7.36.1';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/index.html
+++ b/index.html
@@ -34,8 +34,13 @@
 <link rel="stylesheet" href="styles.css">
 <link rel="stylesheet" href="dg-system.css?v=7.33.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
-<link rel="stylesheet" href="lift-shell.css?v=7.36.0">
-<link rel="stylesheet" href="lift-screens.css?v=7.36.0">
+<!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
+     viewports get the mockup column + tab bar; desktop keeps the classic
+     layout (sidebar + full-width pages). lift-shell.js mirrors this gate
+     via matchMedia(LIFT_MQ). The Capacitor iOS wrap is always narrow, so
+     the native app always gets the lift. -->
+<link rel="stylesheet" href="lift-shell.css?v=7.36.1" media="(max-width: 899px)">
+<link rel="stylesheet" href="lift-screens.css?v=7.36.1" media="(max-width: 899px)">
 <!-- v5.5.1 — Fraunces display face for the editorial system (Home v3
      reimagining + cross-surface). Body stays the app font; Fraunces is
      scoped to display moments in dg-system.css. preconnect + display=swap
@@ -756,7 +761,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.36.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.36.1</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/lift-shell.js
+++ b/lift-shell.js
@@ -1,9 +1,16 @@
 /* LIFT-SHELL · Phase 0 — bottom tab bar + showPage hook.
    Companion to lift-shell.css; see the plan doc for the phase map.
    Phase 3: the Drills tab routes to the dedicated #page-drills screen,
-   rendered here from real app data (wrong bank, weak spots, domains). */
+   rendered here from real app data (wrong bank, weak spots, domains).
+   v7.36.1: the lift is VIEWPORT-GATED — this file's chrome (tab bar, seg
+   switcher, exam sheet) only acts under LIFT_MQ, mirroring the media
+   attribute on the lift-shell/lift-screens <link> tags. Desktop keeps the
+   classic layout (sidebar + native pickers); the Capacitor iOS wrap is
+   always narrow, so the native app always gets the lift. */
 (function () {
   'use strict';
+
+  var LIFT_MQ = window.matchMedia('(max-width: 899px)');
 
   var TABS = [
     { page: 'setup',    label: 'Home',     icon: '<path d="M4 11l8-7 8 7"></path><path d="M6 10v9h12v-9"></path>' },
@@ -40,6 +47,19 @@
       navTo(b.getAttribute('data-page'));
     });
     injectSeg();
+
+    /* viewport gate: lift chrome exists only under LIFT_MQ. The gated
+       stylesheets stop applying on desktop, so the injected elements must
+       hide themselves too or they'd render unstyled. */
+    function applyGate() {
+      var on = LIFT_MQ.matches;
+      bar.hidden = !on;
+      document.querySelectorAll('.lift-seg').forEach(function (s) { s.hidden = !on; });
+      document.body.classList.toggle('lift-on', on);
+    }
+    applyGate();
+    if (typeof LIFT_MQ.addEventListener === 'function') LIFT_MQ.addEventListener('change', applyGate);
+    else if (typeof LIFT_MQ.addListener === 'function') LIFT_MQ.addListener(applyGate);
 
     /* keep tab state + tab bar visibility in sync with navigation */
     if (typeof window.showPage === 'function' && !window.showPage.__liftWrapped) {
@@ -303,6 +323,7 @@
   /* capture-phase intercept: the chip's inline onclick (native showPicker)
      never fires; the clear × keeps its native updateExamDate('') path */
   document.addEventListener('click', function (ev) {
+    if (!LIFT_MQ.matches) return; /* desktop keeps the native date picker */
     if (!ev.target.closest) return;
     var row = ev.target.closest('#settings-exam-row');
     if (!row) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.36.0",
+  "version": "7.36.1",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.36.0
+   Network+ AI Quiz — styles.css  v7.36.1
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.36.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.36.0';
+// Service Worker v7.36.1 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.36.1';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -151,39 +151,34 @@ test.describe('Navigation', () => {
   test('navigates to analytics and back', async ({ page }) => {
     await page.goto('/');
 
-    // v7.36.0 (mockup lift): sidebar retired — nav via the bottom tab bar,
-    // then the Progress ⇄ Analytics seg switcher.
-    await page.locator('#lift-tabbar .lift-tab[data-page="progress"]').click();
-    await expect(page.locator('#page-progress')).toHaveClass(/active/);
-    await page.locator('#page-progress .lift-seg-chip[data-page="analytics"]').click();
+    // v4.53.0: nav via sidebar
+    await page.locator('.sb-item[data-sb-page="analytics"]').click();
     await expect(page.locator('#page-analytics')).toHaveClass(/active/);
 
-    await page.locator('#lift-tabbar .lift-tab[data-page="setup"]').click();
+    await page.locator('.sb-item[data-sb-page="setup"]').click();
     await expect(page.locator('#page-setup')).toHaveClass(/active/);
   });
 
   test('navigates to topic progress and back', async ({ page }) => {
     await page.goto('/');
 
-    // v7.36.0 (mockup lift): nav via the bottom tab bar
-    await page.locator('#lift-tabbar .lift-tab[data-page="progress"]').click();
+    // v4.53.0: nav via sidebar
+    await page.locator('.sb-item[data-sb-page="progress"]').click();
     await expect(page.locator('#page-progress')).toHaveClass(/active/);
 
-    await page.locator('#lift-tabbar .lift-tab[data-page="setup"]').click();
+    await page.locator('.sb-item[data-sb-page="setup"]').click();
     await expect(page.locator('#page-setup')).toHaveClass(/active/);
   });
 });
 
-// v7.36.0 (mockup lift): Settings is the Account tab in the bottom tab bar.
+// v4.54.1: Settings moved to its own page — navigate via sidebar first.
 async function gotoSettings(page) {
-  await page.locator('#lift-tabbar .lift-tab[data-page="settings"]').click();
+  await page.locator('.sb-item[data-sb-page="settings"]').click();
   await expect(page.locator('#page-settings')).toHaveClass(/active/);
 }
-// v7.36.0 (mockup lift): Analytics sits behind the Progress tab's seg switcher.
+// v4.54.1: Recent Performance moved to Analytics — navigate via sidebar first.
 async function gotoAnalytics(page) {
-  await page.locator('#lift-tabbar .lift-tab[data-page="progress"]').click();
-  await expect(page.locator('#page-progress')).toHaveClass(/active/);
-  await page.locator('#page-progress .lift-seg-chip[data-page="analytics"]').click();
+  await page.locator('.sb-item[data-sb-page="analytics"]').click();
   await expect(page.locator('#page-analytics')).toHaveClass(/active/);
 }
 
@@ -737,10 +732,8 @@ test.describe('Streak Badge', () => {
     await page.evaluate(() => localStorage.removeItem('nplus_streak'));
     await page.reload();
 
-    // v7.36.0 (mockup lift): sidebar retired — the streak signal lives in the
-    // Home console chip (#cb-streak), which reads 0 in the empty state.
-    await expect(page.locator('#cb-streak')).toBeVisible();
-    await expect(page.locator('#cb-streak')).toHaveText('0');
+    // v4.54.0: empty state rendered as .sb-streak-empty inside the sidebar footer
+    await expect(page.locator('.sb-streak-empty')).toBeVisible();
   });
 });
 
@@ -768,9 +761,8 @@ test.describe('Production Monitor', () => {
   test('triple-tap version badge opens monitor', async ({ page }) => {
     await page.goto('/');
 
-    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
-    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
-    const badge = page.locator('#topbar-version-pill');
+    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
+    const badge = page.locator('.sb-brand-version');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -783,9 +775,8 @@ test.describe('Production Monitor', () => {
     await page.goto('/');
     await page.evaluate(() => localStorage.removeItem('nplus_error_log'));
 
-    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
-    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
-    const badge = page.locator('#topbar-version-pill');
+    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
+    const badge = page.locator('.sb-brand-version');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -806,9 +797,8 @@ test.describe('Production Monitor', () => {
       localStorage.setItem('nplus_error_log', JSON.stringify(log));
     });
 
-    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
-    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
-    const badge = page.locator('#topbar-version-pill');
+    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
+    const badge = page.locator('.sb-brand-version');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -826,9 +816,8 @@ test.describe('Production Monitor', () => {
       localStorage.setItem('nplus_error_log', JSON.stringify(log));
     });
 
-    // v7.36.0 (mockup lift): sidebar retired — the triple-tap gesture also
-    // binds to the topbar version pill (v4.89.7), which the lift keeps visible.
-    const badge = page.locator('#topbar-version-pill');
+    // v4.54.0: legacy #version-badge is hidden; the v4.54.0 init attaches the same triple-tap handler to .sb-brand-version in the sidebar
+    const badge = page.locator('.sb-brand-version');
     await badge.click();
     await badge.click();
     await badge.click();
@@ -1191,7 +1180,7 @@ test.describe('Quiz Revisit — editable navigation', () => {
     await expect(page.locator('#quiz-next-arrow-btn')).toBeEnabled();
 
     // Click next-arrow → advance to Q2.
-    await page.locator('#btn-next').click(); // v7.36.0 lift: arrows hidden, footer Next advances
+    await page.locator('#quiz-next-arrow-btn').click();
     await expect(page.locator('#q-label')).toContainText('Question 2 of 3');
     await expect(page.locator('#quiz-revisit-banner')).toHaveClass(/is-hidden/);
     // Prev should be enabled now.
@@ -1231,7 +1220,7 @@ test.describe('Quiz Revisit — editable navigation', () => {
     await expect(page.locator('#live-streak')).toContainText('Streak 1');
 
     // Advance to Q2 via next-arrow.
-    await page.locator('#btn-next').click(); // v7.36.0 lift: arrows hidden, footer Next advances
+    await page.locator('#quiz-next-arrow-btn').click();
     await expect(page.locator('#q-label')).toContainText('Question 2 of 3');
 
     // Click dot for Q1 → revisit.
@@ -1403,7 +1392,7 @@ test.describe('Quiz Hot-Area — click-on-diagram PBQs', () => {
     await expect(page.locator('#live-score')).toContainText('0 / 1');
 
     // Advance to Q2
-    await page.locator('#btn-next').click(); // v7.36.0 lift: arrows hidden, footer Next advances
+    await page.locator('#quiz-next-arrow-btn').click();
     await expect(page.locator('#q-label')).toContainText('Question 2 of 2');
 
     // Click dot back to Q1
@@ -1643,5 +1632,40 @@ test.describe('bug-report drawer', () => {
     await page.click('#topbar-bug-report');
     await page.click('#br-close');
     await expect(page.locator('#topbar-bug-report')).toHaveClass(/has-queue/);
+  });
+});
+
+// ─── v7.36.1: cert-ios lift (viewport-gated) ─────────────────────────────
+// Under 900px the app renders the mockup column + bottom tab bar; desktop
+// (all suites above, Playwright's default 1280px viewport) keeps the classic
+// sidebar layout. These tests pin the gate from the narrow side.
+test.describe('Mobile lift chrome (viewport-gated)', () => {
+  test.use({ viewport: { width: 430, height: 844 } });
+
+  test('tab bar navigates Home → Progress → Analytics (seg) → Settings', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('#lift-tabbar')).toBeVisible();
+    await page.locator('#lift-tabbar .lift-tab[data-page="progress"]').click();
+    await expect(page.locator('#page-progress')).toHaveClass(/active/);
+    await page.locator('#page-progress .lift-seg-chip[data-page="analytics"]').click();
+    await expect(page.locator('#page-analytics')).toHaveClass(/active/);
+    await page.locator('#lift-tabbar .lift-tab[data-page="settings"]').click();
+    await expect(page.locator('#page-settings')).toHaveClass(/active/);
+    await page.locator('#lift-tabbar .lift-tab[data-page="setup"]').click();
+    await expect(page.locator('#page-setup')).toHaveClass(/active/);
+  });
+
+  test('Drills tab opens the dedicated drills screen', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('#lift-tabbar .lift-tab[data-page="drills"]').click();
+    await expect(page.locator('#page-drills')).toHaveClass(/active/);
+    await expect(page.locator('#drills-domain-list .drills-domain')).toHaveCount(5);
+  });
+
+  test('desktop viewport hides the lift chrome (sidebar owns nav)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/');
+    await expect(page.locator('#lift-tabbar')).toBeHidden();
+    await expect(page.locator('.sb-item[data-sb-page="analytics"]')).toBeVisible();
   });
 });


### PR DESCRIPTION
Gates the v7.36.0 lift at 900px: phones/tablet-portrait (and the always-narrow Capacitor iOS wrap) keep the cert-ios look; desktop restores the classic sidebar layout. CSS gated via link media attributes; lift-shell.js mirrors with matchMedia (tab bar/seg hide, exam sheet yields to native picker). Desktop E2E restored to the sidebar contract + new 430px mobile suite. Playwright 81/81, UAT 4109/4109, verified live at both widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)