### PR TITLE
v7.40.0 — Free tier: 15 questions + 5 review cards/day (GAP-1, gated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.40.0 | Free tier 15 questions + 5 review cards per day (GAP-1 of tier-logic sweep) |
 | v7.39.0 | Manage-subscription static UI lift — plan card, Pro pricing, Stripe-ready seams |
 | v7.38.0 | Account-pages lift phase 2 — Go Pro card + upsell sheet + auth modal lift (mobile, <900px) |
 | v7.37.0 | Account-pages mobile lift — viewport-gated cert-ios reskin of landing /account + /analytics |

--- a/api/ai/generate.js
+++ b/api/ai/generate.js
@@ -27,7 +27,8 @@ const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || '';
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || '';
 
 const ANTHROPIC_VERSION = '2023-06-01';
-const FREE_DAILY_LIMIT = 20;  // mirrors consume_daily_quota's hardcoded limit
+const FREE_DAILY_LIMIT = 15;  // mirrors consume_daily_quota's hardcoded limit
+                              // (15/day since 20260611_free_tier_15_questions.sql)
 
 // ── Security Phase 1 (2026-05-29) — abuse hardening (audit C1/C2/H1/L1) ──
 const crypto = require('crypto');

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.39.0
+// Network+ AI Quiz — app.js  v7.40.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.39.0';
+const APP_VERSION = '7.40.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -345,7 +345,7 @@ const CLAUDE_MODEL = 'claude-haiku-4-5-20251001';
 //     fallback). Phase E.4 removes this fallback once the server proxy
 //     ships with the daily-quota guarantee.
 //   • Anonymous user with no stored key → throws err.needsAuth, caller
-//     surfaces a "sign in for free 20 questions/day" UI.
+//     surfaces a "sign in for free 15 questions/day" UI.
 //
 // The wrapper preserves the same call shape as fetch(url, init) so all 13
 // existing Anthropic call sites in this file collapsed to a single global
@@ -443,7 +443,7 @@ async function _claudeFetch(init) {
   }
 
   // No session, no key — surface a sign-in nag
-  var err = new Error('Sign in to study — 20 free questions/day at certanvil.com.');
+  var err = new Error('Sign in to study — 15 free questions/day at certanvil.com.');
   err.needsAuth = true;
   throw err;
 }
@@ -670,7 +670,7 @@ function _showQuotaExceededUI(detail) {
     '<div class="quota-exceeded-card">' +
       '<div class="quota-exceeded-icon">&#128267;</div>' +
       '<div class="quota-exceeded-title">You&rsquo;ve used today&rsquo;s free questions</div>' +
-      '<div class="quota-exceeded-sub">' + _streakPrefix + 'Free is 20 questions a day, every day, no card required &middot; resets in <strong>' + resetText + '</strong> (midnight UTC).</div>' +
+      '<div class="quota-exceeded-sub">' + _streakPrefix + 'Free is 15 questions a day, every day, no card required &middot; resets in <strong>' + resetText + '</strong> (midnight UTC).</div>' +
       '<div class="quota-exceeded-actions">' +
         _srBtnHtml +
         '<a class="quota-exceeded-cta" href="https://certanvil.com/pricing" target="_blank" rel="noopener">Upgrade to Pro &middot; $9.99/mo &rarr;</a>' +
@@ -701,7 +701,7 @@ function _showQuotaExceededUI(detail) {
 // v4.99.4 Phase E.4.1 — drills moved to Pro-only via _gateProOnly() below.
 //
 // Called at quiz entry points (startQuiz, startExam). If a Free user is at
-// 20/20 today, blocks the action and shows the quota-exceeded modal.
+// 15/15 today, blocks the action and shows the quota-exceeded modal.
 // Pro users + admins always pass through (is_pro() in Postgres returns true
 // for both, so _quotaState.daily_limit comes back as -1 and tier='pro' —
 // chip + paywall both fall through to "unlimited" automatically).
@@ -863,6 +863,7 @@ const STORAGE = {
   WRONG_BANK: 'nplus_wrong_bank',
   SR_QUEUE: 'nplus_sr_queue',
   SR_PREFS: 'nplus_sr_prefs',     // #8: review session prefs (sessionSize, topUp)
+  SR_FREE_COUNT: 'nplus_sr_free_count', // GAP-1: free-tier reviews used today ({date, count})
   REPORTS: 'nplus_reports',
   BUG_REPORTS: 'nplus_bug_reports', // v5.6.x bug-report drawer retry queue
   TB_V3_DRAFT: 'nplus_tb_v3_draft', // v6.x topology-builder v3 canvas state (Net+ only)
@@ -2455,7 +2456,7 @@ function getTodayQuestionCount() {
 }
 
 // ── Daily goal ──
-// Kept BELOW the 20/day free quota cap so completing the goal leaves headroom
+// Kept BELOW the 15/day free quota cap so completing the goal leaves headroom
 // for "one more" instead of landing the user on the paywall at the same moment.
 const DEFAULT_DAILY_GOAL = 15;
 function getDailyGoal() {
@@ -3455,6 +3456,37 @@ const SR_GRADUATION_INTERVAL = 30;    // days interval needed at graduation
 const SR_EXAM_BUFFER_PCT = 0.15;      // #7: leave 15% of days-to-exam as a final-pass buffer
 const SR_LAPSE_FACTOR = 0.30;         // #3: a wrong answer drops the interval to ~30% of prior (floor 1d), not a hard reset to 1
 const SR_LIGHT_DAY_THRESHOLD = 8;     // #8: fewer than this many due cards = a "light day" that offers top-up practice
+const SR_FREE_DAILY_CAP = 5;          // GAP-1 (2026-06-11): free tier reviews 5 cards/day
+                                      // (cert-ios-daily-limit mockup: "15 practice + 5 review").
+                                      // Gentle queue, not a wall — extra due cards simply wait
+                                      // for tomorrow. Pro/admin and anonymous users are uncapped
+                                      // (anonymous = BYOK self-pay; cap applies to free accounts).
+
+// ── GAP-1: free-tier review-cap helpers ─────────────────────────────────
+// The 5/day cap is enforced client-side on purpose: review cards are saved
+// questions with zero AI spend, so this is product gating, not cost
+// protection (the 15/day question quota is the server-enforced half).
+// Counter is a per-day localStorage cell; resets implicitly when the
+// stored date rolls over.
+function _srIsFreeTier() {
+  return !!(_quotaState && _quotaState.tier === 'free');
+}
+function _srFreeReviewedToday() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORAGE.SR_FREE_COUNT) || 'null');
+    if (raw && raw.date === new Date().toISOString().slice(0, 10)) return raw.count || 0;
+  } catch (_) {}
+  return 0;
+}
+function _srBumpFreeReviewed() {
+  if (!_srIsFreeTier()) return;
+  try {
+    localStorage.setItem(STORAGE.SR_FREE_COUNT, JSON.stringify({
+      date: new Date().toISOString().slice(0, 10),
+      count: _srFreeReviewedToday() + 1
+    }));
+  } catch (_) {}
+}
 
 // #8: review session preferences (session size + top-up). Cloud-flushed like
 // the queue. sessionSize is 10 | 20 | 30 | 'all' (capped at SR_SESSION_CAP).
@@ -3887,9 +3919,20 @@ function startSrReview() {
   const totalDueCount = due.length;
   // #8: cap to the user's chosen session size (default 30; hard ceiling SR_SESSION_CAP).
   const _srPrefs = loadSrPrefs();
-  const _srCap = (_srPrefs.sessionSize === 'all')
+  let _srCap = (_srPrefs.sessionSize === 'all')
     ? due.length
     : Math.min(_srPrefs.sessionSize || SR_SESSION_CAP, SR_SESSION_CAP);
+  // GAP-1: free tier reviews 5 cards/day — gentle queue, extras wait for
+  // tomorrow. If today's 5 are already done, say so instead of starting.
+  // typeof guard: UAT vm fixtures eval this body without the helpers.
+  if (typeof _srIsFreeTier === 'function' && _srIsFreeTier()) {
+    const _freeLeft = Math.max(0, SR_FREE_DAILY_CAP - _srFreeReviewedToday());
+    if (_freeLeft === 0) {
+      showToast("Today's " + SR_FREE_DAILY_CAP + ' free reviews are done. ' + due.length + ' card' + (due.length === 1 ? ' is' : 's are') + ' saved for tomorrow — Pro clears the whole queue daily.', 'info');
+      return;
+    }
+    _srCap = Math.min(_srCap, _freeLeft);
+  }
   if (due.length > _srCap) {
     due = due.slice(0, _srCap);
   }
@@ -4228,6 +4271,11 @@ function srMarkConfidence(outcome) {
     // practice never reschedules real cards early (spacing stays pure).
     if (!_srSession.practice) updateSrEntry(card.qHash, outcome);
 
+    // GAP-1: real (non-practice) reviews count against the free 5/day cap.
+    // Retries don't reach this branch, so a card costs exactly one credit.
+    // typeof guard: UAT vm fixtures eval this body without the helpers.
+    if (!_srSession.practice && typeof _srBumpFreeReviewed === 'function') _srBumpFreeReviewed();
+
     // Tally
     _srSession.answersGiven++;
     if (outcome === 'correct-confident') _srSession.correctConfident++;
@@ -4353,11 +4401,21 @@ function _srEndReview() {
     // v4.85.1: show remaining cards count + "Continue" button when session was capped
     const remaining = (typeof getSrStats === 'function') ? getSrStats().due : 0;
     if (remaining > 0) {
-      const remMin = Math.max(2, Math.round(Math.min(remaining, SR_SESSION_CAP) * 0.5));
-      html += '<div class="sr-remaining-row">'
-        + '<span class="sr-remaining-text">' + remaining + ' more card' + (remaining === 1 ? '' : 's') + ' still due</span>'
-        + '<button class="btn btn-primary sr-continue-btn" onclick="startSrReview()">Continue · ~' + remMin + ' min →</button>'
-        + '</div>';
+      if (typeof _srIsFreeTier === 'function' && _srIsFreeTier()
+          && (SR_FREE_DAILY_CAP - _srFreeReviewedToday()) <= 0) {
+        // GAP-1: today's 5 free reviews are spent — gentle queue note instead
+        // of a Continue button that would bounce off the cap.
+        html += '<div class="sr-remaining-row">'
+          + '<span class="sr-remaining-text">' + remaining + ' more card' + (remaining === 1 ? '' : 's') + ' waiting — ready tomorrow. Pro clears the whole queue daily.</span>'
+          + '<a class="btn btn-primary sr-continue-btn" href="https://certanvil.com/pricing" target="_blank" rel="noopener">Go Pro →</a>'
+          + '</div>';
+      } else {
+        const remMin = Math.max(2, Math.round(Math.min(remaining, SR_SESSION_CAP) * 0.5));
+        html += '<div class="sr-remaining-row">'
+          + '<span class="sr-remaining-text">' + remaining + ' more card' + (remaining === 1 ? '' : 's') + ' still due</span>'
+          + '<button class="btn btn-primary sr-continue-btn" onclick="startSrReview()">Continue · ~' + remMin + ' min →</button>'
+          + '</div>';
+      }
     }
     // #8 top-up — on a light day, offer extra practice on weak topics (helper
     // returns the block or ''). Never shown after a practice session itself.
@@ -6225,9 +6283,9 @@ function validateApiKey(key) {
   // (line 270) handles the actual routing based on session presence.
   if (typeof window !== 'undefined' && window._certanvilSignedIn === true) return null;
   // BYOK retired (v4.99.3): a signed-out user with no key can't reach the proxy.
-  // Prompt sign-in (free, 20/day) up front instead of the stale "enter API key"
+  // Prompt sign-in (free, 15/day) up front instead of the stale "enter API key"
   // wall or a thrown needsAuth error mid-quiz.
-  if (!key) return 'Sign in to study free: 20 questions a day, no API key needed. Tap "Sign in" at the top right.';
+  if (!key) return 'Sign in to study free: 15 questions a day, no API key needed. Tap "Sign in" at the top right.';
   if (!key.startsWith('sk-ant-')) return 'Invalid API key format. Anthropic keys start with "sk-ant-".';
   if (key.length < 20) return 'API key looks too short. Please check and try again.';
   return null;
@@ -6253,7 +6311,7 @@ function _showSignInPrompt(anchorEl, message) {
   box.innerHTML = '<span class="signin-inline-msg"></span>' +
     '<button type="button" class="btn btn-primary signin-inline-cta">Sign in to start free</button>';
   box.querySelector('.signin-inline-msg').textContent = message ||
-    'Sign in to study free: 20 questions a day, no API key needed.';
+    'Sign in to study free: 15 questions a day, no API key needed.';
   box.querySelector('.signin-inline-cta').addEventListener('click', function() {
     // Prefer clicking the topbar pill so auth-state.js owns the URL-build logic.
     var pill = document.querySelector('.topbar-signin-pill');

--- a/docs/planning/TIER-LOGIC-SWEEP-2026-06-11.md
+++ b/docs/planning/TIER-LOGIC-SWEEP-2026-06-11.md
@@ -1,0 +1,52 @@
+# Free/Pro tier-logic sweep — 2026-06-11
+
+Definitive done/not-done audit of every free-vs-pro rule discussed during the
+cert-ios screen build. Sources: Forge decision log, the mockups' own design
+notes (`stage-sub` annotations + `free-only`/`pro-only` markup in
+`.claude/worktrees/cert-ios-e2e/mockups/`), and verification against live code
+(app.js `_quotaState`/`_claudeFetch`, `api/ai/generate.js`,
+`supabase/migrations/20260509_phase_e_*.sql`, `landing/lib/*`).
+
+## ✅ Implemented and live
+
+| # | Rule | Where it lives |
+|---|------|----------------|
+| A1 | Free users: daily AI question quota, enforced server-side (currently **20/day** — see GAP-1), quota chip shows remaining | `consume_daily_quota()` RPC + `api/ai/generate.js` `_metered` + app.js quota chip (Phase E.3) |
+| A2 | Quota-exceeded wall with upgrade CTA + free escape hatch (Daily Review) | `#quota-exceeded-modal`, lifted to cert-ios language in v7.36 |
+| A3 | Pro/admin = unlimited questions (`daily_limit = -1`) | `is_pro()` OR role=admin (Phase E.4 migration) |
+| A4 | Free tier = ONE cert; others locked until Pro | v7.33.0 free-cert lock (web + native) |
+| A5 | Drills are a Pro perk | app.js (~line 748) — Pro gate on drills |
+| A6 | Pro-only menu items show 🔒 to free users | `body.is-pro-tier` class system (v4.99.8) |
+| A7 | Locked cert rows on /account open an upsell sheet → Go Pro card (mobile) | v7.38.0 account-pages lift phase 2 |
+| A8 | Go Pro pricing surfaces ($89/yr / $9.99/mo) with honest "coming soon" CTAs | v7.38 (account card + sheet) + v7.39 (manage-subscription page) |
+| A9 | Free cert picker: pick locks in, switching needs Pro | v7.30–7.33, behind `onboarding_enabled` gate (OFF until launch) |
+| A10 | Exam-result logging ("Mark result") + Passed badges | /account er-list (v4.93.0) — but see GAP-4 for the Pro-gating nuance |
+| A11 | Account deletion (7-day grace) | /account danger zone — see GAP-6 for the Apple in-app requirement check |
+
+## ❌ Decided in the iOS build but NOT implemented (the work list)
+
+| # | Rule (as decided) | Current reality | Effort / lane |
+|---|---|---|---|
+| GAP-1 | **Free daily allowance = 15 practice questions + 5 review cards.** Decision: "fixed caps of 5 cards/day and 15 questions/day". Mockup: cert-ios-daily-limit ("15 practice + 5 review. Pro removes the cap.") | Live cap is **20 questions/day**, and Daily Review has **no free cap at all** | Gated lane: migration changes `consume_daily_quota` 20→15 + proxy `FREE_DAILY_LIMIT` + app copy; new client+server logic for the 5-cards/day review cap |
+| GAP-2 | **Soft blocker when a free user picks a session bigger than the remaining allowance** ("You picked a 25-question set… Start a 15-question set instead") | Wall appears only after quota is exhausted mid-flow; no pre-emptive size check | Client-side, fast lane; depends on GAP-1 numbers |
+| GAP-3 | **Settings: Daily Goal + Daily Review size controls locked for free users** (pro-lock pills, lock-note, Go Pro button; Pro gets live controls). Mockup: cert-ios-settings `.plan-free`/`.plan-pro` system | Controls are live for everyone | Client-side UI gating off `_quotaState.tier`, fast lane |
+| GAP-4 | **Cross-cert analytics is a Pro feature** (hub mockup: "Pro" pill; cross-cert mockup: "One Pro dashboard") | /analytics only requires sign-in; free users see everything | landing/lib JS gate + upsell state, fast lane |
+| GAP-5 | **Log-your-exam-result is a Pro feature** (mockup: "a Pro user records the score") + the lifted log-result screen styling | Feature exists on /account for ALL unlocked certs, not Pro-gated; mockup styling not lifted | Decide: keep free (generous) or gate to Pro per decision; styling lift optional |
+| GAP-6 | **Apple requires in-app account deletion** (onboarding-account-deletion mockup: Settings row + confirm sheet inside the app) | Deletion exists on certanvil.com/account, but the cert app's Settings has no deletion row — verify the wrap path satisfies Apple | Check + likely small Settings addition before submission |
+
+## ⏸ Correctly parked (cannot be built yet — needs billing)
+
+| # | Rule | Blocked on |
+|---|---|---|
+| P1 | Pro-expired / lapsed-subscription notice (drop to Free, data kept, one-tap renew) | Stripe (web) / StoreKit IAP (iOS) — Phase G |
+| P2 | Actual purchase flow behind every "Go Pro" CTA | Phase G / StoreKit |
+| P3 | Plan switch (Annual ⇄ Monthly) on /manage-subscription | Phase G (UI shipped inert in v7.39) |
+
+## Proposed implementation order
+
+1. **GAP-1** — the 15/5 caps (foundation numbers; everything else displays them)
+2. **GAP-2** — the pre-emptive soft blocker (uses GAP-1's numbers)
+3. **GAP-3** — Settings tier locks
+4. **GAP-4** — cross-cert Pro gate
+5. **GAP-5** — log-result decision + optional styling lift
+6. **GAP-6** — in-app deletion check (fold into the pre-submission checklist)

--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.39.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.40.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.39.0",
+  "version": "7.40.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.39.0
+   Network+ AI Quiz — styles.css  v7.40.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/supabase/migrations/20260611_free_tier_15_questions.sql
+++ b/supabase/migrations/20260611_free_tier_15_questions.sql
@@ -1,0 +1,96 @@
+-- ══════════════════════════════════════════════════════════════════════════
+-- 2026-06-11 — Free-tier daily question quota: 20 → 15
+-- ══════════════════════════════════════════════════════════════════════════
+-- GAP-1 of the tier-logic sweep (docs/planning/TIER-LOGIC-SWEEP-2026-06-11.md).
+-- The cert-ios build locked the free daily allowance at 15 practice questions
+-- + 5 review cards (mockup cert-ios-daily-limit.html: "15 practice + 5 review.
+-- Pro removes the cap."). The question half lives here; the 5-review-cards cap
+-- is client-side in app.js (reviews are saved cards — no AI spend to protect).
+--
+-- Re-creates both Phase E quota functions from 20260509_phase_e_subscriptions
+-- with daily_limit 15. Function bodies are otherwise byte-identical to the
+-- originals. api/ai/generate.js FREE_DAILY_LIMIT mirrors this value and ships
+-- in the same PR.
+--
+-- Pro/admin behaviour unchanged: is_pro() users remain unlimited (-1).
+-- Users who already consumed 15–20 today simply hit the wall on their next
+-- metered call — no data backfill needed (ai_usage rows are plain counters).
+-- ══════════════════════════════════════════════════════════════════════════
+
+create or replace function consume_daily_quota(uid uuid, q_count int default 1)
+returns boolean
+language plpgsql
+security definer
+as $$
+declare
+  is_pro_user boolean;
+  today_count int;
+  daily_limit constant int := 15;
+begin
+  is_pro_user := is_pro(uid);
+
+  if is_pro_user then
+    -- Pro: unlimited (E.6 may add fair-use throttling). Still log for analytics.
+    insert into ai_usage (user_id, call_date, call_count)
+    values (uid, current_date, q_count)
+    on conflict (user_id, call_date)
+    do update set call_count = ai_usage.call_count + q_count;
+    return true;
+  end if;
+
+  -- Free tier: check today's count first
+  select coalesce(call_count, 0)
+    into today_count
+    from ai_usage
+    where user_id = uid and call_date = current_date;
+
+  if (today_count + q_count) > daily_limit then
+    return false;  -- quota exceeded — proxy returns 429 with upgrade CTA
+  end if;
+
+  -- Within quota — increment and allow
+  insert into ai_usage (user_id, call_date, call_count)
+  values (uid, current_date, q_count)
+  on conflict (user_id, call_date)
+  do update set call_count = ai_usage.call_count + q_count;
+  return true;
+end;
+$$;
+
+comment on function consume_daily_quota is
+  'Atomic check + increment of the user''s daily AI quota (free limit 15/day as of 2026-06-11). Returns true if the call should proceed, false if Free quota exceeded. Pro users always pass.';
+
+create or replace function get_daily_quota_usage(uid uuid)
+returns table(used_today int, daily_limit int, tier text)
+language plpgsql
+security definer
+stable
+as $$
+declare
+  is_pro_user boolean;
+  today_count int;
+begin
+  is_pro_user := is_pro(uid);
+
+  select coalesce(call_count, 0)
+    into today_count
+    from ai_usage
+    where user_id = uid and call_date = current_date;
+
+  return query select
+    coalesce(today_count, 0) as used_today,
+    case when is_pro_user then -1 else 15 end as daily_limit,  -- -1 = unlimited
+    case when is_pro_user then 'pro'::text else 'free'::text end as tier;
+end;
+$$;
+
+comment on function get_daily_quota_usage is
+  'Read-only quota state for the Phase E.5 daily-counter UI. Returns (used_today, daily_limit, tier). daily_limit = -1 means unlimited (Pro); free limit 15/day as of 2026-06-11.';
+
+-- ROLLBACK:
+-- Re-run sections 7 + 8 of 20260509_phase_e_subscriptions.sql verbatim, i.e.
+-- the same two CREATE OR REPLACE statements above with the two literals set
+-- back to 20 ("daily_limit constant int := 20" in consume_daily_quota and
+-- "else 20 end as daily_limit" in get_daily_quota_usage) and the original
+-- function comments. No table or data changes to undo — ai_usage rows are
+-- plain counters and remain valid under either limit.

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.39.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.39.0';
+// Service Worker v7.40.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.40.0';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
GAP-1 of the tier-logic sweep. Aligns the live free tier with the locked cert-ios decision: **15 practice questions + 5 review cards per day** (was 20 questions / unlimited reviews).

**Gated lane:** migration (`20260611_free_tier_15_questions.sql`, with ROLLBACK block) + `api/ai/generate.js` constant + app.js copy & new client-side 5-cards/day review cap (gentle queue: extras wait for tomorrow, soft Pro note, no hard wall). Pro/admin/anonymous uncapped — verified live (free: 7 due → 5 served, counter, end-note, re-entry block; pro/anon: 7 served). UAT 4109/4109.

**ACTION REQUIRED after merge:** apply the migration in the Supabase SQL Editor — until then prod serves 20/day (stale but safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)