### PR TITLE
v7.44.0 — Log-exam-result gated as Pro on /account (GAP-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.44.0 | Log-exam-result gated as Pro on /account per mockup (GAP-5) |
 | v7.43.0 | Cross-cert analytics gated as Pro feature with upsell state for free users (GAP-4) |
 | v7.42.0 | Settings tier locks — Daily Goal + Daily Review controls pro-locked for free users (GAP-3) |
 | v7.41.0 | Free tier pre-emptive daily-limit screen — oversized sessions blocked before start with right-size option (GAP-2) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.43.0
+// Network+ AI Quiz — app.js  v7.44.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.43.0';
+const APP_VERSION = '7.44.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.43.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.44.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/landing/account.html
+++ b/landing/account.html
@@ -234,6 +234,12 @@
   #account-page .er-action{background:none;border:0;cursor:pointer;font:650 12.5px/1 'Inter',sans-serif;color:var(--accent);padding:7px 4px}
   @media (hover:hover){#account-page .er-action:hover{text-decoration:underline;text-underline-offset:3px}}
   #account-page .er-empty{font-size:13px;color:var(--muted);padding:18px 2px}
+  /* v7.44.0 GAP-5: Pro-locked exam-results state */
+  #account-page .er-pro-lock{display:flex;flex-direction:column;align-items:flex-start;gap:12px;padding:20px 18px;border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border-soft));border-radius:13px;background:color-mix(in oklab,var(--accent) 5%,transparent)}
+  #account-page .er-pro-lock p{margin:0;font-size:13.5px;line-height:1.55;color:var(--muted)}
+  #account-page .er-pro-lock p b{color:var(--ink,var(--text))}
+  #account-page .er-pro-lock-pill{font:800 9px/1 'Inter',sans-serif;letter-spacing:.12em;text-transform:uppercase;color:var(--accent);background:color-mix(in oklab,var(--accent) 14%,transparent);border:1px solid color-mix(in oklab,var(--accent) 32%,var(--border-soft));border-radius:999px;padding:4px 8px;display:inline-flex;align-items:center;gap:4px}
+  #account-page .er-pro-lock-pill svg{width:10px;height:10px;stroke:currentColor;fill:none;stroke-width:2.4;stroke-linecap:round;stroke-linejoin:round}
   #account-page .security-sessions{margin-top:24px}
   #account-page .security-sessions-label{font-size:10.5px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--muted);margin-bottom:10px}
   #account-page .session-list .sess-row,#account-page .session-row{display:flex;align-items:center;gap:14px;padding:15px 16px;border:1px solid var(--border-soft);border-radius:12px}

--- a/landing/lib/account.js
+++ b/landing/lib/account.js
@@ -321,6 +321,17 @@
   };
 
   function renderExamResultsList(role, profile) {
+    // GAP-5 (v7.44.0): logging real exam results is Pro-only per the
+    // cert-ios-log-result mockup. Same tier logic as the tier pill above:
+    // admin = Pro until Stripe lands; paying users will arrive as tier='pro'.
+    if (role !== 'admin') {
+      return ''
+        + '<div class="er-pro-lock">'
+        +   '<span class="er-pro-lock-pill"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span>'
+        +   '<p>Logging real exam results is part of Pro. Record your score and test centre after exam day, and your cert tile flips to <b>Passed</b>.</p>'
+        +   '<a class="btn-primary-cta" href="/pricing">See Pro plans →</a>'
+        + '</div>';
+    }
     var certs = getCertEntitlements(role).filter(function (c) { return c.status !== 'locked'; });
     if (!certs.length) {
       return '<p class="er-empty">No certs unlocked yet. Pick a cert and start studying.</p>';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.43.0",
+  "version": "7.44.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.43.0
+   Network+ AI Quiz — styles.css  v7.44.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.43.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.43.0';
+// Service Worker v7.44.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.44.0';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- §03 exam-results editor on /account is Pro-only per the cert-ios-log-result mockup: free users see a PRO-pill lock state with a pricing CTA instead of editable rows.
- Existing result data in metadata.cert_results untouched; admin (=Pro pre-Stripe) keeps the full editor.
- E2E data hooks untouched.

## Testing
- UAT 4109/4109 PASS.
- Live-verified the locked state render on localhost:4181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)