### PR TITLE
Tune AI proxy global kill-switch to $20/mo testing budget (20000 → 500/day)

### DIFF
--- a/api/ai/generate.js
+++ b/api/ai/generate.js
@@ -44,7 +44,12 @@ const MAX_PROMPT_BYTES = 100 * 1024;  // C2: cap serialized messages+system at 1
 // H1: abuse ceilings (separate from the product 20/day question quota).
 const USER_DAILY_LIMIT   = 500;    // ~20 full 90-Q exams/day — no human reaches it
 const IP_HOURLY_LIMIT    = 200;
-const GLOBAL_DAILY_LIMIT = 20000;  // global kill-switch; tune to Anthropic budget
+const GLOBAL_DAILY_LIMIT = 500;    // global kill-switch — matched to the $20/mo
+                                   // Anthropic workspace cap (founder decision
+                                   // 2026-06-11, testing phase). Equals one user's
+                                   // daily ceiling; raise at go-live alongside the
+                                   // workspace cap, after measuring per-session
+                                   // cost from the simulator E2E run.
 const RL_SALT = process.env.RL_SALT || 'certanvil-ai-rl-v1';
 
 // ── Supabase helpers (REST, no SDK) ─────────────────────────────────────


### PR DESCRIPTION
One-constant gated-lane change to `api/ai/generate.js`: `GLOBAL_DAILY_LIMIT` drops from the 20000 placeholder ("tune to Anthropic budget") to **500/day**, matching the founder's \$20/month Anthropic workspace spend cap for the testing phase.

- 500 = `USER_DAILY_LIMIT`, i.e. the brake now allows exactly one maxed-out legitimate user per day — appropriate while the app has ~1 real user.
- The workspace spend cap is the hard dollar guarantee; this constant just stops an abuse burst from eating the month's budget in a day.
- Raise at go-live alongside the cap, informed by measured per-session cost from the simulator E2E run.

No schema, no env, no behavior change for legitimate traffic. UAT 4109/4109 PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)