### PR TITLE
v7.45.0 — In-app account deletion (GAP-6, Apple 5.1.1(v))

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.45.0 | In-app account deletion — Settings danger-zone row + confirm flow, Apple 5.1.1(v) (GAP-6) |
 | v7.44.0 | Log-exam-result gated as Pro on /account per mockup (GAP-5) |
 | v7.43.0 | Cross-cert analytics gated as Pro feature with upsell state for free users (GAP-4) |
 | v7.42.0 | Settings tier locks — Daily Goal + Daily Review controls pro-locked for free users (GAP-3) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.44.0
+// Network+ AI Quiz — app.js  v7.45.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.44.0';
+const APP_VERSION = '7.45.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -18530,6 +18530,8 @@ function renderSettingsPage() {
   if (typeof syncSettingsExamDate === 'function') syncSettingsExamDate();
   // #8: sync the Daily Review session-size chips + top-up toggle
   if (typeof renderSrSettings === 'function') renderSrSettings();
+  // v7.45.0 GAP-6: show the Delete-my-account row for signed-in users
+  if (typeof _syncDeleteAccountRow === 'function') _syncDeleteAccountRow();
   // v4.81.2: refresh the auto-backup list every time Settings opens so the
   // user sees what's available + can restore/download from any snapshot.
   if (typeof renderAutoBackupList === 'function') renderAutoBackupList();
@@ -18770,6 +18772,126 @@ function renderSrSettings() {
     tog.classList.toggle('is-on', !!prefs.topUp);
     tog.setAttribute('aria-checked', prefs.topUp ? 'true' : 'false');
   }
+}
+
+// ── GAP-6 (v7.45.0): in-app account deletion (Apple 5.1.1(v)) ───────────
+// Settings danger-zone row, signed-in users only. Same 7-day-grace
+// mechanism as the /account danger zone: stamps
+// profiles.metadata.deletion_requested_at, then signs the user out.
+// Mockup: onboarding-account-deletion.html (row → honest confirm sheet
+// with type-your-email → deleting state → goodbye).
+function _syncDeleteAccountRow() {
+  var section = document.getElementById('settings-delete-account');
+  if (!section) return;
+  var signedIn = (typeof window !== 'undefined' && window._certanvilSignedIn === true);
+  if (signedIn) section.removeAttribute('hidden');
+  else section.setAttribute('hidden', '');
+  var btn = document.getElementById('btn-app-delete-account');
+  if (btn && !btn._dlaBound) {
+    btn._dlaBound = true;
+    btn.addEventListener('click', function () {
+      if (typeof _showDeleteAccountConfirmUI === 'function') _showDeleteAccountConfirmUI();
+    });
+  }
+}
+
+function _showDeleteAccountConfirmUI() {
+  var sb = window.certanvilSupabase;
+  if (!sb) return;
+  sb.auth.getSession().then(function (s) {
+    var session = s && s.data && s.data.session;
+    if (!session || !session.user) return;
+    var email = session.user.email || '';
+    var userId = session.user.id;
+
+    var prev = document.getElementById('delete-account-modal');
+    if (prev) prev.remove();
+
+    var modal = document.createElement('div');
+    modal.id = 'delete-account-modal';
+    modal.className = 'quota-exceeded-modal';  // reuse overlay scrim
+    modal.innerHTML =
+      '<div class="dlpb-card dla-card" role="dialog" aria-modal="true" aria-label="Delete your account">' +
+        '<div class="dlpb-lockmark dla-mark" aria-hidden="true">' +
+          '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">' +
+            '<path d="M3 6h18"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path><path d="M10 11v6M14 11v6"></path>' +
+          '</svg>' +
+        '</div>' +
+        '<h2 class="dlpb-title">Delete your account?</h2>' +
+        '<p class="dlpb-lede">Here is exactly what gets removed after the 7-day grace window:</p>' +
+        '<div class="dlpb-allow dla-terms">' +
+          '<div class="dlpb-row"><span class="dlpb-row-tx"><b>Progress and history</b><span>Quiz history, streaks, and readiness scores</span></span></div>' +
+          '<div class="dlpb-row"><span class="dlpb-row-tx"><b>Review queue</b><span>Saved cards and their schedule</span></span></div>' +
+          '<div class="dlpb-row"><span class="dlpb-row-tx"><b>Your profile</b><span>Email, exam date, and cert results</span></span></div>' +
+        '</div>' +
+        '<p class="dlpb-pro-line">Sign in any time in the next <b>7 days</b> to cancel. After that it&rsquo;s gone for good.</p>' +
+        '<div class="dla-confirm">' +
+          '<label for="dla-email">Type <b>' + email.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</b> to confirm</label>' +
+          '<input id="dla-email" type="email" inputmode="email" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="Your email" />' +
+        '</div>' +
+        '<div class="dlpb-actions">' +
+          '<button type="button" class="dla-danger-btn" id="dla-confirm" disabled>Delete account</button>' +
+          '<button type="button" class="dlpb-ghost" id="dla-cancel">Cancel</button>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(modal);
+
+    var input = document.getElementById('dla-email');
+    var confirmBtn = document.getElementById('dla-confirm');
+    if (input && confirmBtn) {
+      input.addEventListener('input', function () {
+        confirmBtn.disabled = (input.value.trim().toLowerCase() !== email.toLowerCase());
+      });
+    }
+    var cancelBtn = document.getElementById('dla-cancel');
+    if (cancelBtn) cancelBtn.addEventListener('click', function () { modal.remove(); });
+    modal.addEventListener('click', function (e) { if (e.target === modal) modal.remove(); });
+    if (confirmBtn) {
+      confirmBtn.addEventListener('click', function () {
+        if (confirmBtn.disabled) return;
+        if (typeof _confirmDeleteAccount === 'function') _confirmDeleteAccount(modal, userId);
+      });
+    }
+  });
+}
+
+function _confirmDeleteAccount(modal, userId) {
+  var sb = window.certanvilSupabase;
+  if (!sb) return;
+  var card = modal.querySelector('.dla-card');
+  if (card) {
+    card.innerHTML =
+      '<h2 class="dlpb-title">Deleting your account&hellip;</h2>' +
+      '<p class="dlpb-lede">Scheduling removal. This takes a moment.</p>';
+  }
+  // Read metadata fresh so we don't clobber keys written since page load
+  // (cloud-store debounce flushes into the same jsonb column).
+  sb.from('profiles').select('metadata').eq('id', userId).single().then(function (pr) {
+    var meta = (pr && pr.data && pr.data.metadata) || {};
+    var nextMeta = Object.assign({}, meta, { deletion_requested_at: new Date().toISOString() });
+    return sb.from('profiles').update({ metadata: nextMeta }).eq('id', userId);
+  }).then(function (r) {
+    if (r && r.error) throw r.error;
+    return sb.auth.signOut();
+  }).then(function () {
+    if (card) {
+      card.innerHTML =
+        '<h2 class="dlpb-title">Account scheduled for deletion</h2>' +
+        '<p class="dlpb-lede">You&rsquo;re signed out. Sign back in within <b>7 days</b> if you change your mind &mdash; after that, your data is permanently purged.</p>' +
+        '<div class="dlpb-actions"><button type="button" class="dlpb-ghost" id="dla-done">Done</button></div>';
+      var done = document.getElementById('dla-done');
+      if (done) done.addEventListener('click', function () { modal.remove(); window.location.reload(); });
+    }
+  }).catch(function () {
+    if (card) {
+      card.innerHTML =
+        '<h2 class="dlpb-title">Couldn&rsquo;t schedule deletion</h2>' +
+        '<p class="dlpb-lede">Something went wrong on our side. Nothing was deleted &mdash; try again in a minute.</p>' +
+        '<div class="dlpb-actions"><button type="button" class="dlpb-ghost" id="dla-err-close">Close</button></div>';
+      var closeBtn = document.getElementById('dla-err-close');
+      if (closeBtn) closeBtn.addEventListener('click', function () { modal.remove(); });
+    }
+  });
 }
 
 // ── Sidebar collapse ──

--- a/docs/planning/TIER-LOGIC-SWEEP-2026-06-11.md
+++ b/docs/planning/TIER-LOGIC-SWEEP-2026-06-11.md
@@ -23,16 +23,16 @@ notes (`stage-sub` annotations + `free-only`/`pro-only` markup in
 | A10 | Exam-result logging ("Mark result") + Passed badges | /account er-list (v4.93.0) — but see GAP-4 for the Pro-gating nuance |
 | A11 | Account deletion (7-day grace) | /account danger zone — see GAP-6 for the Apple in-app requirement check |
 
-## ❌ Decided in the iOS build but NOT implemented (the work list)
+## ✅ The work list — ALL DONE (2026-06-11, v7.40.0 → v7.45.0)
 
-| # | Rule (as decided) | Current reality | Effort / lane |
-|---|---|---|---|
-| GAP-1 | **Free daily allowance = 15 practice questions + 5 review cards.** Decision: "fixed caps of 5 cards/day and 15 questions/day". Mockup: cert-ios-daily-limit ("15 practice + 5 review. Pro removes the cap.") | Live cap is **20 questions/day**, and Daily Review has **no free cap at all** | Gated lane: migration changes `consume_daily_quota` 20→15 + proxy `FREE_DAILY_LIMIT` + app copy; new client+server logic for the 5-cards/day review cap |
-| GAP-2 | **Soft blocker when a free user picks a session bigger than the remaining allowance** ("You picked a 25-question set… Start a 15-question set instead") | Wall appears only after quota is exhausted mid-flow; no pre-emptive size check | Client-side, fast lane; depends on GAP-1 numbers |
-| GAP-3 | **Settings: Daily Goal + Daily Review size controls locked for free users** (pro-lock pills, lock-note, Go Pro button; Pro gets live controls). Mockup: cert-ios-settings `.plan-free`/`.plan-pro` system | Controls are live for everyone | Client-side UI gating off `_quotaState.tier`, fast lane |
-| GAP-4 | **Cross-cert analytics is a Pro feature** (hub mockup: "Pro" pill; cross-cert mockup: "One Pro dashboard") | /analytics only requires sign-in; free users see everything | landing/lib JS gate + upsell state, fast lane |
-| GAP-5 | **Log-your-exam-result is a Pro feature** (mockup: "a Pro user records the score") + the lifted log-result screen styling | Feature exists on /account for ALL unlocked certs, not Pro-gated; mockup styling not lifted | Decide: keep free (generous) or gate to Pro per decision; styling lift optional |
-| GAP-6 | **Apple requires in-app account deletion** (onboarding-account-deletion mockup: Settings row + confirm sheet inside the app) | Deletion exists on certanvil.com/account, but the cert app's Settings has no deletion row — verify the wrap path satisfies Apple | Check + likely small Settings addition before submission |
+| # | Rule (as decided) | Shipped as |
+|---|---|---|
+| GAP-1 ✅ | **Free daily allowance = 15 practice questions + 5 review cards.** | v7.40.0 (PR #442, gated): migration `20260611_free_tier_15_questions.sql` + proxy `FREE_DAILY_LIMIT` + `SR_FREE_DAILY_CAP` client cap. ⚠️ Migration still needs pasting in Supabase SQL Editor (bundled with June 20). |
+| GAP-2 ✅ | **Soft blocker when a free user picks a session bigger than the remaining allowance** | v7.41.0 (PR #443): `_gateSessionSizeForQuota` + daily-limit pre-block screen in startQuiz / startExam / startBulkQuiz (bulk previously had no gate at all). |
+| GAP-3 ✅ | **Settings: Daily Goal + Daily Review size controls locked for free users** | v7.42.0 (PR #444): `.tier-pro-only`/`.tier-free-only` body-class system, pro-lock pills, lock-notes, Go Pro CTAs, JS guards. |
+| GAP-4 ✅ | **Cross-cert analytics is a Pro feature** | v7.43.0 (PR #445): tier resolved via `get_daily_quota_usage` RPC before render; free → `#cca-pro-gate` upsell; fails open on RPC error. |
+| GAP-5 ✅ | **Log-your-exam-result is a Pro feature** | v7.44.0 (PR #446): `renderExamResultsList` returns `.er-pro-lock` upsell for non-admin. Gate-vs-keep-free decided as GATE per mockup-as-spec (Simi may veto). Styling lift of the log-result screen deferred (optional). |
+| GAP-6 ✅ | **Apple requires in-app account deletion** | v7.45.0 (PR #447): Settings §03 Danger Zone "Delete my account" row (signed-in only) + mockup confirm flow; same `deletion_requested_at` 7-day-grace mechanism as /account. |
 
 ## ⏸ Correctly parked (cannot be built yet — needs billing)
 

--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.44.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.45.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>
@@ -1553,6 +1553,15 @@
         <h3 class="settings-section-title">Wrong Answers Bank</h3>
         <button class="btn btn-ghost" id="wrong-bank-clear" style="width:100%;font-size:13px" onclick="clearWrongBank()" title="Clear all saved wrong answers" aria-label="Clear all wrong answers">Clear Wrong Answers Bank <span class="wrong-count-badge" id="wrong-bank-clear-count">0</span></button>
         <p class="settings-section-hint">Removes all saved mistakes. The "Drill Mistakes" preset on the home page fires a drill quiz from this bank.</p>
+      </section>
+      <!-- v7.45.0 GAP-6: Apple 5.1.1(v) requires in-app account deletion.
+           Signed-in users only — _syncDeleteAccountRow() unhides it. Same
+           7-day-grace mechanism as the /account danger zone
+           (profiles.metadata.deletion_requested_at). -->
+      <section class="card settings-section settings-section-danger" id="settings-delete-account" hidden>
+        <h3 class="settings-section-title">Delete my account</h3>
+        <button class="btn btn-ghost" id="btn-app-delete-account" style="width:100%;font-size:13px" type="button">Delete my account&hellip;</button>
+        <p class="settings-section-hint">Marks your account for deletion. After 7 days your profile and quiz history are permanently purged. Sign in during the grace window to cancel. Practice data saved on this device stays on this device.</p>
       </section>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.44.0",
+  "version": "7.45.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.44.0
+   Network+ AI Quiz — styles.css  v7.45.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -14081,6 +14081,54 @@ body.is-pro-tier .tier-free-only { display: none !important; }
 @media (hover: hover) and (pointer: fine) {
   .settings-go-pro-btn:hover { filter: brightness(1.05); }
 }
+
+/* ── GAP-6 — in-app account deletion confirm (mockup onboarding-account-deletion) ── */
+.dla-card { text-align: left; }
+.dla-card .dlpb-title, .dla-card .dlpb-lede { text-align: center; }
+.dla-mark {
+  background: color-mix(in oklab, var(--red, #f87171) 12%, transparent);
+  border-color: color-mix(in oklab, var(--red, #f87171) 38%, transparent);
+  color: var(--red, #f87171);
+}
+.dla-terms .dlpb-row { padding: 10px 14px; }
+.dla-confirm { margin-bottom: 16px; }
+.dla-confirm label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-mid, #b0b0cc);
+  margin-bottom: 7px;
+}
+.dla-confirm label b { color: var(--text, #f0f0f8); word-break: break-all; }
+.dla-confirm input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 12px 13px;
+  border-radius: 10px;
+  border: 1px solid var(--border, rgba(255,255,255,0.16));
+  background: var(--surface, #131320);
+  color: var(--text, #f0f0f8);
+  font-size: 14px;
+  font-family: inherit;
+}
+.dla-confirm input:focus {
+  outline: none;
+  border-color: color-mix(in oklab, var(--red, #f87171) 55%, transparent);
+}
+.dla-danger-btn {
+  display: block;
+  background: var(--red, #f87171);
+  color: #14110b;
+  padding: 13px 22px;
+  font-size: 13.5px;
+  font-weight: 700;
+  border-radius: 10px;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  transition: transform 0.16s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.16s ease;
+}
+.dla-danger-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.dla-danger-btn:not(:disabled):active { transform: scale(0.97); }
 
 @media (prefers-reduced-motion: reduce) {
   .quota-exceeded-modal { animation: none; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.44.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.44.0';
+// Service Worker v7.45.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.45.0';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- Settings §03 Danger Zone gains a "Delete my account" row (signed-in users only) — the in-app deletion entry point Apple requires for App Store submission.
- Confirm sheet per the onboarding-account-deletion mockup: what-gets-removed list, 7-day grace copy, type-your-email confirm, deleting → goodbye states.
- Same mechanism as the landing /account danger zone (metadata.deletion_requested_at + 7-day purge); metadata re-read before write to avoid clobbering cloud-store flushes; then auth.signOut().

## Testing
- UAT 4109/4109 PASS.
- Full flow live-verified on localhost:4182 against a stubbed Supabase client (visibility gating, email match logic, metadata merge, sign-out, goodbye/error states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)