### PR TITLE
v7.46.1 — Pro-gate polish: de-slop modal, per-feature copy, pill consolidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.46.1 | Pro-gate polish — modal rebuilt in house design language, per-feature copy, pill consolidation |
 | v7.46.0 | Free-tier hard gates — exam sim, marathons, Deep Scan, Drill Mistakes Pro-only; custom quiz capped at 15 for free |
 | v7.45.0 | In-app account deletion — Settings danger-zone row + confirm flow, Apple 5.1.1(v) (GAP-6) |
 | v7.44.0 | Log-exam-result gated as Pro on /account per mockup (GAP-5) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.46.0
+// Network+ AI Quiz — app.js  v7.46.1
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.46.0';
+const APP_VERSION = '7.46.1';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -871,7 +871,7 @@ function _showDailyLimitPreblockUI(detail) {
 //
 // Returns true if the user is Pro/admin (proceed), false if Free (blocked +
 // modal shown). Pattern: `if (!_gateProOnly('Acronym Blitz')) return;`
-function _gateProOnly(featureLabel) {
+function _gateProOnly(featureLabel, opts) {
   // v4.99.7 — optimistic-allow for signed-in users while quota state is still
   // hydrating. Pre-v4.99.7, the default-deny path here caused signed-in Pro
   // users to briefly see the upgrade modal during the first ~500ms after page
@@ -880,48 +880,58 @@ function _gateProOnly(featureLabel) {
   // Subsequent gate checks (in start* functions or showPage on later nav)
   // fire after state has resolved with the correct verdict. Anonymous users
   // still default-deny since they're definitely not Pro.
+  // v7.46.1: opts {title, body} let call sites pass bespoke modal copy —
+  // the old "<label> is a Pro feature" template broke on plural labels.
+  var detail = Object.assign({ feature: featureLabel || 'this feature' }, opts || {});
   if (!_quotaState) {
     if (window._certanvilSignedIn === true) {
       // Optimistic allow; gate re-fires on actual activity start with real state
       return true;
     }
     // Anonymous → block
-    if (typeof _showProOnlyUI === 'function') {
-      _showProOnlyUI({ feature: featureLabel || 'this feature' });
-    }
+    if (typeof _showProOnlyUI === 'function') _showProOnlyUI(detail);
     return false;
   }
   // Pro / admin → daily_limit < 0 (unlimited) or tier === 'pro'
   if (_quotaState.tier === 'pro') return true;
   if (typeof _quotaState.daily_limit === 'number' && _quotaState.daily_limit < 0) return true;
   // Otherwise — Free user. Block.
-  if (typeof _showProOnlyUI === 'function') {
-    _showProOnlyUI({ feature: featureLabel || 'this feature' });
-  }
+  if (typeof _showProOnlyUI === 'function') _showProOnlyUI(detail);
   return false;
 }
 
 // v4.99.4 Phase E.4.1 — Pro-only modal. Distinct from quota-exceeded because
 // the value prop is different: "this is locked behind Pro" vs "you've used
-// your daily allowance." Shares the layout but has its own copy.
+// your daily allowance."
+// v7.46.1 — rebuilt in the daily-limit card family (lock mark, accent CTA)
+// so every gate in the app speaks one visual language. detail.title/body
+// carry per-feature copy; legacy callers fall back to the safe template.
 function _showProOnlyUI(detail) {
   detail = detail || {};
   var feature = detail.feature || 'This feature';
+  var title = detail.title || (feature + ' is a Pro feature');
+  var body = detail.body ||
+    'Free covers the daily core: 15 practice questions and 5 review cards, every day. This one is part of Pro.';
 
   var prev = document.getElementById('pro-only-modal');
   if (prev) prev.remove();
 
   var modal = document.createElement('div');
   modal.id = 'pro-only-modal';
-  modal.className = 'quota-exceeded-modal';  // reuse layout class
+  modal.className = 'quota-exceeded-modal';  // reuse overlay scrim
   modal.innerHTML =
-    '<div class="quota-exceeded-card pro-only-card">' +
-      '<div class="quota-exceeded-icon pro-only-icon">&#9889;</div>' +
-      '<div class="quota-exceeded-title">' + feature + ' is a Pro feature</div>' +
-      '<div class="quota-exceeded-sub">The Exam Simulator, marathon sets, Deep Scan, and drills are all part of Pro. Free is 15 practice questions plus 5 review cards a day, every day. Upgrade to unlock everything.</div>' +
-      '<div class="quota-exceeded-actions">' +
-        '<a class="quota-exceeded-cta" href="https://certanvil.com/pricing" target="_blank" rel="noopener">Upgrade to Pro &middot; $9.99/mo &rarr;</a>' +
-        '<button type="button" class="quota-exceeded-dismiss" id="pro-only-dismiss">Maybe later</button>' +
+    '<div class="dlpb-card" role="dialog" aria-modal="true" aria-label="Pro feature">' +
+      '<div class="dlpb-lockmark" aria-hidden="true">' +
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">' +
+          '<rect x="4" y="11" width="16" height="9" rx="2.5"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path>' +
+        '</svg>' +
+      '</div>' +
+      '<h2 class="dlpb-title">' + title + '</h2>' +
+      '<p class="dlpb-lede">' + body + '</p>' +
+      '<p class="dlpb-pro-line"><b>Pro</b> is unlimited questions, every day, on every cert.</p>' +
+      '<div class="dlpb-actions">' +
+        '<a class="dlpb-cta" href="https://certanvil.com/pricing" target="_blank" rel="noopener">Go Pro &mdash; unlimited</a>' +
+        '<button type="button" class="dlpb-ghost" id="pro-only-dismiss">Not now</button>' +
       '</div>' +
     '</div>';
   document.body.appendChild(modal);
@@ -943,7 +953,12 @@ document.addEventListener('click', function (e) {
   if (typeof _srIsFreeTier === 'function' && _srIsFreeTier()) {
     e.preventDefault();
     e.stopPropagation();
-    if (typeof _gateProOnly === 'function') _gateProOnly('Going past 15 questions per set');
+    if (typeof _gateProOnly === 'function') {
+      _gateProOnly('Bigger sets', {
+        title: 'Bigger sets are a Pro feature',
+        body: 'Free tops out at 15 questions a set — your whole daily allowance in one go. Pro goes as big as you like.'
+      });
+    }
   }
 }, true);
 
@@ -6280,7 +6295,10 @@ function clearWrongBank() {
 // wrong-bank). If every answer was correct the button is hidden upstream.
 function drillMistakesFromResults() {
   // v7.46.0: Drill Mistakes is Pro-only — same gate as startWrongDrill
-  if (typeof _gateProOnly === 'function' && !_gateProOnly('Drill Mistakes')) return;
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Drill Mistakes', {
+    title: 'Drill Mistakes is a Pro feature',
+    body: 'Re-run the questions you got wrong until they stick. Your wrong-answer bank keeps saving either way — the drill itself is Pro.'
+  })) return;
   if (!Array.isArray(log) || log.length === 0) return;
   const wrongEntries = log.filter(e => e && e.isRight === false);
   if (wrongEntries.length === 0) {
@@ -6337,7 +6355,10 @@ function _renderResultsReviewList() {
 
 function startWrongDrill() {
   // v7.46.0: Drill Mistakes is Pro-only (Simi, 2026-06-11)
-  if (typeof _gateProOnly === 'function' && !_gateProOnly('Drill Mistakes')) return;
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Drill Mistakes', {
+    title: 'Drill Mistakes is a Pro feature',
+    body: 'Re-run the questions you got wrong until they stick. Your wrong-answer bank keeps saving either way — the drill itself is Pro.'
+  })) return;
   const bank = loadWrongBank();
   if (bank.length === 0) {
     alert('No wrong answers saved yet. Keep quizzing!');
@@ -6480,7 +6501,10 @@ async function startQuiz() {
   // allowance in one set (Simi, 2026-06-11). The count-chip interceptor
   // blocks the picker; this is the enforcement behind it.
   if (qCount > 15 && typeof _srIsFreeTier === 'function' && _srIsFreeTier()) {
-    if (!_gateProOnly('Going past 15 questions per set')) return;
+    if (!_gateProOnly('Bigger sets', {
+      title: 'Bigger sets are a Pro feature',
+      body: 'Free tops out at 15 questions a set — your whole daily allowance in one go. Pro goes as big as you like.'
+    })) return;
   }
   if (!_gateSessionSizeForQuota(qCount, { mode: 'quiz' })) return;
   const key = document.getElementById('api-key').value.trim();
@@ -6883,7 +6907,10 @@ function _formatElapsed(ms) {
 async function startExam() {
   // v7.46.0: the Exam Simulator is Pro-only (Simi, 2026-06-11). The quota
   // and size gates below only matter for Pro edge states now.
-  if (!_gateProOnly('The Exam Simulator')) return;
+  if (!_gateProOnly('The Exam Simulator', {
+    title: 'The Exam Simulator is a Pro feature',
+    body: '90 questions against a 90-minute clock, scored 100–900 like test day. Free covers your daily practice; the full rehearsal is Pro.'
+  })) return;
   if (!_gateActivityForQuota('exam simulator')) return;
   if (!_gateSessionSizeForQuota(90, { mode: 'exam' })) return;
   const key = document.getElementById('api-key').value.trim();
@@ -10808,13 +10835,32 @@ function startStreakSave() {
 function applyPreset(name) {
   // v7.46.0: Deep Scan + all marathon presets are Pro-only (Simi, 2026-06-11).
   // Free stays on Warmup (5), Focused (10), and custom sets up to 15.
+  // v7.46.1: per-preset modal copy (the shared template broke on plurals).
   const PRO_PRESETS = {
-    grind: 'The 20-min Deep Scan',
-    bulk30: '30-question marathons',
-    bulk45: '45-question marathons',
-    bulk60: 'The 60-Question SIM'
+    grind: {
+      feature: 'The 20-min Deep Scan',
+      title: 'The Deep Scan is a Pro feature',
+      body: '20 exam-level questions across every topic in one sitting — more than the free day holds.'
+    },
+    bulk30: {
+      feature: 'The 30-question marathon',
+      title: 'The 30-question marathon is a Pro feature',
+      body: 'One marathon burns past the free day’s 15 questions. Pro takes the cap off.'
+    },
+    bulk45: {
+      feature: 'The 45-question marathon',
+      title: 'The 45-question marathon is a Pro feature',
+      body: 'One marathon burns past the free day’s 15 questions. Pro takes the cap off.'
+    },
+    bulk60: {
+      feature: 'The 60-Question SIM',
+      title: 'The 60-Question SIM is a Pro feature',
+      body: 'The closest thing to the real exam, minus the timer. Full-length sims are Pro.'
+    }
   };
-  if (PRO_PRESETS[name] && typeof _gateProOnly === 'function' && !_gateProOnly(PRO_PRESETS[name])) return;
+  const _proPreset = PRO_PRESETS[name];
+  if (_proPreset && typeof _gateProOnly === 'function' &&
+      !_gateProOnly(_proPreset.feature, { title: _proPreset.title, body: _proPreset.body })) return;
   // Bulk Mixed presets — large counts that exceed the single-call ceiling are
   // batched via startBulkQuiz so the AI never gets asked for >20 Qs at once.
   const bulkSizes = { bulk30: 30, bulk45: 45, bulk60: 60 };
@@ -11171,7 +11217,10 @@ async function startBulkQuiz(count) {
   // v7.46.0: marathons are Pro-only — belt behind the applyPreset gate so a
   // direct startBulkQuiz() call can't sidestep it. The GAP-2 gates below
   // only matter for Pro edge states now.
-  if (typeof _gateProOnly === 'function' && !_gateProOnly('Marathon sets')) return;
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Marathon sets', {
+    title: 'Marathon sets are a Pro feature',
+    body: 'One marathon burns past the free day’s 15 questions. Pro takes the cap off.'
+  })) return;
   // GAP-2: bulk presets previously had no quota gate (free user would 429 mid-run)
   if (!_gateActivityForQuota('practice quizzes')) return;
   if (!_gateSessionSizeForQuota(count, { mode: 'bulk' })) return;

--- a/index.html
+++ b/index.html
@@ -396,25 +396,25 @@
       <!-- CELL 5 · practice. Deep Scan / 30Q / 45Q. -->
       <section class="tile lift cell-practice reveal" style="--d:4">
         <div class="tile-head">
-          <div><h3 class="tile-title">Practice</h3><p class="tile-sub" id="prac-note">Focused study on your weak spots</p></div>
+          <div><h3 class="tile-title">Practice <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></h3><p class="tile-sub" id="prac-note">Focused study on your weak spots</p></div>
           <span class="meta" id="prac-range">10-30 min</span>
         </div>
         <div class="opts cols2" id="grp-practice">
-          <button type="button" class="opt" onclick="applyPreset('grind')"><span class="on">20-min Deep Scan <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">20 questions, exam level, mixed</span></button>
-          <button type="button" class="opt" onclick="applyPreset('bulk30')"><span class="on">30 Questions <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">Marathon mixed, about 25 min</span></button>
-          <button type="button" class="opt" onclick="applyPreset('bulk45')"><span class="on">45 Questions <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">Marathon mixed, about 38 min</span></button>
+          <button type="button" class="opt" onclick="applyPreset('grind')"><span class="on">20-min Deep Scan</span><span class="od">20 questions, exam level, mixed</span></button>
+          <button type="button" class="opt" onclick="applyPreset('bulk30')"><span class="on">30 Questions</span><span class="od">Marathon mixed, about 25 min</span></button>
+          <button type="button" class="opt" onclick="applyPreset('bulk45')"><span class="on">45 Questions</span><span class="od">Marathon mixed, about 38 min</span></button>
         </div>
       </section>
 
       <!-- CELL 6 · exam simulation. 60-Q SIM / Full Exam. -->
       <section class="tile lift tile-exam cell-exam reveal" style="--d:4">
         <div class="tile-head">
-          <div><h3 class="tile-title">Exam <i>simulation</i></h3><p class="tile-sub" id="exam-note">Pressure-test your readiness, scored 100-900</p></div>
+          <div><h3 class="tile-title">Exam <i>simulation</i> <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></h3><p class="tile-sub" id="exam-note">Pressure-test your readiness, scored 100-900</p></div>
           <span class="meta" id="exam-range">60-90 min</span>
         </div>
         <div class="opts cols2" id="grp-exam">
-          <button type="button" class="opt" onclick="applyPreset('bulk60')"><span class="on">60-Question SIM <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">Closest to the real thing, no timer</span></button>
-          <button type="button" class="opt" onclick="startExam()"><span class="on">Full Exam Simulator <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="od">90 questions, 90-min timer, scored 100-900</span></button>
+          <button type="button" class="opt" onclick="applyPreset('bulk60')"><span class="on">60-Question SIM</span><span class="od">Closest to the real thing, no timer</span></button>
+          <button type="button" class="opt" onclick="startExam()"><span class="on">Full Exam Simulator</span><span class="od">90 questions, 90-min timer, scored 100-900</span></button>
         </div>
       </section>
 
@@ -762,7 +762,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.46.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.46.1</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.46.0",
+  "version": "7.46.1",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.46.0
+   Network+ AI Quiz — styles.css  v7.46.1
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -14012,9 +14012,13 @@ body.is-pro-tier .tier-free-only { display: none !important; }
   stroke: currentColor; fill: none;
   stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round;
 }
-/* v7.46.0: pill variants inside home tiles + custom-quiz count chips */
+/* v7.46.1: pill placement — one pill per locked tile head (not per row),
+   and the 20-count chip swaps its "~20 min" sub for the pill on free so
+   the chip never stacks three lines. */
+.tile-title .pro-lock-pill { font-size: 8px; padding: 3px 6px; vertical-align: 2px; }
 .opt .on .pro-lock-pill { font-size: 8px; padding: 3px 6px; margin-left: 4px; }
 .chip-count .chip-count-pro { font-size: 8px; padding: 3px 6px; margin: 4px auto 0; }
+body.is-state-resolved:not(.is-pro-tier) #count-group .chip[data-v="20"] .chip-count-sub { display: none; }
 .settings-lock-bignum {
   display: flex;
   align-items: baseline;

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.46.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.46.0';
+// Service Worker v7.46.1 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.46.1';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -7879,7 +7879,7 @@ test('v5.5.8 StreakRedesign: sidebar streak render = brand flame + Longest sub, 
 test('bento HTML: 3 commitment tiles (quick / practice / exam simulation)',
   html.includes('id="grp-quick"') && html.includes('id="grp-practice"') && html.includes('id="grp-exam"')
     && /class="tile-title">Quick start</.test(html)
-    && /class="tile-title">Practice</.test(html)
+    && /class="tile-title">Practice[ <]/.test(html)  // v7.46.1: free-tier PRO pill may follow the title
     && /class="tile-title">Exam <i>simulation<\/i>/.test(html));
 test('v4.76.0 HTML: Daily Challenge tile in Quick tier', html.includes('id="modes-dc-tile"'));
 test('v4.76.0 HTML: Drill Mistakes tile in Quick tier', html.includes('id="modes-wrong-tile"'));
@@ -15200,13 +15200,13 @@ test('v4.99.3 gate: startExam protected',
 // v4.99.4: drill entry points now use _gateProOnly (drills are Pro-only).
 // Quizzes (startQuiz/startExam) still use _gateActivityForQuota (20/day quota).
 test('v4.99.4 ProOnly: _gateProOnly helper defined',
-  /function _gateProOnly\(featureLabel\)/.test(js));
+  /function _gateProOnly\(featureLabel, opts\)/.test(js));  // v7.46.1: opts carries per-feature modal copy
 test('v4.99.4 ProOnly: _showProOnlyUI modal helper defined',
   /function _showProOnlyUI\(/.test(js));
 // v4.99.7 — softened from hard default-deny to anonymous-only default-deny.
 // Signed-in users now optimistic-allow during state hydration (race fix).
 test('v4.99.4 ProOnly: anonymous users denied when quotaState is null (safe default)',
-  /_gateProOnly[\s\S]{0,800}!_quotaState[\s\S]{0,400}window\._certanvilSignedIn === true[\s\S]{0,300}return false/.test(js));
+  /_gateProOnly[\s\S]{0,1300}!_quotaState[\s\S]{0,400}window\._certanvilSignedIn === true[\s\S]{0,300}return false/.test(js));  // window 800→1300: v7.46.1 detail/opts preamble
 test('v4.99.4 ProOnly: modal links to upgrade page',
   /pro-only-modal[\s\S]{0,1000}certanvil\.com\/pricing/.test(js));
 
@@ -15306,7 +15306,7 @@ test('v4.99.7 ShowPageGate: topic-dive Back no longer raw-toggles .active class'
 test('v4.99.7 ShowPageGate: guided-lab Back no longer raw-toggles .active class',
   !/getElementById\('page-guided-lab'\)\.classList\.remove\('active'\)/.test(js));
 test('v4.99.7 GateRace: _gateProOnly optimistic-allows signed-in users when _quotaState pending',
-  /function _gateProOnly[\s\S]{0,800}window\._certanvilSignedIn === true[\s\S]{0,200}return true/.test(js));
+  /function _gateProOnly[\s\S]{0,1300}window\._certanvilSignedIn === true[\s\S]{0,200}return true/.test(js));  // window 800→1300: v7.46.1 detail/opts preamble
 test('v4.99.7 GateRace: anonymous users still default-deny in _gateProOnly',
   /function _gateProOnly[\s\S]{0,1200}_showProOnlyUI\([\s\S]{0,200}return false/.test(js));
 test('v4.99.7 QuotaModal: countdown shows "(midnight UTC)" clarifier',


### PR DESCRIPTION
## Summary
Four-pass polish (design-taste → emil → humanizer → marketing-psychology) on the free-tier gate surfaces:
- Upgrade modal rebuilt in the house card family (bronze lock, accent CTA, animation) — no more emoji icon or purple gradient.
- Per-feature modal copy with fixed grammar; concrete value statements instead of "Upgrade to unlock everything".
- PRO pills consolidated to tile heads (2 instead of 5); count-chip pill placement fixed.

## Testing
- UAT 4109/4109 PASS (4 stale pins updated with comments).
- Live-verified all 9 gate paths show grammatical titles, pill counts, Pro passthrough unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)