### PR TITLE
v7.42.0 — Settings tier locks: Daily Goal + Daily Review pro-locked for free (GAP-3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.42.0 | Settings tier locks — Daily Goal + Daily Review controls pro-locked for free users (GAP-3) |
 | v7.41.0 | Free tier pre-emptive daily-limit screen — oversized sessions blocked before start with right-size option (GAP-2) |
 | v7.40.0 | Free tier 15 questions + 5 review cards per day (GAP-1 of tier-logic sweep) |
 | v7.39.0 | Manage-subscription static UI lift — plan card, Pro pricing, Stripe-ready seams |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.41.0
+// Network+ AI Quiz — app.js  v7.42.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.41.0';
+const APP_VERSION = '7.42.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -18713,6 +18713,9 @@ function pickSettingsDailyPreset(n) {
   });
 }
 function saveSettingsDailyGoal() {
+  // GAP-3: free tier has a fixed 15/day allowance — controls are CSS-hidden,
+  // this guard is the enforcement behind the curtain.
+  if (typeof _srIsFreeTier === 'function' && _srIsFreeTier()) return;
   const input = document.getElementById('settings-daily-input');
   if (!input) return;
   const v = parseInt(input.value, 10);
@@ -18731,6 +18734,8 @@ function saveSettingsDailyGoal() {
 
 // #8: Daily Review (spaced repetition) settings — session size + top-up.
 function pickSrSessionSize(n) {
+  // GAP-3: free tier reviews a fixed 5 cards/day (SR_FREE_DAILY_CAP)
+  if (typeof _srIsFreeTier === 'function' && _srIsFreeTier()) return;
   const prefs = loadSrPrefs();
   prefs.sessionSize = n;
   saveSrPrefs(prefs);
@@ -18740,6 +18745,8 @@ function pickSrSessionSize(n) {
   }
 }
 function toggleSrTopUp() {
+  // GAP-3: light-day top-ups are Pro-only
+  if (typeof _srIsFreeTier === 'function' && _srIsFreeTier()) return;
   const prefs = loadSrPrefs();
   prefs.topUp = !prefs.topUp;
   saveSrPrefs(prefs);

--- a/dg-system.css
+++ b/dg-system.css
@@ -1841,6 +1841,11 @@ html[data-theme] body #page-settings .ana-ready-datechip,html[data-theme] body #
 html[data-theme] body #page-settings .ana-ready-datechip:hover,html[data-theme] body #page-settings .ana-exam-date-btn:hover{border-color:var(--accent)!important;color:var(--accent)!important;}
 #page-settings .ana-ready-datechip-days,#page-settings .ana-ready-datechip-date{color:var(--text-mid)!important;}
 html[data-theme] body #page-settings .settings-daily-row{display:flex!important;align-items:center!important;gap:12px!important;flex-wrap:wrap!important;margin:14px 0 0!important;}
+/* v7.42.0 GAP-3: tier locks must beat the display:flex!important rules above —
+   resolved free users lose the live controls regardless of dg reskin. */
+html[data-theme] body.is-state-resolved:not(.is-pro-tier) #page-settings .tier-pro-only{display:none!important;}
+html[data-theme] body:not(.is-state-resolved) #page-settings .tier-free-only,
+html[data-theme] body.is-pro-tier #page-settings .tier-free-only{display:none!important;}
 html[data-theme] body #page-settings .settings-daily-input{background:color-mix(in oklab,var(--accent) 5%,var(--surface))!important;border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border))!important;border-radius:11px!important;color:var(--text)!important;font:600 32px/1 'Fraunces',Georgia,serif!important;padding:10px 14px!important;width:auto!important;min-width:86px!important;max-width:132px!important;text-align:center!important;font-variant-numeric:tabular-nums!important;box-shadow:none!important;}
 html[data-theme] body #page-settings .settings-daily-input:focus{border-color:var(--accent)!important;outline:none!important;}
 html[data-theme] body #page-settings .settings-daily-unit{font-size:var(--t-1)!important;color:var(--text-dim)!important;}

--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.41.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.42.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>
@@ -1447,36 +1447,53 @@
         </div>
         <p class="settings-section-hint">Powers the <strong>days until exam</strong> countdown on Home + Analytics, and the red marker cell on the 365-day study heatmap. Set it to keep your study pressure honest.</p>
       </section>
-      <!-- v4.54.10: editable daily question goal. -->
+      <!-- v4.54.10: editable daily question goal.
+           v7.42.0 GAP-3: pro-locked for free users (mockup cert-ios-settings
+           .plan-free system) — body.is-state-resolved:not(.is-pro-tier) hides
+           .tier-pro-only and reveals .tier-free-only. Anonymous/unresolved
+           users keep the live controls (GAP-1 left anon uncapped). -->
       <section class="card settings-section">
-        <h3 class="settings-section-title">Daily Goal</h3>
-        <div class="settings-daily-row">
+        <h3 class="settings-section-title">Daily Goal <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></h3>
+        <div class="settings-daily-row tier-pro-only">
           <input type="number" inputmode="numeric" id="settings-daily-input" min="1" max="500" step="1" aria-label="Daily question goal" class="settings-daily-input" />
           <span class="settings-daily-unit">questions per day</span>
           <button class="btn btn-primary settings-daily-save" id="settings-daily-save" onclick="saveSettingsDailyGoal()">Save</button>
         </div>
-        <div class="settings-daily-presets" role="group" aria-label="Daily goal presets">
+        <div class="settings-daily-presets tier-pro-only" role="group" aria-label="Daily goal presets">
           <button type="button" class="settings-daily-chip" data-goal="10" onclick="pickSettingsDailyPreset(10)">10</button>
           <button type="button" class="settings-daily-chip" data-goal="20" onclick="pickSettingsDailyPreset(20)">20</button>
           <button type="button" class="settings-daily-chip" data-goal="30" onclick="pickSettingsDailyPreset(30)">30</button>
           <button type="button" class="settings-daily-chip" data-goal="50" onclick="pickSettingsDailyPreset(50)">50</button>
         </div>
-        <p class="settings-section-hint">The count behind the "Today" card on your home page. Aim for something you can hit every day without burning out.</p>
+        <p class="settings-section-hint tier-pro-only">The count behind the "Today" card on your home page. Aim for something you can hit every day without burning out.</p>
+        <div class="settings-lock-bignum tier-free-only"><span class="slb-n">15</span><span class="slb-l">questions per day</span></div>
+        <div class="lock-note tier-free-only">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 8v4l3 2"></path></svg>
+          <p>Free is fixed at <b>15 questions a day</b> &mdash; that&rsquo;s your daily allowance. Go Pro to set a higher goal.</p>
+        </div>
+        <a class="settings-go-pro-btn tier-free-only" href="https://certanvil.com/pricing" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l2.5 5.5L20 9l-4 4 1 6-5-3-5 3 1-6-4-4 5.5-.5z"></path></svg>Go Pro to raise your goal</a>
       </section>
-      <!-- v7.22.0: Daily Review (spaced repetition) session settings (#8) -->
+      <!-- v7.22.0: Daily Review (spaced repetition) session settings (#8)
+           v7.42.0 GAP-3: pro-locked for free users (5 cards/day fixed). -->
       <section class="card settings-section">
-        <h3 class="settings-section-title">Daily Review <span class="settings-health-eyebrow">spaced repetition</span></h3>
-        <div class="settings-daily-presets sr-size-presets" role="group" aria-label="Review session size">
+        <h3 class="settings-section-title">Daily Review <span class="settings-health-eyebrow">spaced repetition</span> <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></h3>
+        <div class="settings-daily-presets sr-size-presets tier-pro-only" role="group" aria-label="Review session size">
           <button type="button" class="settings-daily-chip sr-size-chip" data-size="10">10</button>
           <button type="button" class="settings-daily-chip sr-size-chip" data-size="20">20</button>
           <button type="button" class="settings-daily-chip sr-size-chip" data-size="30">30</button>
           <button type="button" class="settings-daily-chip sr-size-chip" data-size="all">All due</button>
         </div>
-        <label class="sr-topup-row">
+        <label class="sr-topup-row tier-pro-only">
           <span class="sr-topup-label">Top up on light days<span class="sr-topup-sub">When few cards are due, offer extra practice on your weakest topics.</span></span>
           <button type="button" class="sr-topup-toggle" id="sr-topup-toggle" role="switch" aria-checked="true" aria-label="Top up on light days"></button>
         </label>
-        <p class="settings-section-hint">How many due review cards per session (about 30 seconds each), up to 30. Anything over waits for a second pass. These only affect <strong>Daily Review</strong>, not your standard quizzes or exams.</p>
+        <p class="settings-section-hint tier-pro-only">How many due review cards per session (about 30 seconds each), up to 30. Anything over waits for a second pass. These only affect <strong>Daily Review</strong>, not your standard quizzes or exams.</p>
+        <div class="settings-lock-bignum tier-free-only"><span class="slb-n">5</span><span class="slb-l">cards a day</span></div>
+        <div class="lock-note tier-free-only">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 8v4l3 2"></path></svg>
+          <p>Free review is capped at <b>5 cards a day</b>, with no light-day top-ups. Go Pro for custom sizes, All-due sessions, and top-ups.</p>
+        </div>
+        <a class="settings-go-pro-btn tier-free-only" href="https://certanvil.com/pricing" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l2.5 5.5L20 9l-4 4 1 6-5-3-5 3 1-6-4-4 5.5-.5z"></path></svg>Go Pro for full review control</a>
       </section>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.41.0",
+  "version": "7.42.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.41.0
+   Network+ AI Quiz — styles.css  v7.42.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -13983,10 +13983,109 @@ html { zoom: 1.10; }
 }
 .dlpb-ghost:active { transform: scale(0.97); }
 
+/* ── GAP-3 — Settings tier locks (mockup cert-ios-settings .plan-free) ──
+   Contract: resolved FREE users see locked values + upsell; Pro/admin and
+   anonymous/unresolved users keep the live controls (anon is uncapped). */
+body.is-state-resolved:not(.is-pro-tier) .tier-pro-only { display: none !important; }
+body:not(.is-state-resolved) .tier-free-only,
+body.is-pro-tier .tier-free-only { display: none !important; }
+
+.pro-lock-pill {
+  font-size: 9px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent, #b08d57);
+  background: color-mix(in oklab, var(--accent, #b08d57) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent, #b08d57) 32%, var(--border, rgba(255,255,255,0.12)));
+  border-radius: 999px;
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+.pro-lock-pill svg {
+  width: 10px; height: 10px;
+  stroke: currentColor; fill: none;
+  stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round;
+}
+.settings-lock-bignum {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 4px 0 2px;
+}
+.settings-lock-bignum .slb-n {
+  font-size: 34px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--text, #f0f0f8);
+  font-variant-numeric: tabular-nums;
+}
+.settings-lock-bignum .slb-l {
+  font-size: 13px;
+  color: var(--text-mid, #b0b0cc);
+}
+.lock-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin-top: 13px;
+  padding: 11px 13px;
+  border: 1px solid color-mix(in oklab, var(--accent, #b08d57) 22%, var(--border, rgba(255,255,255,0.12)));
+  border-radius: 13px;
+  background: color-mix(in oklab, var(--accent, #b08d57) 5%, var(--surface, #131320));
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-mid, #b0b0cc);
+}
+.lock-note p { margin: 0; }
+.lock-note b { color: var(--text, #f0f0f8); font-weight: 700; }
+.lock-note svg {
+  flex: 0 0 auto;
+  width: 15px; height: 15px;
+  stroke: var(--accent, #b08d57); fill: none;
+  stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  margin-top: 1px;
+}
+.settings-go-pro-btn {
+  width: 100%;
+  margin-top: 11px;
+  border: none;
+  border-radius: 12px;
+  padding: 13px;
+  cursor: pointer;
+  background: var(--accent, #b08d57);
+  color: var(--on-accent, #14110b) !important;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-decoration: none;
+  box-sizing: border-box;
+  box-shadow: 0 10px 22px -13px color-mix(in oklab, var(--accent, #b08d57) 70%, transparent);
+  transition: transform 0.16s cubic-bezier(0.23, 1, 0.32, 1), filter 0.2s ease;
+}
+.settings-go-pro-btn svg {
+  width: 15px; height: 15px;
+  stroke: currentColor; fill: none;
+  stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round;
+}
+.settings-go-pro-btn:active { transform: scale(0.985); }
+@media (hover: hover) and (pointer: fine) {
+  .settings-go-pro-btn:hover { filter: brightness(1.05); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .quota-exceeded-modal { animation: none; }
   .dlpb-card { animation: none; }
-  .dlpb-cta, .dlpb-ghost { transition: none !important; }
+  .dlpb-cta, .dlpb-ghost, .settings-go-pro-btn { transition: none !important; }
   .topbar-quota-chip,
   .topbar-quota-chip .quota-chip-fill,
   .quota-exceeded-cta { transition: none !important; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.41.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.41.0';
+// Service Worker v7.42.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.42.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -4109,7 +4109,7 @@ test('v4.54.1 HTML: #page-settings exists',
 // Backups. Also bumped importData → clearWrongBank window 2500 → 3500 for
 // headroom (current gap ~2250 with §04 Danger Zone wrapper).
 test('v4.54.1 (v4.54.16 update) HTML: settings has API key + Exam Date + Daily Goal + Export/Import + Clear Wrong Bank',
-  html.includes('id="api-key"') && /id="page-settings"[\s\S]{0,7000}exportData\(\)[\s\S]{0,800}importData\([\s\S]{0,3500}clearWrongBank/.test(html));
+  html.includes('id="api-key"') && /id="page-settings"[\s\S]{0,9500}exportData\(\)[\s\S]{0,800}importData\([\s\S]{0,3500}clearWrongBank/.test(html));  // window 7000→9500: v7.42.0 GAP-3 tier-lock markup grew the settings page
 test('v4.54.1 HTML: #history-panel moved to #page-analytics',
   /id="page-analytics"[\s\S]{0,1500}id="history-panel"/.test(html));
 test('v4.54.1 HTML: regression \u2014 #advanced-section removed from home',
@@ -4648,7 +4648,7 @@ test('v4.54.10 CSS: legacy .dg-weak-chips hidden via !important',
 
 // Settings: editable daily goal
 test('v4.54.10 HTML: Settings page has Daily Goal section with input + presets',
-  /id="page-settings"[\s\S]{0,3000}settings-daily-input[\s\S]{0,800}settings-daily-chip/.test(html));
+  /id="page-settings"[\s\S]{0,3800}settings-daily-input[\s\S]{0,800}settings-daily-chip/.test(html));  // window 3000→3800: v7.42.0 GAP-3 pro-lock pill + comment before the input
 test('v4.54.10 JS: saveSettingsDailyGoal + pickSettingsDailyPreset + syncSettingsDailyGoal defined',
   js.includes('function saveSettingsDailyGoal(') &&
   js.includes('function pickSettingsDailyPreset(') &&


### PR DESCRIPTION
## Summary
- Daily Goal + Daily Review controls in Settings are now pro-locked for resolved free users per the cert-ios-settings mockup: PRO pill, fixed-allowance bignum (15 questions / 5 cards), lock-note, Go Pro CTA.
- Pro/admin and anonymous users keep the live controls (anon is uncapped per GAP-1).
- JS guards behind the CSS so hidden controls can't be driven programmatically.
- dg-system.css gets a higher-specificity tier-lock override (its settings reskin used display:flex!important).
- Two stale UAT char windows widened for the grown settings markup.

## Testing
- UAT 4109/4109 PASS.
- Live-verified anon/free/pro visibility matrices + guard no-ops on localhost:4182, dark theme, mobile viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)