### PR TITLE
v7.43.0 — Cross-cert analytics gated as Pro (GAP-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.43.0 | Cross-cert analytics gated as Pro feature with upsell state for free users (GAP-4) |
 | v7.42.0 | Settings tier locks — Daily Goal + Daily Review controls pro-locked for free users (GAP-3) |
 | v7.41.0 | Free tier pre-emptive daily-limit screen — oversized sessions blocked before start with right-size option (GAP-2) |
 | v7.40.0 | Free tier 15 questions + 5 review cards per day (GAP-1 of tier-logic sweep) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.42.0
+// Network+ AI Quiz — app.js  v7.43.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.42.0';
+const APP_VERSION = '7.43.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.42.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.43.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/landing/analytics.html
+++ b/landing/analytics.html
@@ -413,6 +413,16 @@
       <a href="/" class="btn-ghost-link">Back to home</a>
     </div>
 
+    <!-- v7.43.0 GAP-4: Pro gate — free users see this instead of the dashboard.
+         Reuses the anon-gate component styling, no new CSS. -->
+    <div class="account-anon-gate" id="cca-pro-gate" hidden>
+      <div class="anon-gate-icon" aria-hidden="true"></div>
+      <h2>Cross-cert analytics is a Pro feature</h2>
+      <p>Readiness, skill overlap, and your best next move across every cert, in one dashboard. Pro unlocks it along with every exam in the library.</p>
+      <a href="/pricing" class="btn-primary-cta">See Pro plans →</a>
+      <a href="/account" class="btn-ghost-link">Back to account</a>
+    </div>
+
     <!-- Authenticated content — populated by lib/cross-cert-analytics.js -->
     <div class="cca-content" id="cca-content" hidden>
 

--- a/landing/lib/cross-cert-analytics.js
+++ b/landing/lib/cross-cert-analytics.js
@@ -238,22 +238,48 @@
   window.ccaGetCertCatalog = getCertCatalog;
 
   // ── Auth flow ──────────────────────────────────────────────────────────
+  var elProGate = document.getElementById('cca-pro-gate');
+
   function showLoading() {
     if (elLoading) elLoading.removeAttribute('hidden');
     if (elAnonGate) elAnonGate.setAttribute('hidden', '');
+    if (elProGate) elProGate.setAttribute('hidden', '');
     if (elContent) elContent.setAttribute('hidden', '');
   }
 
   function showAnonGate() {
     if (elLoading) elLoading.setAttribute('hidden', '');
     if (elAnonGate) elAnonGate.removeAttribute('hidden');
+    if (elProGate) elProGate.setAttribute('hidden', '');
+    if (elContent) elContent.setAttribute('hidden', '');
+  }
+
+  // GAP-4 (v7.43.0): cross-cert analytics is a Pro feature.
+  function showProGate() {
+    if (elLoading) elLoading.setAttribute('hidden', '');
+    if (elAnonGate) elAnonGate.setAttribute('hidden', '');
+    if (elProGate) elProGate.removeAttribute('hidden');
     if (elContent) elContent.setAttribute('hidden', '');
   }
 
   function showContent() {
     if (elLoading) elLoading.setAttribute('hidden', '');
     if (elAnonGate) elAnonGate.setAttribute('hidden', '');
+    if (elProGate) elProGate.setAttribute('hidden', '');
     if (elContent) elContent.removeAttribute('hidden');
+  }
+
+  // Tier check — same RPC the cert app's quota chip uses (is_pro() in
+  // Postgres folds admin into 'pro'). Returns 'free' | 'pro' | null.
+  // null = unknown (RPC error) — callers fail OPEN so a transient hiccup
+  // never locks a paying user out of their dashboard.
+  function fetchTier(userId) {
+    return supabase.rpc('get_daily_quota_usage', { uid: userId })
+      .then(function (res) {
+        var row = res && res.data && res.data[0];
+        return (row && row.tier) ? row.tier : null;
+      })
+      .catch(function () { return null; });
   }
 
   function fetchProfile(userId) {
@@ -1056,22 +1082,31 @@
         showAnonGate();
         return;
       }
-      // Render the panel synchronously with no profile while we fetch — the
-      // catalog itself is enough to render the active/coming-soon rows.
-      // Profile fetch only changes the passed-cert section.
-      var emptyProfile = { role: 'user', metadata: {} };
-      renderPanel1(emptyProfile);
-      renderPanel2(emptyProfile);
-      renderPanel3(emptyProfile);
-      showContent();
-
-      // Async: fetch real profile, re-render once we have cert_results
-      fetchProfile(session.user.id).then(function (profile) {
-        if (profile) {
-          renderPanel1(profile);
-          renderPanel2(profile);
-          renderPanel3(profile);
+      // GAP-4 (v7.43.0): Pro-only surface. Resolve tier before any content
+      // renders so free users never see a flash of the dashboard. Unknown
+      // tier (null, RPC error) fails open.
+      fetchTier(session.user.id).then(function (tier) {
+        if (tier === 'free') {
+          showProGate();
+          return;
         }
+        // Render the panel synchronously with no profile while we fetch — the
+        // catalog itself is enough to render the active/coming-soon rows.
+        // Profile fetch only changes the passed-cert section.
+        var emptyProfile = { role: 'user', metadata: {} };
+        renderPanel1(emptyProfile);
+        renderPanel2(emptyProfile);
+        renderPanel3(emptyProfile);
+        showContent();
+
+        // Async: fetch real profile, re-render once we have cert_results
+        fetchProfile(session.user.id).then(function (profile) {
+          if (profile) {
+            renderPanel1(profile);
+            renderPanel2(profile);
+            renderPanel3(profile);
+          }
+        });
       });
     }).catch(function () {
       showAnonGate();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.42.0",
+  "version": "7.43.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.42.0
+   Network+ AI Quiz — styles.css  v7.43.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.42.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.42.0';
+// Service Worker v7.43.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.43.0';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- /analytics now resolves tier before rendering: free users get a Pro upsell gate (reuses anon-gate styling), Pro/admin get the dashboard, anonymous users keep the sign-in gate.
- Tier via the existing get_daily_quota_usage RPC; RPC errors fail open.
- No new CSS; E2E data hooks untouched.

## Testing
- UAT 4109/4109 PASS.
- Live-verified anon flow + pro-gate render on localhost:4181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)