### PR TITLE
v7.46.0 — Free-tier hard gates: exam sim, marathons, Deep Scan, Drill Mistakes Pro-only + 15-Q custom cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.46.0 | Free-tier hard gates — exam sim, marathons, Deep Scan, Drill Mistakes Pro-only; custom quiz capped at 15 for free |
 | v7.45.0 | In-app account deletion — Settings danger-zone row + confirm flow, Apple 5.1.1(v) (GAP-6) |
 | v7.44.0 | Log-exam-result gated as Pro on /account per mockup (GAP-5) |
 | v7.43.0 | Cross-cert analytics gated as Pro feature with upsell state for free users (GAP-4) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.45.0
+// Network+ AI Quiz — app.js  v7.46.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.45.0';
+const APP_VERSION = '7.46.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -918,7 +918,7 @@ function _showProOnlyUI(detail) {
     '<div class="quota-exceeded-card pro-only-card">' +
       '<div class="quota-exceeded-icon pro-only-icon">&#9889;</div>' +
       '<div class="quota-exceeded-title">' + feature + ' is a Pro feature</div>' +
-      '<div class="quota-exceeded-sub">Drills, the topology builder, ACL labs, and the Sec+ flagships are all part of Pro. Free users get unlimited days at 20 AI-generated questions a day. Upgrade to unlock everything.</div>' +
+      '<div class="quota-exceeded-sub">The Exam Simulator, marathon sets, Deep Scan, and drills are all part of Pro. Free is 15 practice questions plus 5 review cards a day, every day. Upgrade to unlock everything.</div>' +
       '<div class="quota-exceeded-actions">' +
         '<a class="quota-exceeded-cta" href="https://certanvil.com/pricing" target="_blank" rel="noopener">Upgrade to Pro &middot; $9.99/mo &rarr;</a>' +
         '<button type="button" class="quota-exceeded-dismiss" id="pro-only-dismiss">Maybe later</button>' +
@@ -930,6 +930,22 @@ function _showProOnlyUI(detail) {
   if (dismissBtn) dismissBtn.addEventListener('click', function () { modal.remove(); });
   modal.addEventListener('click', function (e) { if (e.target === modal) modal.remove(); });
 }
+
+// v7.46.0: free custom quizzes cap at 15 questions. Capture-phase listener
+// beats the generic chip handler, so a free user tapping the 20 chip gets
+// the Pro modal and the selection never changes. startQuiz() re-checks as
+// the enforcement layer.
+document.addEventListener('click', function (e) {
+  var chip = e.target && e.target.closest ? e.target.closest('#count-group .chip') : null;
+  if (!chip) return;
+  var v = parseInt(chip.getAttribute('data-v'), 10);
+  if (!(v > 15)) return;
+  if (typeof _srIsFreeTier === 'function' && _srIsFreeTier()) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (typeof _gateProOnly === 'function') _gateProOnly('Going past 15 questions per set');
+  }
+}, true);
 
 // Self-contained auth listener — keeps the quota chip in sync with auth state
 // (fires on initial load, sign-in, sign-out, and token refresh). Safe to call
@@ -6263,6 +6279,8 @@ function clearWrongBank() {
 // Builds a fresh quiz from THIS session's wrong log entries (not the global
 // wrong-bank). If every answer was correct the button is hidden upstream.
 function drillMistakesFromResults() {
+  // v7.46.0: Drill Mistakes is Pro-only — same gate as startWrongDrill
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Drill Mistakes')) return;
   if (!Array.isArray(log) || log.length === 0) return;
   const wrongEntries = log.filter(e => e && e.isRight === false);
   if (wrongEntries.length === 0) {
@@ -6318,6 +6336,8 @@ function _renderResultsReviewList() {
 }
 
 function startWrongDrill() {
+  // v7.46.0: Drill Mistakes is Pro-only (Simi, 2026-06-11)
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Drill Mistakes')) return;
   const bank = loadWrongBank();
   if (bank.length === 0) {
     alert('No wrong answers saved yet. Keep quizzing!');
@@ -6456,6 +6476,12 @@ function _showSignInPrompt(anchorEl, message) {
 // ══════════════════════════════════════════
 async function startQuiz() {
   if (!_gateActivityForQuota('practice quizzes')) return;
+  // v7.46.0: free custom quizzes cap at 15 questions — the full daily
+  // allowance in one set (Simi, 2026-06-11). The count-chip interceptor
+  // blocks the picker; this is the enforcement behind it.
+  if (qCount > 15 && typeof _srIsFreeTier === 'function' && _srIsFreeTier()) {
+    if (!_gateProOnly('Going past 15 questions per set')) return;
+  }
   if (!_gateSessionSizeForQuota(qCount, { mode: 'quiz' })) return;
   const key = document.getElementById('api-key').value.trim();
   const errBox = document.getElementById('setup-err');
@@ -6855,6 +6881,9 @@ function _formatElapsed(ms) {
 // START EXAM SIMULATION
 // ══════════════════════════════════════════
 async function startExam() {
+  // v7.46.0: the Exam Simulator is Pro-only (Simi, 2026-06-11). The quota
+  // and size gates below only matter for Pro edge states now.
+  if (!_gateProOnly('The Exam Simulator')) return;
   if (!_gateActivityForQuota('exam simulator')) return;
   if (!_gateSessionSizeForQuota(90, { mode: 'exam' })) return;
   const key = document.getElementById('api-key').value.trim();
@@ -10777,6 +10806,15 @@ function startStreakSave() {
 
 // ── Quiz Presets (3 one-click starting configs) ──
 function applyPreset(name) {
+  // v7.46.0: Deep Scan + all marathon presets are Pro-only (Simi, 2026-06-11).
+  // Free stays on Warmup (5), Focused (10), and custom sets up to 15.
+  const PRO_PRESETS = {
+    grind: 'The 20-min Deep Scan',
+    bulk30: '30-question marathons',
+    bulk45: '45-question marathons',
+    bulk60: 'The 60-Question SIM'
+  };
+  if (PRO_PRESETS[name] && typeof _gateProOnly === 'function' && !_gateProOnly(PRO_PRESETS[name])) return;
   // Bulk Mixed presets — large counts that exceed the single-call ceiling are
   // batched via startBulkQuiz so the AI never gets asked for >20 Qs at once.
   const bulkSizes = { bulk30: 30, bulk45: 45, bulk60: 60 };
@@ -11130,6 +11168,10 @@ async function startBulkQuiz(count) {
   diff = 'Exam Level';
   qCount = count;
 
+  // v7.46.0: marathons are Pro-only — belt behind the applyPreset gate so a
+  // direct startBulkQuiz() call can't sidestep it. The GAP-2 gates below
+  // only matter for Pro edge states now.
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Marathon sets')) return;
   // GAP-2: bulk presets previously had no quota gate (free user would 429 mid-run)
   if (!_gateActivityForQuota('practice quizzes')) return;
   if (!_gateSessionSizeForQuota(count, { mode: 'bulk' })) return;

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
         <div class="opts" id="grp-quick">
           <button type="button" class="opt" onclick="applyPreset('warmup')"><span class="on">5-min Warmup</span><span class="od">5 questions, foundational</span></button>
           <button type="button" class="opt" onclick="startDailyChallenge()"><span class="on">Daily Challenge</span><span class="od">1 question, about a minute, streak +1</span></button>
-          <button type="button" class="opt is-hidden" id="bento-wrong-opt" onclick="startWrongDrill()"><span class="on">Drill Mistakes</span><span class="od" id="bento-wrong-sub">0 wrong answers saved</span></button>
+          <button type="button" class="opt is-hidden" id="bento-wrong-opt" onclick="startWrongDrill()"><span class="on">Drill Mistakes <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od" id="bento-wrong-sub">0 wrong answers saved</span></button>
         </div>
       </section>
 
@@ -400,9 +400,9 @@
           <span class="meta" id="prac-range">10-30 min</span>
         </div>
         <div class="opts cols2" id="grp-practice">
-          <button type="button" class="opt" onclick="applyPreset('grind')"><span class="on">20-min Deep Scan</span><span class="od">20 questions, exam level, mixed</span></button>
-          <button type="button" class="opt" onclick="applyPreset('bulk30')"><span class="on">30 Questions</span><span class="od">Marathon mixed, about 25 min</span></button>
-          <button type="button" class="opt" onclick="applyPreset('bulk45')"><span class="on">45 Questions</span><span class="od">Marathon mixed, about 38 min</span></button>
+          <button type="button" class="opt" onclick="applyPreset('grind')"><span class="on">20-min Deep Scan <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">20 questions, exam level, mixed</span></button>
+          <button type="button" class="opt" onclick="applyPreset('bulk30')"><span class="on">30 Questions <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">Marathon mixed, about 25 min</span></button>
+          <button type="button" class="opt" onclick="applyPreset('bulk45')"><span class="on">45 Questions <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">Marathon mixed, about 38 min</span></button>
         </div>
       </section>
 
@@ -413,8 +413,8 @@
           <span class="meta" id="exam-range">60-90 min</span>
         </div>
         <div class="opts cols2" id="grp-exam">
-          <button type="button" class="opt" onclick="applyPreset('bulk60')"><span class="on">60-Question SIM</span><span class="od">Closest to the real thing, no timer</span></button>
-          <button type="button" class="opt" onclick="startExam()"><span class="on">Full Exam Simulator</span><span class="od">90 questions, 90-min timer, scored 100-900</span></button>
+          <button type="button" class="opt" onclick="applyPreset('bulk60')"><span class="on">60-Question SIM <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">Closest to the real thing, no timer</span></button>
+          <button type="button" class="opt" onclick="startExam()"><span class="on">Full Exam Simulator <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">90 questions, 90-min timer, scored 100-900</span></button>
         </div>
       </section>
 
@@ -613,6 +613,7 @@
             <button class="chip chip-count" data-v="20" type="button">
               <span class="chip-count-num">20</span>
               <span class="chip-count-sub">~20 min</span>
+              <span class="pro-lock-pill tier-free-only chip-count-pro"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span>
             </button>
           </div>
         </div>
@@ -761,7 +762,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.45.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.46.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>
@@ -1217,7 +1218,7 @@
   <p class="drills-lede">Short, repeat passes on the things you get wrong. Ten questions or fewer, scored like practice.</p>
 
   <div class="drills-card" id="drills-mistakes-card">
-    <div class="drills-card-head"><span class="drills-card-title">Drill Mistakes</span><span class="drills-count-pill" id="drills-mistakes-pill">0 saved</span></div>
+    <div class="drills-card-head"><span class="drills-card-title">Drill Mistakes <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill" id="drills-mistakes-pill">0 saved</span></div>
     <p class="drills-card-note" id="drills-mistakes-note">Clear the wrong answers in your bank. Get one right twice in a row and it leaves the bank for good.</p>
     <button type="button" class="drills-btn" id="drills-mistakes-btn" onclick="startWrongDrill()">Drill your mistakes</button>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.45.0",
+  "version": "7.46.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.45.0
+   Network+ AI Quiz — styles.css  v7.46.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -14012,6 +14012,9 @@ body.is-pro-tier .tier-free-only { display: none !important; }
   stroke: currentColor; fill: none;
   stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round;
 }
+/* v7.46.0: pill variants inside home tiles + custom-quiz count chips */
+.opt .on .pro-lock-pill { font-size: 8px; padding: 3px 6px; margin-left: 4px; }
+.chip-count .chip-count-pro { font-size: 8px; padding: 3px 6px; margin: 4px auto 0; }
 .settings-lock-bignum {
   display: flex;
   align-items: baseline;

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.45.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.45.0';
+// Service Worker v7.46.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.46.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -4442,7 +4442,7 @@ test('v4.54.8 HTML: #results-review-list container + eyebrow + italic-accent tit
 test('v4.54.8 HTML: Drill my mistakes CTA button exists',
   /id="btn-drill-mistakes"[\s\S]{0,200}drillMistakesFromResults\(\)/.test(html));
 test('v4.54.8 JS: _sessionStartTs tracked on startQuiz + drillMistakesFromResults',
-  /function startQuiz\([\s\S]{0,6000}_sessionStartTs\s*=\s*Date\.now\(\)/.test(js) &&
+  /function startQuiz\([\s\S]{0,6800}_sessionStartTs\s*=\s*Date\.now\(\)/.test(js) &&  // window 6000→6800: v7.46.0 free-tier hard gates grew the startQuiz preamble
   js.includes('let _sessionStartTs') &&
   js.includes('function drillMistakesFromResults(') &&
   js.includes('function _formatElapsed('));
@@ -15196,7 +15196,7 @@ test('v4.99.3 gate: shows quota-exceeded modal when blocked',
 test('v4.99.3 gate: startQuiz protected',
   /async function startQuiz[\s\S]{0,200}_gateActivityForQuota/.test(js));
 test('v4.99.3 gate: startExam protected',
-  /async function startExam[\s\S]{0,200}_gateActivityForQuota/.test(js));
+  /async function startExam[\s\S]{0,420}_gateActivityForQuota/.test(js));  // window 200→420: v7.46.0 _gateProOnly now precedes the quota gate
 // v4.99.4: drill entry points now use _gateProOnly (drills are Pro-only).
 // Quizzes (startQuiz/startExam) still use _gateActivityForQuota (20/day quota).
 test('v4.99.4 ProOnly: _gateProOnly helper defined',


### PR DESCRIPTION
## Summary
Implements Simi's free-tier decision (2026-06-11):
- Pro-only: Exam Simulator, 60-Q SIM, 45-Q, 30-Q, 20-min Deep Scan, Drill Mistakes — hard gates with the Pro upgrade modal at every entry point (tiles, presets, direct function calls, results-page drill).
- Free custom quizzes capped at 15 questions: the 20 chip shows a PRO pill and opens the upgrade modal for free users; startQuiz enforces behind the UI.
- PRO pills on all gated tiles via the GAP-3 tier-visibility system (hidden for Pro/anonymous-unresolved).
- Pro-only modal copy fixed (stale 20/day + deleted features).
- Single codebase ⇒ identical behavior on iOS app, Mobile Safari, desktop.

## Testing
- UAT 4109/4109 PASS (2 stale char-windows widened with comments).
- Live-verified: all 10 free gate paths show the modal, 15-Q set passes, Pro passthrough on every gate, pill show/hide matrix (free/pro/unresolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)