### PR TITLE
v7.41.0 — Free tier pre-emptive daily-limit screen (GAP-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.41.0 | Free tier pre-emptive daily-limit screen — oversized sessions blocked before start with right-size option (GAP-2) |
 | v7.40.0 | Free tier 15 questions + 5 review cards per day (GAP-1 of tier-logic sweep) |
 | v7.39.0 | Manage-subscription static UI lift — plan card, Pro pricing, Stripe-ready seams |
 | v7.38.0 | Account-pages lift phase 2 — Go Pro card + upsell sheet + auth modal lift (mobile, <900px) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.40.0
+// Network+ AI Quiz — app.js  v7.41.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.40.0';
+const APP_VERSION = '7.41.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -740,6 +740,128 @@ function _gateActivityForQuota(activityLabel) {
     });
   }
   return false;
+}
+
+// ── GAP-2 (tier-logic sweep) — pre-emptive session-size gate ────────────
+// _gateActivityForQuota fires AT the cap (15/15). This one fires BEFORE a
+// session starts when the picked set is bigger than what's left of the free
+// day (e.g. picked 20, only 15 left) — so the user sees the daily-limit
+// screen up front instead of a mid-quiz wall when the proxy 429s at Q16.
+// Design lifted from mockups/cert-ios-daily-limit.html.
+
+// Questions a Free user can still generate today. Infinity = no cap applies
+// (Pro/admin, unknown state, or signed-out — the proxy is the backstop).
+function _quotaRemainingToday() {
+  if (!_quotaState) return Infinity;
+  if (_quotaState.tier === 'pro') return Infinity;
+  if (typeof _quotaState.daily_limit !== 'number') return Infinity;
+  if (_quotaState.daily_limit < 0) return Infinity;
+  return Math.max(0, _quotaState.daily_limit - (_quotaState.used_today || 0));
+}
+
+// Returns true if the session may start at the requested size.
+// opts.mode: 'quiz' (keep the user's topic/diff on downsize) or
+// 'exam' / 'bulk' (downsize restarts as a Mixed Exam-Level practice set).
+// Callers pattern: `if (!_gateSessionSizeForQuota(qCount, { mode: 'quiz' })) return;`
+function _gateSessionSizeForQuota(requestedCount, opts) {
+  var remaining = _quotaRemainingToday();
+  if (!isFinite(remaining)) return true;            // uncapped
+  if (remaining <= 0) return true;                  // fully spent — _gateActivityForQuota owns this
+  if (!requestedCount || requestedCount <= remaining) return true;
+  if (typeof _showDailyLimitPreblockUI === 'function') {
+    _showDailyLimitPreblockUI({
+      picked: requestedCount,
+      remaining: remaining,
+      limit: _quotaState.daily_limit,
+      mode: (opts && opts.mode) || 'quiz'
+    });
+  }
+  return false;
+}
+
+// The pre-block screen itself — lock mark, allowance rows, Go Pro CTA, and
+// a one-tap "start a right-sized set instead" escape hatch.
+function _showDailyLimitPreblockUI(detail) {
+  detail = detail || {};
+  var picked = detail.picked || 0;
+  var remaining = detail.remaining || 0;
+  var limit = detail.limit || 15;
+  var mode = detail.mode || 'quiz';
+  var srCap = (typeof SR_FREE_DAILY_CAP === 'number') ? SR_FREE_DAILY_CAP : 5;
+
+  var lede;
+  if (mode === 'exam') {
+    lede = 'The exam simulator runs <b>' + picked + ' questions</b>. On Free you study <b>' +
+      limit + ' practice questions</b> a day, so the full sim needs Pro.';
+  } else if (remaining >= limit) {
+    lede = 'You picked a <b>' + picked + '-question</b> set. On Free you study <b>' +
+      limit + ' practice questions</b> a day, so this one needs Pro.';
+  } else {
+    lede = 'You picked a <b>' + picked + '-question</b> set, but you&rsquo;ve only got <b>' +
+      remaining + '</b> of today&rsquo;s <b>' + limit + '</b> free questions left.';
+  }
+
+  var prev = document.getElementById('daily-limit-preblock');
+  if (prev) prev.remove();
+
+  var modal = document.createElement('div');
+  modal.id = 'daily-limit-preblock';
+  modal.className = 'quota-exceeded-modal';  // reuse the overlay scrim
+  modal.innerHTML =
+    '<div class="dlpb-card" role="dialog" aria-modal="true" aria-label="Free daily limit">' +
+      '<div class="dlpb-lockmark" aria-hidden="true">' +
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">' +
+          '<rect x="4" y="11" width="16" height="9" rx="2.5"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path>' +
+        '</svg>' +
+      '</div>' +
+      '<h2 class="dlpb-title">That&rsquo;s more than your <i>free</i> day</h2>' +
+      '<p class="dlpb-lede">' + lede + '</p>' +
+      '<div class="dlpb-allow">' +
+        '<div class="dlpb-row">' +
+          '<span class="dlpb-row-tx"><b>Practice</b><span>Quizzes and custom sets</span></span>' +
+          '<span class="dlpb-row-amt">' + limit + ' / day</span>' +
+        '</div>' +
+        '<div class="dlpb-row">' +
+          '<span class="dlpb-row-tx"><b>Daily Review</b><span>Spaced repetition</span></span>' +
+          '<span class="dlpb-row-amt">' + srCap + ' / day</span>' +
+        '</div>' +
+      '</div>' +
+      '<p class="dlpb-pro-line"><b>Pro</b> is unlimited questions, every day, on every cert.</p>' +
+      '<div class="dlpb-actions">' +
+        '<a class="dlpb-cta" href="https://certanvil.com/pricing" target="_blank" rel="noopener">Go Pro &mdash; unlimited</a>' +
+        '<button type="button" class="dlpb-ghost" id="dlpb-start-smaller">Start a ' + remaining + '-question set instead</button>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(modal);
+
+  var smallerBtn = document.getElementById('dlpb-start-smaller');
+  if (smallerBtn) {
+    smallerBtn.addEventListener('click', function () {
+      modal.remove();
+      qCount = remaining;
+      if (mode !== 'quiz') {
+        // Exam / bulk downsizes restart as a Mixed Exam-Level practice set —
+        // there's no smaller exam sim, so the closest useful session wins.
+        topic = MIXED_TOPIC;
+        diff = 'Exam Level';
+        examMode = false;
+      }
+      // Reflect the new size on the setup-page chips so the UI stays honest.
+      document.querySelectorAll('#topic-group .chip').forEach(function (c) { c.classList.toggle('on', c.dataset.v === topic); });
+      document.querySelectorAll('#diff-group .chip').forEach(function (c) { c.classList.toggle('on', c.dataset.v === diff); });
+      document.querySelectorAll('#count-group .chip').forEach(function (c) { c.classList.toggle('on', c.dataset.v === String(qCount)); });
+      if (typeof syncChipAriaPressed === 'function') {
+        syncChipAriaPressed('#topic-group');
+        syncChipAriaPressed('#diff-group');
+        syncChipAriaPressed('#count-group');
+      }
+      if (typeof startQuiz === 'function') startQuiz();
+    });
+  }
+  // Click the scrim → dismiss (stay on setup, nothing consumed)
+  modal.addEventListener('click', function (e) {
+    if (e.target === modal) modal.remove();
+  });
 }
 
 // v4.99.4 Phase E.4.1 — Pro-only feature gate (drills, flagship labs).
@@ -6334,6 +6456,7 @@ function _showSignInPrompt(anchorEl, message) {
 // ══════════════════════════════════════════
 async function startQuiz() {
   if (!_gateActivityForQuota('practice quizzes')) return;
+  if (!_gateSessionSizeForQuota(qCount, { mode: 'quiz' })) return;
   const key = document.getElementById('api-key').value.trim();
   const errBox = document.getElementById('setup-err');
   errBox.classList.add('is-hidden');
@@ -6733,6 +6856,7 @@ function _formatElapsed(ms) {
 // ══════════════════════════════════════════
 async function startExam() {
   if (!_gateActivityForQuota('exam simulator')) return;
+  if (!_gateSessionSizeForQuota(90, { mode: 'exam' })) return;
   const key = document.getElementById('api-key').value.trim();
   const errBox = document.getElementById('setup-err');
   errBox.classList.add('is-hidden');
@@ -11005,6 +11129,10 @@ async function startBulkQuiz(count) {
   topic = MIXED_TOPIC;
   diff = 'Exam Level';
   qCount = count;
+
+  // GAP-2: bulk presets previously had no quota gate (free user would 429 mid-run)
+  if (!_gateActivityForQuota('practice quizzes')) return;
+  if (!_gateSessionSizeForQuota(count, { mode: 'bulk' })) return;
 
   showPage('loading');
   document.getElementById('loading-msg').textContent = `Generating ${count} mixed Exam Level questions\u2026`;

--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.40.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.41.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.40.0",
+  "version": "7.41.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.40.0
+   Network+ AI Quiz — styles.css  v7.41.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -13871,8 +13871,122 @@ html { zoom: 1.10; }
   border-color: rgba(255,255,255,0.32);
 }
 
+/* ── GAP-2 — pre-emptive daily-limit screen (mockup cert-ios-daily-limit) ──
+   Shares the .quota-exceeded-modal scrim; the card is its own block. */
+.dlpb-card {
+  box-sizing: border-box;
+  background: var(--bg, #0b0b14);
+  border: 1px solid var(--border, rgba(255,255,255,0.12));
+  border-radius: 16px;
+  padding: 30px 26px 24px;
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+  animation: dlpbCardIn 0.2s cubic-bezier(0.23, 1, 0.32, 1) forwards;
+}
+@keyframes dlpbCardIn {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}
+.dlpb-lockmark {
+  width: 54px; height: 54px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--accent, #b08d57) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent, #b08d57) 38%, transparent);
+  color: var(--accent, #b08d57);
+  display: grid; place-items: center;
+}
+.dlpb-lockmark svg { width: 26px; height: 26px; }
+.dlpb-title {
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--text, #f0f0f8);
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
+}
+.dlpb-title i {
+  font-style: italic;
+  color: var(--accent, #b08d57);
+}
+.dlpb-lede {
+  font-size: 13.5px;
+  color: var(--text-mid, #b0b0cc);
+  line-height: 1.55;
+  margin: 0 0 18px;
+}
+.dlpb-lede b { color: var(--text, #f0f0f8); font-variant-numeric: tabular-nums; }
+.dlpb-allow {
+  border: 1px solid var(--border, rgba(255,255,255,0.12));
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 14px;
+  text-align: left;
+}
+.dlpb-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 14px;
+}
+.dlpb-row + .dlpb-row { border-top: 1px solid var(--border, rgba(255,255,255,0.12)); }
+.dlpb-row-tx { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.dlpb-row-tx b { font-size: 13px; font-weight: 650; color: var(--text, #f0f0f8); }
+.dlpb-row-tx span { font-size: 11.5px; color: var(--text-mid, #b0b0cc); }
+.dlpb-row-amt {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--text, #f0f0f8);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.dlpb-pro-line {
+  font-size: 12.5px;
+  color: var(--text-mid, #b0b0cc);
+  margin: 0 0 18px;
+}
+.dlpb-pro-line b { color: var(--text, #f0f0f8); }
+.dlpb-actions { display: flex; flex-direction: column; gap: 9px; }
+.dlpb-cta {
+  display: block;
+  background: var(--accent, #b08d57);
+  color: var(--on-accent, #14110b) !important;
+  padding: 13px 22px;
+  font-size: 13.5px;
+  font-weight: 700;
+  border-radius: 10px;
+  text-decoration: none;
+  border: 0;
+  cursor: pointer;
+  transition: transform 0.16s cubic-bezier(0.23, 1, 0.32, 1);
+}
+@media (hover: hover) and (pointer: fine) {
+  .dlpb-cta:hover { transform: translateY(-1px); }
+}
+.dlpb-cta:active { transform: scale(0.97); }
+.dlpb-ghost {
+  background: transparent;
+  color: var(--text, #f0f0f8);
+  border: 1px solid var(--border, rgba(255,255,255,0.16));
+  padding: 12px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: transform 0.16s cubic-bezier(0.23, 1, 0.32, 1), border-color 0.16s ease;
+}
+@media (hover: hover) and (pointer: fine) {
+  .dlpb-ghost:hover { border-color: color-mix(in oklab, var(--text, #fff) 32%, transparent); }
+}
+.dlpb-ghost:active { transform: scale(0.97); }
+
 @media (prefers-reduced-motion: reduce) {
   .quota-exceeded-modal { animation: none; }
+  .dlpb-card { animation: none; }
+  .dlpb-cta, .dlpb-ghost { transition: none !important; }
   .topbar-quota-chip,
   .topbar-quota-chip .quota-chip-fill,
   .quota-exceeded-cta { transition: none !important; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.40.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.40.0';
+// Service Worker v7.41.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.41.0';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- Free users picking a session bigger than their remaining daily allowance (e.g. 20-Q Deep Scan with 10 left) now get the cert-ios daily-limit screen BEFORE generation starts, instead of a mid-quiz 429 wall.
- One-tap escape hatch: "Start a N-question set instead" right-sizes the session and starts it immediately. Go Pro CTA to pricing.
- Wired into startQuiz, startExam (90-Q copy variant), and startBulkQuiz (which previously had no quota gate at all).
- At-cap users keep the existing quota-exceeded modal; Pro/admin/anonymous unaffected. Client-side only (numbers from _quotaState).
- Design lifted 1:1 from mockups/cert-ios-daily-limit.html; dark + light verified; reduced-motion respected.

## Testing
- UAT 4109/4109 PASS (pre-commit hook re-ran it).
- Live-verified on localhost:4182: gate fires pre-loading for quiz/exam/bulk, right-size flow sets qCount and starts, scrim dismiss, both themes, fresh-day + partial-day copy variants.
- tech-debt: no new breach (pre-existing line-count/dead-fn breaches unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)