### PR TITLE
v7.48.0 — Reword Gauntlet: the flagship drill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.48.0 | Reword Gauntlet — flagship drill: one concept five ways, crack on 5/5, Pro-only |
 | v7.47.0 | Mistake Autopsy — wrong-bank questions return re-worded, beating the concept not the question |
 | v7.46.1 | Pro-gate polish — modal rebuilt in house design language, per-feature copy, pill consolidation |
 | v7.46.0 | Free-tier hard gates — exam sim, marathons, Deep Scan, Drill Mistakes Pro-only; custom quiz capped at 15 for free |

--- a/app.js
+++ b/app.js
@@ -6661,10 +6661,10 @@ async function gauntletStart(opts) {
   if (_gauntletBusy) return; // double-tap guard
   if (typeof _gateProOnly === 'function' && !_gateProOnly('Reword Gauntlet', {
     title: 'The Reword Gauntlet is a Pro feature',
-    body: 'One concept, asked five ways — crack all five and you own it in any wording. Go Pro to run the Gauntlet on every cert in the library.'
+    body: 'One concept, asked five ways. Crack all five and you own it in any wording. Go Pro to run the Gauntlet on every cert in the library.'
   })) return;
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
-    showToast('The Gauntlet forges fresh questions — it needs a connection.', 'info');
+    showToast('The Gauntlet forges fresh questions, so it needs a connection.', 'info');
     return;
   }
   if (typeof _canMakeMeteredCall === 'function' && !_canMakeMeteredCall('Reword Gauntlet')) return;
@@ -6696,7 +6696,7 @@ async function gauntletStart(opts) {
     if (typeof _loadingProgressFinish === 'function') { try { _loadingProgressFinish(); } catch (_) {} }
     renderGauntletEntry();
     showPage('gauntlet');
-    try { showToast('The forge misfired — nothing was used. Hit Start to try again.', 'error'); } catch (_) {}
+    try { showToast('The forge misfired. Nothing was used up. Hit Start to try again.', 'error'); } catch (_) {}
     return;
   }
   if (typeof _loadingProgressFinish === 'function') { try { _loadingProgressFinish(); } catch (_) {} }
@@ -6742,11 +6742,22 @@ function _renderGauntletLadder() {
   }
   if (dots) dots.classList.add('is-hidden');
   el.classList.remove('is-hidden');
-  el.innerHTML = GAUNTLET_RUNGS.map((r, i) => {
+  // Build the five rung nodes ONCE, then reconcile classes in place — an
+  // innerHTML rebuild would restart the bar-fill transition on every
+  // already-done rung at each advance (emil pass 2, 2026-06-12).
+  if (el.children.length !== GAUNTLET_RUNGS.length) {
+    el.innerHTML = GAUNTLET_RUNGS.map(r =>
+      '<div class="gnt-rung"><div class="gnt-rung-bar"><i></i></div><div class="gnt-rung-name">' + r.key + '</div></div>'
+    ).join('');
+  }
+  GAUNTLET_RUNGS.forEach((r, i) => {
+    const node = el.children[i];
+    if (!node) return;
     const res = _gauntletRun.results[i];
-    const cls = 'gnt-rung' + (res === true ? ' done' : '') + (res === false ? ' missed' : '') + (i === current && current < GAUNTLET_RUNGS.length ? ' live' : '');
-    return '<div class="' + cls + '"><div class="gnt-rung-bar"><i></i></div><div class="gnt-rung-name">' + r.key + '</div></div>';
-  }).join('');
+    node.classList.toggle('done', res === true);
+    node.classList.toggle('missed', res === false);
+    node.classList.toggle('live', i === current && current < GAUNTLET_RUNGS.length);
+  });
   if (chip) {
     chip.textContent = GAUNTLET_RUNGS[current] ? GAUNTLET_RUNGS[current].key : '';
     chip.classList.toggle('is-hidden', !GAUNTLET_RUNGS[current]);
@@ -6876,7 +6887,8 @@ function renderGauntletDrillsCard() {
   const pill = document.getElementById('drills-gauntlet-pill');
   if (!pill) return;
   const n = loadGauntletCracked().length;
-  pill.textContent = n === 1 ? '1 cracked' : n + ' cracked';
+  // Zero-state invites instead of anchoring on no progress (marketing pass 4)
+  pill.textContent = n === 0 ? 'Flagship drill' : (n === 1 ? '1 cracked' : n + ' cracked');
 }
 
 // ══════════════════════════════════════════

--- a/app.js
+++ b/app.js
@@ -1034,6 +1034,7 @@ const STORAGE = {
   SUBNET_STATS: 'nplus_subnet_stats',
   DAILY_GOAL: 'nplus_daily_goal',
   DAILY_CHALLENGE: 'nplus_daily_challenge',
+  GAUNTLET_CRACKED: 'nplus_gauntlet_cracked', // v7.48.0 Reword Gauntlet: [{concept, topic, certId, date, attempts}]
   DEEP_DIVE_USES: 'nplus_deep_dive_uses',
   ERROR_LOG: 'nplus_error_log',
   GH_TOKEN: 'nplus_gh_monitor_token',
@@ -1151,6 +1152,12 @@ let qCount     = 10;
 let apiKey     = '';
 let wrongDrillMode = false;
 let dailyChallengeMode = false;
+
+// v7.48.0 — Reword Gauntlet run state
+let gauntletMode = false;     // a gauntlet run is riding the quiz engine
+let _gauntletRun = null;      // { concept, topic, results: [bool x5], attempts }
+let _gauntletBusy = false;    // in-flight guard: double-tap on Start
+let _gauntletTopic = null;    // entry-screen topic override (null = weakest)
 
 // Multi-select state (regular quiz)
 let msSelections = [];
@@ -2437,6 +2444,11 @@ function goSetup() {
   examMode = false;
   wrongDrillMode = false;
   dailyChallengeMode = false;
+  // v7.48.0: quitting a gauntlet mid-run (confirmBack → goSetup) = no crack,
+  // no penalty. Reset the mode + restore the standard quiz chrome.
+  gauntletMode = false;
+  _gauntletRun = null;
+  if (typeof _renderGauntletLadder === 'function') { try { _renderGauntletLadder(); } catch (_) {} }
   navOpen = false;
   // v4.54.1: renderHistoryPanel moved to renderAnalytics (Recent Performance now lives on Analytics page)
   renderStatsCard();
@@ -3546,6 +3558,9 @@ function saveWrongBank(bank) {
 }
 
 function addToWrongBank(q, chosen) {
+  // v7.48.0: Gauntlet runs are parallel to the wrong-bank loop — a gauntlet
+  // miss is answered by "Run it again" (fresh wordings), not bank/SR enrolment.
+  if (typeof gauntletMode !== 'undefined' && gauntletMode) return;
   // v4.74.0: also enroll into the spaced-repetition queue. SR runs ahead
   // of the dedup check below — we WANT a repeated miss on the same
   // question to re-trigger SR (resets interval, drops ease) even though
@@ -6516,6 +6531,355 @@ function getWeakTopic() {
 // getWeakTopic() is still used by applyPreset('focused') as a fallback.
 
 // ══════════════════════════════════════════
+// REWORD GAUNTLET (v7.48.0) — the flagship drill
+// ══════════════════════════════════════════
+// Research-verified pain (FLAGSHIP-DRILL-RESEARCH-2026-06-11): candidates
+// memorize questions, real exams re-word concepts. The Gauntlet asks ONE
+// AI-picked concept five ways — Plain → Scenario → Best-of → Not-trap →
+// Twisted. The run always finishes all five rungs; the concept cracks only
+// on a clean 5/5. A miss names the rung type that got you; "Run it again"
+// regenerates five fresh wordings (the retry IS the anti-memorization demo).
+// Pro-only at Start; parallel to the wrong-bank/SR loop in v1.
+const GAUNTLET_RUNGS = [
+  { key: 'Plain',    sub: 'Straight definition' },
+  { key: 'Scenario', sub: 'Real-world setup' },
+  { key: 'Best-of',  sub: 'One word decides it' },
+  { key: 'Not-trap', sub: 'The negation flip' },
+  { key: 'Twisted',  sub: 'Trickiest phrasing' }
+];
+
+function loadGauntletCracked() {
+  try { return JSON.parse(localStorage.getItem(STORAGE.GAUNTLET_CRACKED) || '[]'); } catch (e) { return []; }
+}
+
+// Entry points (Drills hero card + Home Practice tile). The entry screen is
+// viewable by free users (funnel tease) — the Pro gate fires on Start.
+function startRewordGauntlet() {
+  _gauntletTopic = null;
+  renderGauntletEntry();
+  showPage('gauntlet');
+}
+
+function renderGauntletEntry() {
+  const w = getWeakTopic();
+  let topicName = _gauntletTopic || (w && w.topic) || null;
+  if (!topicName && typeof getTodaysFocusTopics === 'function') {
+    const f = getTodaysFocusTopics(1);
+    const first = Array.isArray(f) ? f[0] : null;
+    topicName = typeof first === 'string' ? first : (first && first.topic) || null;
+  }
+  if (!topicName) topicName = Object.keys((typeof TOPIC_DOMAINS !== 'undefined' && TOPIC_DOMAINS) || {})[0] || MIXED_TOPIC;
+  const nameEl = document.getElementById('gnt-topic-name');
+  if (nameEl) nameEl.textContent = topicName;
+  const whyEl = document.getElementById('gnt-topic-why');
+  if (whyEl) whyEl.textContent = _gauntletTopic ? 'Your pick' : ((w && w.topic === topicName) ? 'Your weakest topic right now' : 'A good place to start');
+  const n = loadGauntletCracked().length;
+  const row = document.getElementById('gnt-cracked-row');
+  if (row) row.classList.toggle('is-hidden', n === 0);
+  const nEl = document.getElementById('gnt-cracked-n');
+  if (nEl) nEl.textContent = n;
+  const listEl = document.getElementById('gnt-topic-list');
+  if (listEl) listEl.classList.add('is-hidden');
+}
+
+function gauntletToggleTopicList() {
+  const el = document.getElementById('gnt-topic-list');
+  if (!el) return;
+  if (!el.classList.contains('is-hidden')) { el.classList.add('is-hidden'); return; }
+  const topics = Object.keys((typeof TOPIC_DOMAINS !== 'undefined' && TOPIC_DOMAINS) || {});
+  el.innerHTML = topics.map(t =>
+    // data-action delegation (Sec-P7): no inline onclick in generated HTML
+    '<button type="button" class="gnt-topic-opt" data-action="gauntletChooseTopic" data-args="' + escAttr(JSON.stringify([t])) + '">' + escHtml(t) + '</button>'
+  ).join('');
+  el.classList.remove('is-hidden');
+}
+
+function gauntletChooseTopic(t) {
+  _gauntletTopic = t;
+  renderGauntletEntry();
+}
+
+// One metered call per run (Approach A, approved): weakest topic + the
+// cert's exemplar slice (style grounding) + the 5-rung recipe. The model
+// picks ONE precise testable concept inside the topic, then writes all five
+// rungs about THAT concept. Cert-agnostic: inputs are CERT_PACK topics +
+// exemplars only.
+async function _fetchGauntletRun(topicName, forcedConcept) {
+  const exemplars = (typeof _pickExemplarsForTopic === 'function') ? _pickExemplarsForTopic(topicName, 3) : [];
+  const exemplarBlock = (exemplars && exemplars.length && typeof _formatExemplarsForPrompt === 'function')
+    ? _formatExemplarsForPrompt(exemplars) : '';
+  const rungSpecs =
+    '1. Plain — a direct, plainly worded question on the concept. hinge = the concept term itself.\n' +
+    '2. Scenario — a short real-world scenario (2-3 sentences) where the concept is the answer. hinge = the scenario detail that points to the concept.\n' +
+    '3. Best-of — several options are partially workable; a BEST/MOST-style qualifier decides it. hinge = the qualifier word.\n' +
+    '4. Not-trap — a negation question (NOT / EXCEPT / LEAST). hinge = the negation word.\n' +
+    '5. Twisted — the trickiest wording: inverted framing, double qualifier, or distractor-heavy phrasing. hinge = the word or phrase the whole question pivots on.';
+  const prompt = (forcedConcept
+      ? 'Write a fresh 5-question "Reword Gauntlet" run about this exact concept: "' + forcedConcept + '" (exam topic: ' + topicName + '). Brand-new wordings — reuse nothing from any previous phrasing.\n\n'
+      : 'Pick ONE precise, testable concept inside the certification exam topic "' + topicName + '" — a single fact or decision a candidate must know cold, not the whole topic. Then write a 5-question "Reword Gauntlet" run about THAT concept only.\n\n') +
+    'All five questions test the SAME concept and the SAME underlying fact, each in a different disguise:\n' + rungSpecs + '\n\n' +
+    'Rules: 4 plausible options per question (plain text, no letter prefixes), exactly one correct, vary which position is correct across the five. ' +
+    'The hinge must be copied VERBATIM from that question\'s own text. Add a 1-2 sentence explanation per question that says why the hinge decides it.\n' +
+    (exemplarBlock ? '\n' + exemplarBlock + '\n' : '') +
+    '\nReturn ONLY JSON:\n{"concept":"...","rungs":[{"question":"...","options":["...","...","...","..."],"answer":"A","explanation":"...","hinge":"..."}]}\n' +
+    '"answer" is the letter (A-D) of the correct option by position. Exactly 5 rungs, in the order above.';
+
+  const res = await _claudeFetch({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true'
+    },
+    // _metered: true — counts toward quota + the global kill-switch.
+    body: JSON.stringify({ model: CLAUDE_MODEL, max_tokens: MAX_TOKENS_GENERATION, messages: [{ role: 'user', content: prompt }], _metered: true })
+  });
+  if (!res.ok) throw new Error('gauntlet API error ' + res.status);
+  const data = await res.json();
+  const raw = (data.content && data.content[0] && data.content[0].text) || '';
+  const m = raw.match(/\{[\s\S]*\}/);
+  if (!m) throw new Error('gauntlet: no JSON object in response');
+  const parsed = JSON.parse(m[0]);
+  // Per-rung shape validation — any bad rung fails the WHOLE run (a 4-rung
+  // gauntlet would be a lie). Caller shows a friendly retry; nothing recorded.
+  const rungs = (parsed && Array.isArray(parsed.rungs)) ? parsed.rungs : [];
+  const ok = parsed && typeof parsed.concept === 'string' && parsed.concept.length >= 3 &&
+    rungs.length === 5 && rungs.every(r =>
+      r && typeof r.question === 'string' && r.question.length > 20 &&
+      Array.isArray(r.options) && r.options.length === 4 &&
+      typeof r.answer === 'string' && /^[A-D]$/.test(r.answer.trim().toUpperCase()) &&
+      typeof r.explanation === 'string' && r.explanation.length > 0 &&
+      typeof r.hinge === 'string' && r.hinge.length > 0);
+  if (!ok) throw new Error('gauntlet: malformed run shape');
+  return { concept: parsed.concept, rungs };
+}
+
+// Start CTA. opts: { topic, concept, attempts } — used by the retry paths.
+async function gauntletStart(opts) {
+  opts = opts || {};
+  if (_gauntletBusy) return; // double-tap guard
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Reword Gauntlet', {
+    title: 'The Reword Gauntlet is a Pro feature',
+    body: 'One concept, asked five ways — crack all five and you own it in any wording. Go Pro to run the Gauntlet on every cert in the library.'
+  })) return;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    showToast('The Gauntlet forges fresh questions — it needs a connection.', 'info');
+    return;
+  }
+  if (typeof _canMakeMeteredCall === 'function' && !_canMakeMeteredCall('Reword Gauntlet')) return;
+
+  let topicName = opts.topic || _gauntletTopic || null;
+  if (!topicName) { const w = getWeakTopic(); topicName = (w && w.topic) || null; }
+  if (!topicName && typeof getTodaysFocusTopics === 'function') {
+    const f = getTodaysFocusTopics(1);
+    const first = Array.isArray(f) ? f[0] : null;
+    topicName = typeof first === 'string' ? first : (first && first.topic) || null;
+  }
+  if (!topicName) topicName = Object.keys((typeof TOPIC_DOMAINS !== 'undefined' && TOPIC_DOMAINS) || {})[0] || MIXED_TOPIC;
+
+  apiKey = (document.getElementById('api-key') || { value: '' }).value.trim();
+  _gauntletBusy = true;
+  const lp = document.getElementById('load-progress');
+  if (lp) lp.classList.add('is-hidden');
+  showPage('loading');
+  const lm = document.getElementById('loading-msg');
+  if (lm) lm.textContent = 'Forging five disguises…';
+  if (typeof _loadingProgressBegin === 'function') _loadingProgressBegin('Forging five disguises…');
+
+  let run;
+  try {
+    run = await _fetchGauntletRun(topicName, opts.concept || null);
+  } catch (e) {
+    // Friendly error + retry — no crack, no attempt, nothing recorded.
+    _gauntletBusy = false;
+    if (typeof _loadingProgressFinish === 'function') { try { _loadingProgressFinish(); } catch (_) {} }
+    renderGauntletEntry();
+    showPage('gauntlet');
+    try { showToast('The forge misfired — nothing was used. Hit Start to try again.', 'error'); } catch (_) {}
+    return;
+  }
+  if (typeof _loadingProgressFinish === 'function') { try { _loadingProgressFinish(); } catch (_) {} }
+  _gauntletBusy = false;
+
+  _gauntletRun = { concept: run.concept, topic: topicName, results: [], attempts: (opts.attempts || 0) + 1 };
+  gauntletMode = true;
+  wrongDrillMode = false;
+  examMode = false;
+  sessionMode = false;
+  activeQuizTopic = topicName;
+  questions = run.rungs.map((r, i) => ({
+    question: r.question,
+    options: r.options,
+    answer: r.answer.trim().toUpperCase(),
+    explanation: r.explanation,
+    hinge: r.hinge,
+    topic: topicName,
+    difficulty: 'Exam Level',
+    type: 'mcq',
+    _rung: i
+  }));
+  current = 0; score = 0; streak = 0; bestStreak = 0; answered = 0; log = [];
+  quizFlags = new Array(questions.length).fill(false);
+  _sessionStartTs = Date.now();
+  showCacheNotice(false);
+  showPage('quiz');
+  render();
+  _renderGauntletLadder();
+}
+
+// The rung ladder rides the quiz page in place of the numbered dot strip.
+function _renderGauntletLadder() {
+  const el = document.getElementById('gauntlet-ladder');
+  const dots = document.getElementById('quiz-prog-dots');
+  const chip = document.getElementById('gauntlet-rung-chip');
+  if (!el) return;
+  if (!gauntletMode || !_gauntletRun) {
+    el.classList.add('is-hidden');
+    if (dots) dots.classList.remove('is-hidden');
+    if (chip) chip.classList.add('is-hidden');
+    return;
+  }
+  if (dots) dots.classList.add('is-hidden');
+  el.classList.remove('is-hidden');
+  el.innerHTML = GAUNTLET_RUNGS.map((r, i) => {
+    const res = _gauntletRun.results[i];
+    const cls = 'gnt-rung' + (res === true ? ' done' : '') + (res === false ? ' missed' : '') + (i === current && current < GAUNTLET_RUNGS.length ? ' live' : '');
+    return '<div class="' + cls + '"><div class="gnt-rung-bar"><i></i></div><div class="gnt-rung-name">' + r.key + '</div></div>';
+  }).join('');
+  if (chip) {
+    chip.textContent = GAUNTLET_RUNGS[current] ? GAUNTLET_RUNGS[current].key : '';
+    chip.classList.toggle('is-hidden', !GAUNTLET_RUNGS[current]);
+  }
+}
+
+// Highlight the hinge word in the rendered stem after answering.
+// Escape-THEN-highlight, same contract as setQuestionText (XSS: AI text).
+function _gauntletApplyHinge(q) {
+  if (!q || !q.hinge) return;
+  const el = document.getElementById('q-text');
+  if (!el) return;
+  const esc = escHtml(q.question);
+  const escHinge = escHtml(q.hinge);
+  if (escHinge && esc.indexOf(escHinge) !== -1) {
+    el.innerHTML = esc.replace(escHinge, '<mark class="gnt-hinge">' + escHinge + '</mark>');
+  }
+}
+
+// Run complete (all 5 rungs answered). Crack only on a clean 5/5 of FIRST
+// answers. History entry feeds Today's goal + topic signal; streak credits
+// like any finished session.
+function _finishGauntlet() {
+  const results = GAUNTLET_RUNGS.map((_, i) => _gauntletRun.results[i] === true);
+  const crackCount = results.filter(Boolean).length;
+  const cracked = crackCount === 5;
+  const total = questions.length;
+  const pct = total > 0 ? Math.round((crackCount / total) * 100) : 0;
+  try { saveToHistory({ date: new Date().toISOString(), topic: _gauntletRun.topic, difficulty: 'Exam Level', score: crackCount, total, pct, mode: 'gauntlet' }); } catch (_) {}
+  try { updateStreak(); renderStreakBadge(); } catch (_) {}
+  if (cracked) {
+    try {
+      const list = loadGauntletCracked();
+      list.unshift({
+        concept: _gauntletRun.concept,
+        topic: _gauntletRun.topic,
+        certId: (typeof CURRENT_CERT !== 'undefined' && CURRENT_CERT) || 'netplus',
+        date: new Date().toISOString(),
+        attempts: _gauntletRun.attempts
+      });
+      localStorage.setItem(STORAGE.GAUNTLET_CRACKED, JSON.stringify(list));
+      _cloudFlush(STORAGE.GAUNTLET_CRACKED);
+    } catch (_) { try { showToast('Storage full — crack not saved', 'error'); } catch (_) {} }
+  }
+  try { if (typeof _writeReadinessSnapshot === 'function') _writeReadinessSnapshot(); } catch (_) {}
+  try { renderStatsCard(); renderReadinessCard(); } catch (_) {}
+  try { if (typeof _maybeShowDailyRecap === 'function') _maybeShowDailyRecap(); } catch (_) {}
+  gauntletMode = false;
+  _renderGauntletLadder();
+  renderGauntletResult(cracked, results);
+  showPage('gauntlet-result');
+}
+
+function renderGauntletResult(cracked, results) {
+  const root = document.getElementById('gnt-result-root');
+  if (!root) return;
+  if (cracked) {
+    const n = loadGauntletCracked().length;
+    const subLine = _gauntletRun.attempts > 1
+      ? 'Took ' + _gauntletRun.attempts + ' runs. <b>Earned.</b>'
+      : 'Five wordings, five answers. <b>That’s ' + n + ' in your collection.</b>';
+    root.innerHTML =
+      '<div class="gnt-seal-wrap">' +
+        '<div class="gnt-seal"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg></div>' +
+        '<div class="gnt-seal-k">Concept cracked</div>' +
+        '<div class="gnt-seal-concept">' + escHtml(_gauntletRun.concept) + '</div>' +
+        '<div class="gnt-seal-ladder"><i></i><i></i><i></i><i></i><i></i></div>' +
+        '<p class="gnt-seal-sub">' + subLine + '</p>' +
+        '<span class="gnt-streak-line"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.07-2.14-.22-4.05 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.15.43-2.29 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></svg> Streak +1 · 5 questions toward today’s goal</span>' +
+      '</div>' +
+      '<div class="gnt-result-footer">' +
+        '<button type="button" class="btn btn-primary gnt-cta" data-action="gauntletNextTarget">Next target →</button>' +
+        '<button type="button" class="btn gnt-ghost" data-action="gauntletExit">Back to Drills</button>' +
+      '</div>';
+  } else {
+    const crackCount = results.filter(Boolean).length;
+    const missed = GAUNTLET_RUNGS.filter((r, i) => !results[i]).map(r => '<b>' + r.key + '</b>');
+    const missPhrase = missed.length === 1
+      ? 'The ' + missed[0] + ' got you. One rung from the seal.'
+      : missed.length === 2
+        ? 'The ' + missed[0] + ' and the ' + missed[1] + ' got you.'
+        : missed.length + ' rungs got you this time.';
+    const rows = GAUNTLET_RUNGS.map((r, i) => {
+      const ok = results[i];
+      return '<div class="gnt-rr ' + (ok ? 'ok' : 'bad') + '"><span class="gnt-rr-ic"><svg viewBox="0 0 24 24" aria-hidden="true">' +
+        (ok ? '<path d="M20 6 9 17l-5-5"/>' : '<path d="M18 6 6 18M6 6l12 12"/>') +
+        '</svg></span><span class="gnt-rr-t"><b>' + r.key + '</b><span>' + r.sub + '</span></span></div>';
+    }).join('');
+    root.innerHTML =
+      '<div class="gnt-miss-head">' +
+        '<div class="gnt-miss-score">Cracked <b>' + crackCount + ' of 5</b></div>' +
+        '<p class="gnt-miss-callout">' + missPhrase + '</p>' +
+      '</div>' +
+      '<div class="gnt-rung-report">' + rows + '</div>' +
+      '<p class="gnt-miss-promise">Run it again and every question is re-worded from scratch. There’s nothing to memorize. That’s the point.</p>' +
+      '<div class="gnt-result-footer">' +
+        '<button type="button" class="btn btn-primary gnt-cta" data-action="gauntletRunAgain">Run it again</button>' +
+        '<button type="button" class="btn gnt-ghost" data-action="gauntletDifferentConcept">Different concept</button>' +
+      '</div>';
+  }
+}
+
+// Result-screen CTAs. "Run it again" keeps the concept (attempts carry over,
+// wordings regenerate from scratch); "Next target" re-enters the loop on the
+// next weakest topic; "Different concept" stays on the topic, new concept.
+function gauntletRunAgain() {
+  if (!_gauntletRun) { startRewordGauntlet(); return; }
+  gauntletStart({ topic: _gauntletRun.topic, concept: _gauntletRun.concept, attempts: _gauntletRun.attempts });
+}
+function gauntletDifferentConcept() {
+  if (!_gauntletRun) { startRewordGauntlet(); return; }
+  gauntletStart({ topic: _gauntletRun.topic });
+}
+function gauntletNextTarget() {
+  _gauntletTopic = null;
+  _gauntletRun = null;
+  gauntletStart({});
+}
+function gauntletExit() {
+  _gauntletRun = null;
+  if (typeof renderGauntletDrillsCard === 'function') { try { renderGauntletDrillsCard(); } catch (_) {} }
+  showPage('drills');
+}
+
+// Drills-page hero card pill ("N cracked").
+function renderGauntletDrillsCard() {
+  const pill = document.getElementById('drills-gauntlet-pill');
+  if (!pill) return;
+  const n = loadGauntletCracked().length;
+  pill.textContent = n === 1 ? '1 cracked' : n + ' cracked';
+}
+
+// ══════════════════════════════════════════
 // API KEY VALIDATION
 // ══════════════════════════════════════════
 // v4.99.33 — signed-in users skip the BYOK check entirely.
@@ -8257,6 +8621,15 @@ function showExplanation(q, isRight, entryOverride) {
   } else {
     label = isRight ? 'Correct!' : `Wrong \u2014 correct answer: ${q.answer}`;
   }
+  // v7.48.0 Reword Gauntlet: name the hinge in the verdict, freeze the rung
+  // result on the FIRST answer (re-picks stay study aids, not crack edits),
+  // highlight the hinge word in the stem, repaint the ladder.
+  if (gauntletMode && _gauntletRun) {
+    if (q.hinge) label = (isRight ? 'Correct' : 'Wrong') + ' \u00b7 the hinge: \u201c' + q.hinge + '\u201d';
+    if (_gauntletRun.results[current] === undefined) _gauntletRun.results[current] = isRight;
+    if (typeof _gauntletApplyHinge === 'function') _gauntletApplyHinge(q);
+    if (typeof _renderGauntletLadder === 'function') _renderGauntletLadder();
+  }
   document.getElementById('exp-label').textContent = label;
   document.getElementById('exp-text').textContent  = q.explanation;
   // v4.54.8: per-choice wrongExplain paragraph. If the question carries a
@@ -8292,7 +8665,9 @@ function showExplanation(q, isRight, entryOverride) {
   // v4.54.17: on wrong answers, offer a "Drill this concept" button that
   // injects 2 follow-up questions into the current session immediately
   // after the current question.
-  if (!isRight && typeof followUpOnMistake === 'function') {
+  // v7.48.0: suppressed in gauntlet runs — injecting follow-up questions
+  // would corrupt the fixed 5-rung structure.
+  if (!isRight && !gauntletMode && typeof followUpOnMistake === 'function') {
     extraHtml += '<button class="explain-btn explain-btn-followup" onclick="followUpOnMistake()">Drill this concept</button>';
   }
 
@@ -8319,7 +8694,7 @@ function showExplanation(q, isRight, entryOverride) {
   setTimeout(() => nextBtn.focus(), 100);
 }
 
-function advance() { current++; render(); window.scrollTo(0,0); }
+function advance() { current++; render(); if (gauntletMode && typeof _renderGauntletLadder === 'function') _renderGauntletLadder(); window.scrollTo(0,0); }
 
 function toggleFlag() {
   quizFlags[current] = !quizFlags[current];
@@ -8354,6 +8729,9 @@ function renderResultsDifficultyBreakdown() {
 }
 
 function finish() {
+  // v7.48.0: a Gauntlet run has its own verdict surface (cracked / near-miss)
+  // instead of the standard results page.
+  if (gauntletMode && _gauntletRun) { _finishGauntlet(); return; }
   // v4.42.0: snapshot streak BEFORE updateStreak so we can detect an
   // increment and flag a pulse animation for the next goSetup() render.
   const _prevStreakBefore = (function(){ try { return getStreak().current || 0; } catch (_) { return 0; } })();

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.47.0
+// Network+ AI Quiz — app.js  v7.48.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.47.0';
+const APP_VERSION = '7.48.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/audit-workspace/brand-audit.md
+++ b/audit-workspace/brand-audit.md
@@ -1,0 +1,97 @@
+# Brand Audit — Reword Gauntlet mockups
+
+**Audited:** `mockups/reword-gauntlet.html` + `mockups/landing-gauntlet-section.html` (feat/reword-gauntlet worktree)
+**Against:** `design/brand/BRAND.md` (v5.5.12), cross-checked with live `dg-system.css` tokens
+**Date:** 2026-06-12
+**Method:** static source read + numeric hex→OKLCH conversion. No rendered screenshots in this pass (verification screenshots taken after fixes, on the 4182 preview).
+
+---
+
+## Executive summary
+
+The mockups are structurally and editorially on-brand — Fraunces/Inter split, hairline cards, single focal bronze action per screen, color-mix tints, reduced-motion handling, no purple, no em dashes, no card-spam. The drift is concentrated in one root cause: **both files invent their own hardcoded-hex token blocks instead of using the brand OKLCH tokens**, and those eyeballed hexes are measurably off (accent pulled 9–19° toward flat gold, landing accent 35% under-saturated, pass/fail greens are Tailwind defaults). Add a wrong easing curve, one decorative emoji, rgba shadows, and a Fraunces numeral missing lining-nums (the exact bug v5.5.12 was shipped to kill). This is a token-level cleanup, not a redesign — if the mockups were lifted 1:1 as-is, the app would visibly run two bronzes.
+
+**Top 3 issues to fix first:**
+1. Replace both hex token blocks with brand OKLCH values (F-001/F-002/F-003)
+2. Swap the easing curve to the locked system curve (F-005)
+3. Replace the ⚡ emoji with a monoline flame SVG (F-006)
+
+**Finding count by severity:** Critical 0 · Major 6 · Minor 5
+
+**Categories covered:** Color, Typography, Iconography, Motion, Components, Voice & tone, Style coherence
+**Categories not covered:** Logo (neither mockup renders the monogram); Imagery (no photography/illustration in scope)
+
+---
+
+## Findings
+
+Full structured detail in `findings.json`. Summary:
+
+### Color
+- **F-001 · Hardcoded-hex token blocks instead of brand OKLCH · major** — both files. Fix: swap to BRAND.md §3 / dg-system values; at lift time use the app's real tokens.
+- **F-002 · Accent bronze drifted to flat gold · major** — dark `#e8a33d` → oklch(0.765 0.140 **72.9**) vs brand oklch(0.80 0.155 **64**); light `#a8741f` is +0.10 lighter and -0.04 chroma vs oklch(0.50 0.155 55); landing `#8a5a14` chroma 0.102 vs 0.155.
+- **F-003 · Tailwind pass/fail colors · major** — `#4ade80`/`#f87171` are Tailwind green-400/red-400, not brand `--green`/`--red`.
+- **F-007 · rgba() shadows on product chrome + CTA accent glow · major** — landing `.demo` card shadow is rgba; app CTA has a 75% accent glow (live `.btn-primary` ships shadow-free).
+
+### Typography
+- **F-008 · Fraunces "Cracked 4 of 5" missing lining-nums · major** — the v5.5.12 regression, verbatim.
+- **F-010 · Tracking over 0.14em / labels under 10px / Inter 750 · minor** — `.seal-k` 0.22em, `.kicker` 0.16em, `.pill` 9px, `.rung-name` 8.5px, mark weight 750.
+
+### Iconography
+- **F-006 · ⚡ emoji in streak pill · major** — BRAND §9 bans decorative emoji; replace with monoline currentColor flame.
+
+### Motion
+- **F-005 · Easing cubic-bezier(0.23,1,0.32,1) vs locked (0.16,1,0.3,1) · major** — both files.
+- **F-009 · Entrance scales 0.7 / 0.92 below the 0.96–0.98 floor · minor** — seal stamp raised to 0.9 (keeps the stamp read via rotation+overshoot), demo-seal to 0.96.
+- **F-011 · Landing hover missing pointer:fine gate · minor**
+
+### Components
+- **F-004 · dark --accent-deep lighter than --accent (role inversion) · minor** — remap to the accent-light value (0.86 0.135 64) in dark, true accent-deep (0.42 0.150 52) in light.
+
+### Voice & tone
+No violations. Copy is direct, names mechanisms ("The hinge: NOT"), no throat-clearing, no em dashes besides the approved "Go Pro — unlimited". (Voice passed the four formal audits last session; re-confirmed here.)
+
+### Style coherence
+| Dial | Brand intent | Mockups read as | Evidence |
+|---|---:|---:|---|
+| DESIGN_VARIANCE | mid (editorial, restrained) | mid | hairline cards, one accent, asymmetric ladder spine |
+| MOTION_INTENSITY | low-mid (motion earns its place) | low-mid | rung fills + seal stamp carry data; nothing ambient |
+| VISUAL_DENSITY | mid | mid | one concept per screen, no filler cards |
+
+Reads as the brand's forged-bronze editorial world. No dial drift, no section-grammar repetition, no templated tells beyond the Tailwind palette colors (covered in F-003).
+
+---
+
+## What's not in your brand toolkit
+- **Mobile/app-shell label scale** — BRAND.md's 10–11px eyebrow floor was written for desktop surfaces; the "cert-ios lift grammar" used across v7.36–7.39 runs smaller labels on 390px screens. Worth a one-paragraph addendum so future mockups don't have to guess.
+- **Celebration motion** — the seal stamp is a new motion class (reward stamp); BRAND §6 has no entry for it. Suggest documenting an allowed overshoot range.
+- **Button radius conflict** — toolkit says 7–11px; live `--radius` is 12px. One line in BRAND.md would settle it.
+
+## Quick wins (all applied in this session)
+- Brand OKLCH token blocks in both mockups — fixes F-001/002/003/004
+- Easing swap — F-005 · Flame SVG — F-006 · color-mix shadows / drop CTA glow — F-007
+- lining-nums on .miss-score — F-008 · entrance floors — F-009 · tracking/size/weight caps — F-010 · pointer:fine — F-011
+
+## Systemic issue
+Mockups keep being authored with freehand hex token blocks. Add a canonical "mockup token block" snippet (OKLCH, both themes) to BRAND.md or `design/brand/` so every future mockup starts from the real palette.
+
+---
+
+## Pre-flight checklist
+| # | Question | Y/N/NA |
+|--:|---|:--:|
+| 1 | Hero a complete first scene? | Y |
+| 2 | Headlines avoid weak line breaks? | Y |
+| 3 | Navigation fits cleanly? | NA (screens, not site nav) |
+| 4 | Cards earn their place? | Y |
+| 5 | Loading/empty/error states designed? | Y (loading copy specified; near-miss = the "error" state) |
+| 6 | Real media/diagram weight? | Y (ladder spine + looping demo) |
+| 7 | Specific without the logo? | Y |
+| 8 | Motion matches style? | Y after F-005/F-009 fixes |
+| 9 | Code semantically clean/responsive? | Y |
+| 10 | Feels expensive without trying? | Y |
+| 11 | Materials doing real work? | Y |
+| 12 | Restraint intentional? | Y |
+| 13 | Premium without accent? | Y |
+
+**Synthesis:** token-level cleanup, applied same-session. The design itself is on-brand.

--- a/audit-workspace/brand-rules.md
+++ b/audit-workspace/brand-rules.md
@@ -1,0 +1,23 @@
+# Brand rules extracted — CertAnvil BRAND.md (v5.5.12, 2026-05-19)
+
+Source: `design/brand/BRAND.md`. Live token ground truth cross-checked against `dg-system.css` lines 20–81 (matches BRAND.md §3 exactly).
+
+| # | Rule | Source | Confidence |
+|---|------|--------|------------|
+| R1 | All color tokens are OKLCH; never hardcode hex for chrome (gradients/borders/shadows/tints). Hex only for brand-illustrative SVG fills. | §3 | Explicit |
+| R2 | Dark accent = oklch(0.80 0.155 64); light accent = oklch(0.50 0.155 55); accent-deep darker than accent; pass/warn greens per token table. Dark theme is cool hue-275; light theme warm hue-85. | §3 + dg-system.css | Explicit |
+| R3 | Tints via color-mix(in oklab, var(--accent) N%, transparent); shadows theme-adaptive via color-mix with var(--text) — never rgba()/hex shadows on chrome. | §3, §5 | Explicit |
+| R4 | Fraunces 600 for display; Inter for all UI; UPPERCASE eyebrows = Inter 10–11px / 800 / 0.08–0.14em tracking, never Fraunces. | §4 | Explicit |
+| R5 | Any Fraunces hero number must set `font-variant-numeric: lining-nums tabular-nums` + `font-feature-settings: "lnum","tnum"`. Stacked display numerals: line-height ≥ 1.0. | §4 (v5.5.11–12) | Explicit |
+| R6 | Radius: cards 14–20px, chips/buttons 7–11px, pills 999px. NOTE: live dg-system.css sets `--radius:12px` for buttons — toolkit/live inconsistency, treat 12px as acceptable. | §5 + dg-system.css | Explicit (with noted conflict) |
+| R7 | Easing = cubic-bezier(0.16, 1, 0.3, 1) (literal on body-portaled elements). transform+opacity only. Entrances start scale(0.96–0.98), never scale(0). :active scale(0.97). Hover gated `(hover:hover) and (pointer:fine)`. Reduced-motion → fade-only. | §6 | Explicit |
+| R8 | Duration table: hover 150–160ms, lifts 200–220ms, toasts 340–380ms, card reveals 520–560ms, bar/chart sweeps 800–1100ms; UI motion ≤ ~600ms. | §6 | Explicit |
+| R9 | Icons: monoline stroke currentColor (UI) or brand-illustrative set (sparingly). No emoji as decoration; only semantic ✓/✗/→ survive. Streak flame = 07_study_streak.svg (brand-illustrative). | §7, §9 | Explicit |
+| R10 | No em dashes in copy ("Go Pro — unlimited" is the one approved verbatim survivor). No throat-clearing, no vague declaratives. | §9 + handoff | Explicit |
+| R11 | No purple; no card-spam; no gradient backgrounds on chrome; single focal bronze action per surface; cards = surface + hairline border. | §8, §9 | Explicit |
+| R12 | Both themes verified on every ship (v4.99.63 lesson). | §3 | Explicit |
+
+Ambiguities noted:
+- BRAND.md light `--surface` = oklch(0.992 0.004 85) but dg-system.css app override uses 0.945 — both are "brand"; mockups may use either.
+- Button radius 7–11px (toolkit) vs --radius:12px (live) — live wins for app surfaces.
+- The mockups' "cert-ios lift grammar" token set is NOT a documented brand token set; treated as approximation, not authority.

--- a/audit-workspace/findings.json
+++ b/audit-workspace/findings.json
@@ -1,0 +1,107 @@
+{
+  "audit": "Gauntlet mockups vs CertAnvil BRAND.md",
+  "date": "2026-06-12",
+  "method": "static source read (no rendered screenshots); hex tokens converted to OKLCH numerically",
+  "findings": [
+    {
+      "id": "F-001", "category": "color", "severity": "major",
+      "title": "Mockups define their own hardcoded-hex token blocks instead of the brand OKLCH tokens",
+      "location": "reword-gauntlet.html :root blocks (lines 9-25); landing-gauntlet-section.html :root (lines 9-15)",
+      "observed": "All tokens hex (e.g. --accent:#e8a33d dark / #a8741f light / #8a5a14 landing)",
+      "expected": "OKLCH brand tokens per BRAND.md §3 / dg-system.css (R1, R2)",
+      "fix": "Replace token blocks with brand OKLCH values; at lift time, use the app's existing dg-system tokens directly."
+    },
+    {
+      "id": "F-002", "category": "color", "severity": "major",
+      "title": "Accent bronze drifted toward flat gold in all three token sets",
+      "location": "both mockups, --accent",
+      "observed": "dark #e8a33d = oklch(0.765 0.140 72.9); light #a8741f = oklch(0.598 0.115 74.3); landing #8a5a14 = oklch(0.509 0.102 70.4)",
+      "expected": "dark oklch(0.80 0.155 64); light oklch(0.50 0.155 55)",
+      "notes": "Hue +9 to +19 toward yellow, chroma down up to 35% (landing 0.102 vs 0.155), light-theme lightness +0.10 (worse contrast on ivory)",
+      "fix": "Swap to brand accent values per theme."
+    },
+    {
+      "id": "F-003", "category": "color", "severity": "major",
+      "title": "Pass/fail colors are Tailwind defaults, not brand green/red",
+      "location": "reword-gauntlet.html --pass/--fail",
+      "observed": "dark --pass #4ade80 = oklch(0.800 0.182 151.7) (Tailwind green-400), --fail #f87171 (red-400)",
+      "expected": "dark --pass oklch(0.74 0.150 152), --red oklch(0.66 0.17 25); light equivalents per dg-system",
+      "fix": "Swap to brand pass/red tokens both themes."
+    },
+    {
+      "id": "F-004", "category": "components", "severity": "minor",
+      "title": "--accent-deep inverted in dark theme (lighter than accent, used as text accent)",
+      "location": "reword-gauntlet.html dark tokens; used by .pill, .target-switch, .cracked-n, .rung.live",
+      "observed": "#f0b35a (L 0.806) > accent (L 0.765)",
+      "expected": "Brand dark accent-deep oklch(0.70 0.150 62) is darker; the bright text-accent role belongs to accent-light oklch(0.86 0.135 64)",
+      "fix": "Map the variable to oklch(0.86 0.135 64) in dark (text-accent role) and oklch(0.42 0.150 52) in light."
+    },
+    {
+      "id": "F-005", "category": "motion", "severity": "major",
+      "title": "Wrong system easing curve",
+      "location": "both mockups, --ease",
+      "observed": "cubic-bezier(0.23, 1, 0.32, 1)",
+      "expected": "cubic-bezier(0.16, 1, 0.3, 1) — the locked system curve (R7)",
+      "fix": "One-line token swap in each file."
+    },
+    {
+      "id": "F-006", "category": "iconography", "severity": "major",
+      "title": "Decorative emoji (⚡) in the cracked-screen streak pill",
+      "location": "reword-gauntlet.html .streak-line (&#9889;)",
+      "observed": "Lightning emoji as decoration",
+      "expected": "No emoji decoration (R9); streak iconography = monoline SVG or the brand flame",
+      "fix": "Replace with a monoline currentColor flame SVG."
+    },
+    {
+      "id": "F-007", "category": "color", "severity": "major",
+      "title": "rgba() shadows on product chrome (landing demo card)",
+      "location": "landing-gauntlet-section.html .demo (rgba(34,29,21,0.3)); .cta accent glow in app mockup",
+      "observed": "Hex/rgba shadow on the demo card that lifts 1:1; 75% accent glow under the CTA",
+      "expected": "Shadows via color-mix with --ink/--text (R3); live .btn-primary ships box-shadow:none",
+      "fix": "color-mix the demo shadow; drop the CTA glow."
+    },
+    {
+      "id": "F-008", "category": "typography", "severity": "major",
+      "title": "Fraunces numeral without lining-nums (the exact v5.5.12 bug)",
+      "location": "reword-gauntlet.html .miss-score (\"Cracked 4 of 5\")",
+      "observed": "No font-variant-numeric/font-feature-settings",
+      "expected": "lining-nums tabular-nums + lnum/tnum on every Fraunces number (R5)",
+      "fix": "Add both declarations to .miss-score."
+    },
+    {
+      "id": "F-009", "category": "motion", "severity": "minor",
+      "title": "Entrance scales below the 0.96–0.98 floor",
+      "location": "sealIn keyframe scale(0.7); landing .demo-seal scale(0.92)",
+      "observed": "scale(0.7) and scale(0.92) entrance starts",
+      "expected": "Entrances start scale(0.96–0.98) (R7); the seal stamp is deliberately theatrical — raised, not removed",
+      "fix": "sealIn 0.7 → 0.9 (rotation + overshoot keep the stamp read); demo-seal 0.92 → 0.96."
+    },
+    {
+      "id": "F-010", "category": "typography", "severity": "minor",
+      "title": "Eyebrow tracking over the 0.14em ceiling; sub-10px uppercase labels; Inter 750",
+      "location": ".seal-k 0.22em, landing .kicker 0.16em, .demo-seal 0.2em; .pill 9px, .rung-name/.ladder-preview 8.5px; .q-text mark weight 750",
+      "observed": "Tracking 0.16–0.22em; uppercase labels at 8.5–9px; non-catalog weight 750",
+      "expected": "Eyebrows 10–11px / 800 / 0.08–0.14em (R4); Inter weights 400–800 catalog",
+      "fix": "Cap tracking at 0.14em, raise labels to 10px, mark weight 700."
+    },
+    {
+      "id": "F-011", "category": "motion", "severity": "minor",
+      "title": "Hover rule missing pointer:fine gate",
+      "location": "landing-gauntlet-section.html @media (hover:hover) .btn-primary:hover",
+      "observed": "(hover:hover) only",
+      "expected": "(hover:hover) and (pointer:fine) (R7)",
+      "fix": "Extend the media query."
+    }
+  ],
+  "passes": [
+    "Fraunces 600 display / Inter UI split correct throughout",
+    "color-mix used for all tints and state borders in the app mockup",
+    "No em dashes except the approved 'Go Pro — unlimited'",
+    "Both themes present in the app mockup (R12)",
+    "prefers-reduced-motion handled in both files",
+    ":active scale(0.97) press feedback on all clickables",
+    "Durations within the §6 table (0.45–0.55s reveals, 0.5s demo steps)",
+    "✓ in landing demo-seal is a semantic verdict mark (allowed)",
+    "Style coherence: editorial hairline cards, single focal bronze CTA per screen, no card-spam, no purple, no gradients on chrome"
+  ]
+}

--- a/design/brand/BRAND.md
+++ b/design/brand/BRAND.md
@@ -370,6 +370,7 @@ When fixing a class-of-bug, grep the **pattern** (shape), not the specific funct
 - **Landing**: `landing/index.html` + `landing/dg-system.css` (separate Vercel project)
 - **Logo**: `brand/logo.svg` (standalone) + inline `brandSvg` in `app.js renderSidebar()`
 - **Mockups**: `mockups/*-concept.html` (every feature/redesign is mockup-first)
+- **Mockup starter tokens**: [`brand/mockup-starter-tokens.css`](./mockup-starter-tokens.css) — copy-paste this token block into every new mockup's `<style>`. Never freehand a hex token block (the 2026-06-12 Gauntlet-mockup lesson: eyeballed hexes pulled the accent toward gold and imported Tailwind greens).
 - **Concept-mockup-first workflow**: see [`feedback_concept_mockup_first`](../docs/feedback_concept_mockup_first.md) memory — approved across 14+ ships with zero revision rounds.
 
 ### Versioning
@@ -379,4 +380,4 @@ When fixing a class-of-bug, grep the **pattern** (shape), not the specific funct
 
 ---
 
-**Last updated**: v5.5.12 · 2026-05-19
+**Last updated**: 2026-06-12 (mockup starter token block) · prior v5.5.12 · 2026-05-19

--- a/design/brand/mockup-starter-tokens.css
+++ b/design/brand/mockup-starter-tokens.css
@@ -1,0 +1,48 @@
+/* ════════════════════════════════════════════════════════════════════════
+   CertAnvil · MOCKUP STARTER TOKEN BLOCK
+   ────────────────────────────────────────────────────────────────────────
+   Copy this into the <style> of every new mockup. Do NOT eyeball hex —
+   freehand token blocks are how the 2026-06-12 Gauntlet-mockup drift
+   happened (accent pulled 9-19° toward gold, Tailwind pass/fail greens).
+   Values = BRAND.md §3 / live dg-system.css. Audit trail:
+   mockups branch audit-workspace/brand-audit.md.
+
+   Reminders that pair with this block (BRAND.md §4-§9):
+   · easing is ONLY cubic-bezier(0.16, 1, 0.3, 1); entrances start
+     scale(0.96-0.98); hover gated (hover:hover) and (pointer:fine)
+   · Fraunces numbers: font-variant-numeric: lining-nums tabular-nums;
+     font-feature-settings: "lnum","tnum";
+   · eyebrows: Inter 800, 10-11px, tracking 0.08-0.14em (never more)
+   · shadows/tints: color-mix(in oklab, var(--ink) N%, transparent) —
+     never rgba()/hex on chrome
+   · no emoji decoration (semantic ✓ ✗ → only) · no em dashes in copy
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── App-surface mockups (dual theme; --accent-deep = text-accent role) ── */
+:root, [data-theme="dark"] {
+  --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+  --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+  --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+  --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+  --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25);
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-theme="light"] {
+  --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+  --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+  --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+  --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+  --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25);
+}
+
+/* ── Landing (certanvil.com) mockups — light only ──────────────────────── */
+/*
+:root {
+  --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85);
+  --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+  --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+  --accent: oklch(0.50 0.155 55); --accent-bright: oklch(0.80 0.155 64); --on-accent: oklch(0.985 0.010 85);
+  --pass: oklch(0.52 0.13 150); --fail: oklch(0.52 0.19 25);
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+*/

--- a/design/brand/mockup-starter-tokens.css
+++ b/design/brand/mockup-starter-tokens.css
@@ -35,7 +35,13 @@
   --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25);
 }
 
-/* ── Landing (certanvil.com) mockups — light only ──────────────────────── */
+/* ── Landing (certanvil.com) mockups — light only ──────────────────────────
+   ⚠ LIFT RULE: when lifting into landing/index.html, these tokens MUST be
+   redefined SCOPED TO THE SECTION ID (`#my-section{--accent:...}` + a
+   `[data-theme="dark"] #my-section{...}` block) — landing/styles.css :root
+   still defines the LEGACY PURPLE --accent (#5b4fdb/#7c6ff7). A section that
+   relies on inherited var(--accent) renders purple (the 2026-06-12 Gauntlet
+   landing-section incident). Copy the #sq2 / #proof-of-product pattern. ── */
 /*
 :root {
   --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85);

--- a/dg-system.css
+++ b/dg-system.css
@@ -3710,3 +3710,86 @@ html.cl-locked,html.cl-locked body{overflow:hidden;}
   #page-setup .home-collapsed{padding-bottom:0}
 }
 
+
+/* ════════════════════════════════════════════════════════════════════════
+   v7.48.0 · REWORD GAUNTLET — entry / in-rung ladder / verdict screens
+   Lift of mockups/reword-gauntlet.html (brand-audited 2026-06-12) onto the
+   app tokens. New-surface rule: centered ~560px column, no classic desktop
+   variant. These elements live on their own .page roots (not #page-setup),
+   so easing is the LITERAL system curve, never var(--dgh-ease) — the
+   v5.5.4 portal lesson.
+   ═══════════════════════════════════════════════════════════════════════ */
+.gnt-drills-hero{border-color:color-mix(in oklab,var(--accent) 30%,var(--border));}
+.gnt-shell{max-width:560px;margin:0 auto;padding:18px 22px 40px;display:flex;flex-direction:column;}
+.gnt-hdr{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:4px 0 14px;}
+.gnt-hdr-title{font:650 16px/1 Inter,sans-serif;letter-spacing:-0.01em;color:var(--text);margin:0;}
+.gnt-mark{width:64px;height:64px;margin:14px auto;border-radius:50%;display:grid;place-items:center;background:color-mix(in oklab,var(--accent) 13%,transparent);border:1px solid color-mix(in oklab,var(--accent) 36%,transparent);color:var(--accent);}
+.gnt-mark svg{width:30px;height:30px;stroke:currentColor;fill:none;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round;}
+.gnt-entry-title{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:25px;letter-spacing:-0.014em;text-align:center;color:var(--text);margin:0;}
+.gnt-entry-title i{color:var(--accent);}
+.gnt-entry-lede{text-align:center;color:var(--text-mid);font-size:13.5px;line-height:1.55;margin:9px auto 18px;max-width:30ch;}
+.gnt-target{border:1px solid var(--border);border-radius:14px;background:var(--surface);padding:15px 16px;}
+.gnt-target-k{font:800 10px/1 Inter,sans-serif;letter-spacing:0.13em;text-transform:uppercase;color:var(--text-dim);margin-bottom:7px;}
+.gnt-target-v{font:650 15.5px/1.3 Inter,sans-serif;color:var(--text);}
+.gnt-target-why{font-size:12px;color:var(--text-dim);margin-top:5px;}
+.gnt-target-switch{background:none;border:0;padding:10px 0 0;color:var(--accent-light);font:650 12.5px/1 Inter,sans-serif;cursor:pointer;}
+.gnt-target-switch:active{transform:scale(0.97);}
+.gnt-topic-list{display:flex;flex-direction:column;gap:6px;margin-top:10px;max-height:300px;overflow:auto;}
+.gnt-topic-opt{text-align:left;border:1px solid var(--dg-rule-soft);background:none;border-radius:9px;padding:10px 12px;color:var(--text-mid);font:550 13px/1.3 Inter,sans-serif;cursor:pointer;}
+.gnt-topic-opt:active{transform:scale(0.985);}
+.gnt-cracked-row{display:flex;align-items:center;gap:10px;margin-top:14px;padding:13px 15px;border:1px solid var(--dg-rule-soft);border-radius:14px;background:var(--surface);}
+.gnt-cracked-n{font:800 22px/1 Inter,sans-serif;color:var(--accent-light);font-variant-numeric:tabular-nums;}
+.gnt-cracked-t{font-size:12.5px;color:var(--text-mid);line-height:1.4;}
+.gnt-ladder-preview{display:flex;gap:5px;margin:16px 2px 22px;}
+.gnt-ladder-preview span{flex:1;font:800 10px/1 Inter,sans-serif;letter-spacing:0.05em;text-transform:uppercase;color:var(--text-dim);text-align:center;padding-top:8px;border-top:3px solid var(--surface3);}
+/* ── in-rung ladder (rides #page-quiz in place of the dot strip) ── */
+.gnt-ladder{display:flex;gap:6px;max-width:760px;margin:6px auto 14px;}
+.gnt-rung{flex:1;text-align:center;}
+.gnt-rung-bar{height:5px;border-radius:3px;background:var(--surface3);overflow:hidden;position:relative;}
+.gnt-rung-bar i{position:absolute;inset:0;border-radius:3px;transform:scaleX(0);transform-origin:left;background:var(--accent);}
+.gnt-rung.done .gnt-rung-bar i{transform:scaleX(1);transition:transform 0.45s cubic-bezier(0.16,1,0.3,1);}
+.gnt-rung.missed .gnt-rung-bar i{transform:scaleX(1);background:var(--red);transition:transform 0.45s cubic-bezier(0.16,1,0.3,1);}
+.gnt-rung.live .gnt-rung-bar{box-shadow:0 0 0 1.5px color-mix(in oklab,var(--accent) 55%,transparent);}
+.gnt-rung-name{font:800 10px/1 Inter,sans-serif;letter-spacing:0.06em;text-transform:uppercase;color:var(--text-dim);margin-top:6px;}
+.gnt-rung.live .gnt-rung-name{color:var(--accent-light);}
+.gnt-rung.done .gnt-rung-name{color:var(--text-mid);}
+.gnt-rung-chip{display:inline-flex;align-items:center;gap:6px;font:800 10px/1 Inter,sans-serif;letter-spacing:0.12em;text-transform:uppercase;color:var(--accent-light);}
+.gnt-rung-chip::before{content:"";width:7px;height:7px;border-radius:2px;background:var(--accent);display:inline-block;}
+mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:inherit;padding:1px 5px;border-radius:5px;font-weight:700;animation:gntHingeIn 0.5s cubic-bezier(0.16,1,0.3,1) 0.25s both;}
+@keyframes gntHingeIn{from{background:transparent;}to{background:color-mix(in oklab,var(--red) 26%,transparent);}}
+/* ── verdict screens ── */
+.gnt-shell-result{min-height:70vh;justify-content:center;}
+.gnt-seal-wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:30px 0 10px;}
+.gnt-seal{width:130px;height:130px;border-radius:50%;display:grid;place-items:center;background:color-mix(in oklab,var(--accent) 15%,transparent);border:2px solid var(--accent);color:var(--accent);animation:gntSealIn 0.55s cubic-bezier(0.16,1,0.3,1) both;}
+.gnt-seal svg{width:56px;height:56px;stroke:currentColor;fill:none;stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;}
+@keyframes gntSealIn{0%{transform:scale(0.9) rotate(-7deg);opacity:0;}70%{transform:scale(1.05) rotate(1deg);}100%{transform:scale(1) rotate(0);opacity:1;}}
+.gnt-seal-k{font:800 11px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent-light);margin:20px 0 8px;}
+.gnt-seal-concept{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:22px;letter-spacing:-0.012em;max-width:24ch;color:var(--text);}
+.gnt-seal-sub{color:var(--text-mid);font-size:13px;margin-top:10px;}
+.gnt-seal-sub b{color:var(--text);}
+.gnt-seal-ladder{display:flex;gap:6px;margin-top:18px;width:78%;}
+.gnt-seal-ladder i{flex:1;height:5px;border-radius:3px;background:var(--accent);animation:gntRungPop 0.4s cubic-bezier(0.16,1,0.3,1) both;}
+.gnt-seal-ladder i:nth-child(2){animation-delay:0.08s;}.gnt-seal-ladder i:nth-child(3){animation-delay:0.16s;}
+.gnt-seal-ladder i:nth-child(4){animation-delay:0.24s;}.gnt-seal-ladder i:nth-child(5){animation-delay:0.32s;}
+@keyframes gntRungPop{from{transform:scaleX(0);}to{transform:scaleX(1);}}
+.gnt-streak-line{display:inline-flex;align-items:center;gap:7px;margin-top:16px;font:650 12.5px/1 Inter,sans-serif;color:var(--text-mid);border:1px solid var(--dg-rule-soft);border-radius:999px;padding:8px 14px;background:var(--surface);}
+.gnt-streak-line svg{width:13px;height:13px;stroke:var(--accent);fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;flex:none;}
+.gnt-miss-head{text-align:center;margin-top:12px;}
+.gnt-miss-score{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:24px;color:var(--text);font-variant-numeric:lining-nums tabular-nums;font-feature-settings:"lnum","tnum";}
+.gnt-miss-score b{color:var(--accent);}
+.gnt-miss-callout{font-size:13.5px;color:var(--text-mid);margin-top:7px;}
+.gnt-miss-callout b{color:var(--red);}
+.gnt-rung-report{display:flex;flex-direction:column;gap:8px;margin:18px 0 6px;}
+.gnt-rr{display:flex;align-items:center;gap:11px;border:1px solid var(--dg-rule-soft);border-radius:12px;padding:11px 13px;background:var(--surface);}
+.gnt-rr-ic{width:22px;height:22px;border-radius:50%;display:grid;place-items:center;flex:none;}
+.gnt-rr-ic svg{width:13px;height:13px;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:round;fill:none;stroke:currentColor;}
+.gnt-rr.ok .gnt-rr-ic{background:color-mix(in oklab,var(--green) 14%,transparent);color:var(--green);}
+.gnt-rr.bad .gnt-rr-ic{background:color-mix(in oklab,var(--red) 14%,transparent);color:var(--red);}
+.gnt-rr-t b{display:block;font:650 13px/1.2 Inter,sans-serif;color:var(--text);}
+.gnt-rr-t span{font-size:11.5px;color:var(--text-dim);}
+.gnt-miss-promise{font-size:12px;color:var(--text-dim);text-align:center;margin-top:10px;}
+.gnt-result-footer{display:flex;flex-direction:column;gap:9px;margin-top:26px;}
+.gnt-ghost{width:100%;background:none;border:1px solid var(--border);border-radius:12px;padding:13px;color:var(--text);font:600 13px/1 Inter,sans-serif;cursor:pointer;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1);}
+.gnt-ghost:active{transform:scale(0.97);}
+.gnt-cta{border-radius:12px;padding:14px;font:700 14.5px/1 Inter,sans-serif;}
+@media (prefers-reduced-motion:reduce){.gnt-seal,.gnt-seal-ladder i,.gnt-rung-bar i,mark.gnt-hinge{animation:none!important;transition:none!important;}}

--- a/dg-system.css
+++ b/dg-system.css
@@ -3732,13 +3732,13 @@ html.cl-locked,html.cl-locked body{overflow:hidden;}
 .gnt-target-k{font:800 10px/1 Inter,sans-serif;letter-spacing:0.13em;text-transform:uppercase;color:var(--text-dim);margin-bottom:7px;}
 .gnt-target-v{font:650 15.5px/1.3 Inter,sans-serif;color:var(--text);}
 .gnt-target-why{font-size:12px;color:var(--text-dim);margin-top:5px;}
-.gnt-target-switch{background:none;border:0;padding:10px 0 0;color:var(--accent-light);font:650 12.5px/1 Inter,sans-serif;cursor:pointer;}
+.gnt-target-switch{background:none;border:0;padding:10px 0 0;color:var(--accent);font:650 12.5px/1 Inter,sans-serif;cursor:pointer;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1);}
 .gnt-target-switch:active{transform:scale(0.97);}
 .gnt-topic-list{display:flex;flex-direction:column;gap:6px;margin-top:10px;max-height:300px;overflow:auto;}
-.gnt-topic-opt{text-align:left;border:1px solid var(--dg-rule-soft);background:none;border-radius:9px;padding:10px 12px;color:var(--text-mid);font:550 13px/1.3 Inter,sans-serif;cursor:pointer;}
+.gnt-topic-opt{text-align:left;border:1px solid var(--dg-rule-soft);background:none;border-radius:9px;padding:10px 12px;color:var(--text-mid);font:550 13px/1.3 Inter,sans-serif;cursor:pointer;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1);}
 .gnt-topic-opt:active{transform:scale(0.985);}
 .gnt-cracked-row{display:flex;align-items:center;gap:10px;margin-top:14px;padding:13px 15px;border:1px solid var(--dg-rule-soft);border-radius:14px;background:var(--surface);}
-.gnt-cracked-n{font:800 22px/1 Inter,sans-serif;color:var(--accent-light);font-variant-numeric:tabular-nums;}
+.gnt-cracked-n{font:800 22px/1 Inter,sans-serif;color:var(--accent);font-variant-numeric:tabular-nums;}
 .gnt-cracked-t{font-size:12.5px;color:var(--text-mid);line-height:1.4;}
 .gnt-ladder-preview{display:flex;gap:5px;margin:16px 2px 22px;}
 .gnt-ladder-preview span{flex:1;font:800 10px/1 Inter,sans-serif;letter-spacing:0.05em;text-transform:uppercase;color:var(--text-dim);text-align:center;padding-top:8px;border-top:3px solid var(--surface3);}
@@ -3751,9 +3751,9 @@ html.cl-locked,html.cl-locked body{overflow:hidden;}
 .gnt-rung.missed .gnt-rung-bar i{transform:scaleX(1);background:var(--red);transition:transform 0.45s cubic-bezier(0.16,1,0.3,1);}
 .gnt-rung.live .gnt-rung-bar{box-shadow:0 0 0 1.5px color-mix(in oklab,var(--accent) 55%,transparent);}
 .gnt-rung-name{font:800 10px/1 Inter,sans-serif;letter-spacing:0.06em;text-transform:uppercase;color:var(--text-dim);margin-top:6px;}
-.gnt-rung.live .gnt-rung-name{color:var(--accent-light);}
+.gnt-rung.live .gnt-rung-name{color:var(--accent);}
 .gnt-rung.done .gnt-rung-name{color:var(--text-mid);}
-.gnt-rung-chip{display:inline-flex;align-items:center;gap:6px;font:800 10px/1 Inter,sans-serif;letter-spacing:0.12em;text-transform:uppercase;color:var(--accent-light);}
+.gnt-rung-chip{display:inline-flex;align-items:center;gap:6px;font:800 10px/1 Inter,sans-serif;letter-spacing:0.12em;text-transform:uppercase;color:var(--accent);}
 .gnt-rung-chip::before{content:"";width:7px;height:7px;border-radius:2px;background:var(--accent);display:inline-block;}
 mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:inherit;padding:1px 5px;border-radius:5px;font-weight:700;animation:gntHingeIn 0.5s cubic-bezier(0.16,1,0.3,1) 0.25s both;}
 @keyframes gntHingeIn{from{background:transparent;}to{background:color-mix(in oklab,var(--red) 26%,transparent);}}
@@ -3763,7 +3763,7 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 .gnt-seal{width:130px;height:130px;border-radius:50%;display:grid;place-items:center;background:color-mix(in oklab,var(--accent) 15%,transparent);border:2px solid var(--accent);color:var(--accent);animation:gntSealIn 0.55s cubic-bezier(0.16,1,0.3,1) both;}
 .gnt-seal svg{width:56px;height:56px;stroke:currentColor;fill:none;stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;}
 @keyframes gntSealIn{0%{transform:scale(0.9) rotate(-7deg);opacity:0;}70%{transform:scale(1.05) rotate(1deg);}100%{transform:scale(1) rotate(0);opacity:1;}}
-.gnt-seal-k{font:800 11px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent-light);margin:20px 0 8px;}
+.gnt-seal-k{font:800 11px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent);margin:20px 0 8px;}
 .gnt-seal-concept{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:22px;letter-spacing:-0.012em;max-width:24ch;color:var(--text);}
 .gnt-seal-sub{color:var(--text-mid);font-size:13px;margin-top:10px;}
 .gnt-seal-sub b{color:var(--text);}
@@ -3791,5 +3791,6 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 .gnt-result-footer{display:flex;flex-direction:column;gap:9px;margin-top:26px;}
 .gnt-ghost{width:100%;background:none;border:1px solid var(--border);border-radius:12px;padding:13px;color:var(--text);font:600 13px/1 Inter,sans-serif;cursor:pointer;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1);}
 .gnt-ghost:active{transform:scale(0.97);}
-.gnt-cta{border-radius:12px;padding:14px;font:700 14.5px/1 Inter,sans-serif;}
+.gnt-cta{border-radius:12px;padding:14px;font:700 14.5px/1 Inter,sans-serif;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1);}
+.gnt-cta:active{transform:scale(0.97);}
 @media (prefers-reduced-motion:reduce){.gnt-seal,.gnt-seal-ladder i,.gnt-rung-bar i,mark.gnt-hinge{animation:none!important;transition:none!important;}}

--- a/docs/planning/REWORD-GAUNTLET-SPEC-2026-06-11.md
+++ b/docs/planning/REWORD-GAUNTLET-SPEC-2026-06-11.md
@@ -1,0 +1,48 @@
+# Reword Gauntlet — Design Spec
+**Approved by Simi, 2026-06-11 (late evening). Build: 2026-06-12.**
+**Research base:** `FLAGSHIP-DRILL-RESEARCH-2026-06-11.md` (Desktop) — deep-research verified the #1 cross-cert failure mode: candidates memorize questions, real exams re-word concepts. The Gauntlet is the flagship answer.
+
+## Product decisions (locked tonight)
+1. **Run size:** ONE concept per run, 5 questions (rungs).
+2. **Rung recipe:** Plain → Scenario → Best-of (BEST/MOST qualifier) → Not-trap (negation) → Twisted. Rung labels are visible — the user learns the trap taxonomy by name.
+3. **Miss rule:** the run always finishes all 5 rungs (max learning). Concept **cracks only on 5/5**. Miss verdict names the rung type that got them ("the Not-trap got you") + one-tap **Run it again** which generates five FRESH wordings. The retry IS the anti-memorization demo.
+4. **Concept selection:** app picks one testable concept from the user's weakest topic (existing weak-spot scores); entry shows "Today's target" + a "pick a different topic" link (topic list reuse). The AI picks the concept inside the topic during generation.
+5. **Reward:** Cracked-concepts collection — `STORAGE.GAUNTLET_CRACKED` (array of {concept, topic, certId, date, attempts}), cloud-flushed like all progress (syncs iOS/Safari/desktop). Entry screen shows the count ("14 cracked"); cracking counts toward the daily streak; answered questions count toward Today's goal.
+6. **Placement:** TOP hero card on the Drills page + Home bento tile in the Practice area (PRO pill) + landing-page section after the pricing teaser.
+7. **Gating:** Pro-only, standard `_gateProOnly` card: "The Reword Gauntlet is a Pro feature". Free users see the locked tile/entry (funnel tease).
+
+## Generation (Approach A — one call per run, approved)
+- One `_claudeFetch` metered call (`CLAUDE_MODEL`, `_metered: true`) at Start:
+  prompt = weakest topic + the cert's exemplar bank slice (style grounding) + the 5-rung recipe + "pick ONE precise testable concept inside the topic, then write the 5 rungs about THAT concept."
+- Response: JSON `{ concept: "...", rungs: [5 × {question, options[4], answer, explanation, hinge}] }` — `hinge` is the word/phrase the rung pivots on, shown highlighted in feedback.
+- Per-rung shape validation (same pattern as `_fetchRewordedVariants`); a malformed run → friendly error + retry, **nothing consumed/recorded**.
+- Cert-agnostic guarantee: inputs are CERT_PACK topics + exemplars only. Every current and future cert has both ⇒ zero per-cert build.
+
+## Screens (mockups tonight; lift pattern — mockups ARE the pages)
+1. **Entry** — "Today's target: <weakest TOPIC>" (the precise concept is chosen by the AI at generation and revealed when the run starts), cracked-count, Start CTA, "pick a different topic" link, Pro pill context for free viewers.
+2. **In-rung** — rung ladder (5 segments, current glowing), rung-type label, question via existing quiz components; post-answer feedback: right/wrong + explanation + hinge word highlighted.
+3. **Cracked** — 5/5 celebration: seal stamp animation, concept added to collection, streak credit line, next-target CTA.
+4. **Near-miss verdict** — "Cracked 4 of 5 — the Not-trap got you", rung breakdown, **Run it again** (fresh wordings) + "different concept" secondary.
+5. **Landing section** (certanvil.com index, after pricing teaser) — headline family: "Memorized the practice test? The real exam re-words everything." + mini animated ladder demo + Pro CTA.
+
+## Process hard rule (Simi)
+Every surface — mockups AND build — goes through the four passes:
+`/design-taste-frontend` (1) → `/emil-design-eng` motion/animation (2) → `/humanizer` (3) → `/marketing-psychology` (4).
+
+## Platform + integration
+- Single codebase; mobile lift design language <900px, classic desktop ≥900px (locked viewport-gate decision). New-surface rule applies: centered ~560px column allowed where no classic version exists.
+- Entry points wired like existing drills (Drills page card = hero position; Home tile in Practice cell with PRO pill via `tier-free-only`).
+- Quota: the run's generation call is metered (Pro = unlimited; global kill-switch applies).
+
+## Edge cases
+- Generation failure → error card + retry, nothing charged/recorded.
+- Double-tap Start → in-flight guard.
+- Anonymous/free → Pro gate card at every entry.
+- Offline → entry gate with "needs a connection" note.
+- Quit mid-run → no crack, no penalty; bank/SR untouched (Gauntlet is parallel to, not part of, the wrong-bank loop in v1).
+
+## Out of scope for v1 (explicitly)
+- Multi-concept chains, lives/sudden-death modes, readiness-score integration (#139 frozen), PBQ-style rungs, sharing the seal, free-tier teaser runs.
+
+## Build-day checklist seed (2026-06-12)
+Branch `feat/reword-gauntlet` (this one). Mockups in `mockups/reword-gauntlet*.html`. Fast lane unless quota/api files get touched. UAT pins to watch: drills-page shape tests, bento tile tests. Version target: v7.48.0.

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.33.0">
+<link rel="stylesheet" href="dg-system.css?v=7.48.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic
@@ -403,6 +403,8 @@
           <button type="button" class="opt" onclick="applyPreset('grind')"><span class="on">20-min Deep Scan</span><span class="od">20 questions, exam level, mixed</span></button>
           <button type="button" class="opt" onclick="applyPreset('bulk30')"><span class="on">30 Questions</span><span class="od">Marathon mixed, about 25 min</span></button>
           <button type="button" class="opt" onclick="applyPreset('bulk45')"><span class="on">45 Questions</span><span class="od">Marathon mixed, about 38 min</span></button>
+          <!-- v7.48.0: Reword Gauntlet entry (flagship drill) -->
+          <button type="button" class="opt" data-action="startRewordGauntlet"><span class="on">Reword Gauntlet</span><span class="od">One concept, five disguises</span></button>
         </div>
       </section>
 
@@ -981,10 +983,15 @@
        The progress track + label moved into .quiz-topbar (lift Phase 1). -->
   <div class="quiz-prog-dots" id="quiz-prog-dots" role="progressbar" aria-label="Per-question progress"></div>
 
+  <!-- v7.48.0: Reword Gauntlet rung ladder — replaces the dot strip during a
+       gauntlet run (rendered by _renderGauntletLadder, hidden otherwise) -->
+  <div class="gnt-ladder is-hidden" id="gauntlet-ladder" aria-label="Gauntlet rung progress"></div>
+
   <div class="q-card">
     <div class="q-meta">
       <span class="q-num" id="q-num">Q1</span>
       <span class="diff-badge" id="diff-badge">Exam Level</span>
+      <span class="gnt-rung-chip is-hidden" id="gauntlet-rung-chip"></span>
       <span class="pbq-badge is-hidden" id="pbq-badge"></span>
     </div>
     <div class="q-text" id="q-text" role="heading" aria-level="3">Loading&#8230;</div>
@@ -1217,6 +1224,13 @@
   </div>
   <p class="drills-lede">Short, repeat passes on the things you get wrong. Ten questions or fewer, scored like practice.</p>
 
+  <!-- v7.48.0: Reword Gauntlet — flagship drill, hero position -->
+  <div class="drills-card gnt-drills-hero" id="drills-gauntlet-card">
+    <div class="drills-card-head"><span class="drills-card-title">Reword Gauntlet <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill" id="drills-gauntlet-pill">0 cracked</span></div>
+    <p class="drills-card-note">One concept, asked five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it in any wording.</p>
+    <button type="button" class="drills-btn" id="drills-gauntlet-btn" data-action="startRewordGauntlet">Run the Gauntlet</button>
+  </div>
+
   <div class="drills-card" id="drills-mistakes-card">
     <div class="drills-card-head"><span class="drills-card-title">Drill Mistakes <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill" id="drills-mistakes-pill">0 saved</span></div>
     <p class="drills-card-note" id="drills-mistakes-note">Your missed questions come back re-worded, so you beat the concept &mdash; not the question. Right twice in a row and it leaves the bank for good.</p>
@@ -1234,6 +1248,41 @@
   <div id="drills-domain-list"></div>
 
   <p class="drills-foot-note">Drills don't touch your daily review queue — those cards stay scheduled.</p>
+</div>
+
+<!-- ══════════════════════════════════════════
+     REWORD GAUNTLET (v7.48.0) — entry + verdict screens
+     Lifted from mockups/reword-gauntlet.html (brand-audited 2026-06-12).
+     Entry is viewable by free users; the Pro gate fires on Start.
+══════════════════════════════════════════ -->
+<div id="page-gauntlet" class="page">
+  <div class="gnt-shell">
+    <div class="gnt-hdr">
+      <button type="button" class="back-btn" data-action="showPage" data-args='["drills"]' aria-label="Back to Drills"><svg viewBox="0 0 24 24" aria-hidden="true" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg><span class="back-btn-label">Drills</span></button>
+      <h1 class="gnt-hdr-title">Reword Gauntlet</h1>
+      <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span>
+    </div>
+    <div class="gnt-mark" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 17l6-6-6-6"></path><path d="M12 19h8"></path></svg></div>
+    <h2 class="gnt-entry-title">Beat the concept in <i>every</i> disguise</h2>
+    <p class="gnt-entry-lede">Five questions on one concept. The wording never repeats.</p>
+    <div class="gnt-target">
+      <div class="gnt-target-k">Today's target</div>
+      <div class="gnt-target-v" id="gnt-topic-name">&mdash;</div>
+      <div class="gnt-target-why" id="gnt-topic-why"></div>
+      <button type="button" class="gnt-target-switch" data-action="gauntletToggleTopicList">Pick a different topic</button>
+      <div class="gnt-topic-list is-hidden" id="gnt-topic-list"></div>
+    </div>
+    <div class="gnt-cracked-row is-hidden" id="gnt-cracked-row">
+      <span class="gnt-cracked-n" id="gnt-cracked-n">0</span>
+      <span class="gnt-cracked-t">concepts cracked so far.<br>Each one survived all five wordings.</span>
+    </div>
+    <div class="gnt-ladder-preview" aria-hidden="true"><span>Plain</span><span>Scenario</span><span>Best-of</span><span>Not-trap</span><span>Twisted</span></div>
+    <button type="button" class="btn btn-primary gnt-cta" id="gnt-start-btn" data-action="gauntletStart">Start the Gauntlet</button>
+  </div>
+</div>
+
+<div id="page-gauntlet-result" class="page">
+  <div class="gnt-shell gnt-shell-result" id="gnt-result-root"></div>
 </div>
 
 <!-- ══════════════════════════════════════════

--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.47.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.48.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/index.html
+++ b/index.html
@@ -1226,7 +1226,7 @@
 
   <!-- v7.48.0: Reword Gauntlet — flagship drill, hero position -->
   <div class="drills-card gnt-drills-hero" id="drills-gauntlet-card">
-    <div class="drills-card-head"><span class="drills-card-title">Reword Gauntlet <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill" id="drills-gauntlet-pill">0 cracked</span></div>
+    <div class="drills-card-head"><span class="drills-card-title">Reword Gauntlet <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill" id="drills-gauntlet-pill">Flagship drill</span></div>
     <p class="drills-card-note">One concept, asked five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it in any wording.</p>
     <button type="button" class="drills-btn" id="drills-gauntlet-btn" data-action="startRewordGauntlet">Run the Gauntlet</button>
   </div>

--- a/landing/index.html
+++ b/landing/index.html
@@ -2175,7 +2175,39 @@
      the neighbouring sections). gx- prefix, fully scoped under #gauntlet.
 ══════════════════════════════════════════ -->
 <style>
-  #gauntlet{padding:96px 24px}
+  /* Scoped brand tokens (BRAND.md §3) — landing's :root --accent is still the
+     legacy purple layer in styles.css; every lifted section redefines its own
+     tokens on the section id, light here + dark below (the sq2/pp pattern). */
+  #gauntlet{
+    --bg:oklch(0.975 0.007 85);
+    --surface:oklch(0.992 0.004 85);
+    --surface-2:oklch(0.965 0.010 84);
+    --ink:oklch(0.22 0.015 280);
+    --ink-soft:oklch(0.36 0.014 280);
+    --muted:oklch(0.50 0.013 280);
+    --border:oklch(0.86 0.008 85);
+    --border-soft:oklch(0.91 0.006 85);
+    --accent:oklch(0.50 0.155 55);
+    --accent-bright:oklch(0.80 0.155 64);
+    --accent-deep:oklch(0.42 0.150 52);
+    --on-accent:oklch(0.985 0.010 85);
+    background:var(--bg);color:var(--ink);
+    padding:96px 24px;
+  }
+  [data-theme="dark"] #gauntlet{
+    --bg:oklch(0.16 0.009 275);
+    --surface:oklch(0.205 0.009 275);
+    --surface-2:oklch(0.185 0.009 275);
+    --ink:oklch(0.96 0.006 275);
+    --ink-soft:oklch(0.78 0.010 275);
+    --muted:oklch(0.60 0.013 275);
+    --border:oklch(0.30 0.008 275);
+    --border-soft:oklch(0.26 0.008 275);
+    --accent:oklch(0.80 0.155 64);
+    --accent-bright:oklch(0.86 0.140 70);
+    --accent-deep:oklch(0.70 0.150 62);
+    --on-accent:oklch(0.18 0.020 275);
+  }
   #gauntlet .gx-wrap{max-width:1080px;margin:0 auto}
   #gauntlet .gx{display:grid;grid-template-columns:1.05fr 0.95fr;gap:64px;align-items:center}
   #gauntlet .gx-kicker{font:800 11px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent);display:inline-flex;align-items:center;gap:7px;margin-bottom:18px}

--- a/landing/index.html
+++ b/landing/index.html
@@ -2168,6 +2168,118 @@
 </section>
 
 <!-- ══════════════════════════════════════════
+     REWORD GAUNTLET (v7.48.0) · flagship-drill pitch where the "why Pro"
+     story peaks. Lift of mockups/landing-gauntlet-section.html
+     (brand-audited 2026-06-12). The demo card replays a five-rung run on
+     a loop; the loop starts on first scroll-into-view (same IO pattern as
+     the neighbouring sections). gx- prefix, fully scoped under #gauntlet.
+══════════════════════════════════════════ -->
+<style>
+  #gauntlet{padding:96px 24px}
+  #gauntlet .gx-wrap{max-width:1080px;margin:0 auto}
+  #gauntlet .gx{display:grid;grid-template-columns:1.05fr 0.95fr;gap:64px;align-items:center}
+  #gauntlet .gx-kicker{font:800 11px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent);display:inline-flex;align-items:center;gap:7px;margin-bottom:18px}
+  #gauntlet .gx-kicker svg{width:12px;height:12px;stroke:currentColor;fill:none;stroke-width:2.4;stroke-linecap:round;stroke-linejoin:round}
+  #gauntlet h2{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:38px;line-height:1.13;letter-spacing:-0.015em;color:var(--ink)}
+  #gauntlet h2 em{font-style:italic;color:var(--accent)}
+  #gauntlet .gx-lede{color:var(--ink-soft);font-size:16px;line-height:1.6;margin:18px 0 6px;max-width:46ch}
+  #gauntlet .gx-lede b{color:var(--ink)}
+  #gauntlet .gx-proof{font-size:13.5px;color:var(--muted);margin:14px 0 26px}
+  #gauntlet .gx-cta-row{display:flex;align-items:center;gap:18px;flex-wrap:wrap}
+  #gauntlet .gx-btn{background:var(--accent);color:var(--on-accent);border:0;border-radius:10px;padding:14px 26px;font:700 15px/1 Inter,sans-serif;cursor:pointer;text-decoration:none;display:inline-block;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1),filter 0.2s ease}
+  #gauntlet .gx-btn:active{transform:scale(0.97)}
+  @media (hover:hover) and (pointer:fine){#gauntlet .gx-btn:hover{filter:brightness(1.08)}}
+  #gauntlet .gx-cta-note{font-size:13px;color:var(--muted)}
+  #gauntlet .gx-demo{background:var(--surface);border:1px solid var(--border);border-radius:16px;padding:26px 24px;box-shadow:0 1px 0 color-mix(in oklab,var(--ink) 4%,transparent),0 18px 50px -30px color-mix(in oklab,var(--ink) 30%,transparent)}
+  #gauntlet .gx-demo-k{font:800 10px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-bottom:16px;display:flex;justify-content:space-between}
+  #gauntlet .gx-demo-k span:last-child{color:var(--accent)}
+  #gauntlet .gx-demo-concept{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:19px;color:var(--ink);margin-bottom:18px}
+  #gauntlet .gx-rungs{display:flex;flex-direction:column;gap:10px}
+  #gauntlet .gx-dr{display:flex;align-items:center;gap:12px;border:1px solid var(--border-soft);border-radius:11px;padding:11px 14px;opacity:0.35;transform:translateX(6px);transition:opacity 0.5s cubic-bezier(0.16,1,0.3,1),transform 0.5s cubic-bezier(0.16,1,0.3,1),border-color 0.5s ease}
+  #gauntlet .gx-dr.on{opacity:1;transform:translateX(0);border-color:color-mix(in oklab,var(--accent) 30%,var(--border))}
+  #gauntlet .gx-dr-n{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;flex:none;font:800 11px/1 Inter,sans-serif;background:color-mix(in oklab,var(--accent) 11%,transparent);color:var(--accent)}
+  #gauntlet .gx-dr.on .gx-dr-n{background:var(--accent);color:var(--on-accent)}
+  #gauntlet .gx-dr-t b{display:block;font:650 13.5px/1.25 Inter,sans-serif;color:var(--ink)}
+  #gauntlet .gx-dr-t span{font-size:12px;color:var(--muted)}
+  #gauntlet .gx-seal{margin-top:16px;text-align:center;font:800 11px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent);opacity:0;transform:scale(0.96);transition:opacity 0.5s cubic-bezier(0.16,1,0.3,1),transform 0.5s cubic-bezier(0.16,1,0.3,1)}
+  #gauntlet .gx-seal.on{opacity:1;transform:scale(1)}
+  @media (max-width:880px){
+    #gauntlet{padding:64px 20px}
+    #gauntlet .gx{grid-template-columns:1fr;gap:38px}
+    #gauntlet h2{font-size:30px}
+  }
+  @media (prefers-reduced-motion:reduce){
+    #gauntlet .gx-dr,#gauntlet .gx-seal{transition:none !important;opacity:1 !important;transform:none !important}
+  }
+</style>
+
+<section class="gauntlet-section" id="gauntlet">
+  <div class="gx-wrap">
+    <div class="gx">
+      <div class="gx-copy">
+        <span class="gx-kicker"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 17l6-6-6-6"></path><path d="M12 19h8"></path></svg>Reword Gauntlet &middot; Pro</span>
+        <h2>Memorized the practice test? The real exam <em>re-words everything.</em></h2>
+        <p class="gx-lede">The Gauntlet asks one concept five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it <b>in any wording</b>. Miss one, and it rebuilds the whole run with fresh questions. There's nothing to memorize.</p>
+        <p class="gx-proof">Built from how people actually fail: candidates who ace question banks, then meet an exam that never repeats itself.</p>
+        <div class="gx-cta-row">
+          <a class="gx-btn" href="/pricing">Go Pro — unlimited</a>
+          <span class="gx-cta-note">Works on every cert in the library, automatically.</span>
+        </div>
+      </div>
+      <div class="gx-demo" aria-hidden="true">
+        <div class="gx-demo-k"><span>The Gauntlet</span><span id="gx-demo-count">Rung 1 / 5</span></div>
+        <div class="gx-demo-concept">HTTPS rides port 443</div>
+        <div class="gx-rungs" id="gx-demo-rungs">
+          <div class="gx-dr"><span class="gx-dr-n">1</span><span class="gx-dr-t"><b>Plain</b><span>Which port does HTTPS use?</span></span></div>
+          <div class="gx-dr"><span class="gx-dr-n">2</span><span class="gx-dr-t"><b>Scenario</b><span>A storefront needs encrypted checkout traffic allowed&hellip;</span></span></div>
+          <div class="gx-dr"><span class="gx-dr-n">3</span><span class="gx-dr-t"><b>Best-of</b><span>Which rule BEST limits the exposure&hellip;</span></span></div>
+          <div class="gx-dr"><span class="gx-dr-n">4</span><span class="gx-dr-t"><b>Not-trap</b><span>Which of these is NOT carried over 443&hellip;</span></span></div>
+          <div class="gx-dr"><span class="gx-dr-n">5</span><span class="gx-dr-t"><b>Twisted</b><span>Two services share a host; only one handshake&hellip;</span></span></div>
+        </div>
+        <div class="gx-seal" id="gx-demo-seal">&#10003; Concept cracked</div>
+      </div>
+    </div>
+  </div>
+  <script>
+    /* Looping demo: rungs light in sequence, seal stamps, hold, reset.
+       Starts on first scroll-into-view (same IO pattern as the other
+       sections); reduced-motion users get the final state instantly. */
+    (function(){
+      var rungs=Array.prototype.slice.call(document.querySelectorAll('#gx-demo-rungs .gx-dr'));
+      var seal=document.getElementById('gx-demo-seal');
+      var count=document.getElementById('gx-demo-count');
+      if(!rungs.length||!seal||!count)return;
+      var reduced=window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if(reduced){count.textContent='5 / 5';return;}
+      var i=0,started=false;
+      function tick(){
+        if(i<rungs.length){
+          rungs[i].classList.add('on');
+          count.textContent='Rung '+(i+1)+' / 5';
+          i++;
+          setTimeout(tick,650);
+        }else{
+          seal.classList.add('on');
+          count.textContent='Cracked';
+          setTimeout(function(){
+            rungs.forEach(function(r){r.classList.remove('on');});
+            seal.classList.remove('on');
+            i=0;
+            setTimeout(tick,700);
+          },2100);
+        }
+      }
+      function start(){ if(started)return; started=true; setTimeout(tick,600); }
+      var s=document.getElementById('gauntlet');
+      if('IntersectionObserver' in window){
+        var io=new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting){start();io.disconnect();}});},{threshold:0.25});
+        io.observe(s);
+      } else { start(); }
+    })();
+  </script>
+</section>
+
+<!-- ══════════════════════════════════════════
      WHY READY (v2) · "Walk in knowing" efficacy + credibility hook.
      Editorial headline + anonymous founder line + ghost diagnostic CTA
      + a 3-step readiness panel (not a 3-equal-card row). FULLY SCOPED

--- a/lift-shell.js
+++ b/lift-shell.js
@@ -137,6 +137,8 @@
      applyDomainPreset. Must never block navigation. */
   function liftRenderDrills() {
     try {
+      /* v7.48.0: Reword Gauntlet hero card pill ("N cracked") */
+      if (typeof renderGauntletDrillsCard === 'function') { try { renderGauntletDrillsCard(); } catch (_) {} }
       var bank = (typeof loadWrongBank === 'function') ? loadWrongBank() : [];
       var n = bank.length;
       var pill = document.getElementById('drills-mistakes-pill');

--- a/mockups/landing-gauntlet-section.html
+++ b/mockups/landing-gauntlet-section.html
@@ -5,27 +5,27 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>certanvil.com · Reword Gauntlet section mockup</title>
 <style>
-  /* certanvil.com landing tokens (locked brand: cream + bronze + Fraunces) */
+  /* certanvil.com landing tokens (brand OKLCH per BRAND.md §3, light theme) */
   :root {
-    --bg: #f7f5f0; --surface: #ffffff; --ink: #221d15; --ink-soft: #5a5347;
-    --muted: #8d8678; --border: rgba(34,29,21,0.12); --border-soft: rgba(34,29,21,0.07);
-    --accent: #8a5a14; --accent-bright: #b07a24; --on-accent: #fff8ec;
-    --pass: #2f7d44; --fail: #b3372f;
-    --ease: cubic-bezier(0.23, 1, 0.32, 1);
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280);
+    --muted: oklch(0.50 0.013 280); --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-bright: oklch(0.80 0.155 64); --on-accent: oklch(0.985 0.010 85);
+    --pass: oklch(0.52 0.13 150); --fail: oklch(0.52 0.19 25);
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
   }
   * { box-sizing: border-box; margin: 0; }
-  body { background: #e9e5dc; color: var(--ink); font: 400 15px/1.55 Inter, -apple-system, sans-serif; padding: 40px 20px 70px; }
+  body { background: oklch(0.92 0.010 85); color: var(--ink); font: 400 15px/1.55 Inter, -apple-system, sans-serif; padding: 40px 20px 70px; }
   .stage-head { max-width: 1080px; margin: 0 auto 24px; }
-  .stage-eyebrow { font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 8px; }
+  .stage-eyebrow { font: 800 10.5px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 8px; }
   .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; color: var(--ink); }
   .stage-sub { color: var(--muted); font-size: 13px; margin-top: 7px; max-width: 72ch; }
   .stage-sub b { color: var(--ink); }
 
   /* The section as it will sit on certanvil.com (after the pricing teaser) */
-  .canvas { max-width: 1080px; margin: 0 auto; background: var(--bg); border-radius: 18px; padding: 84px 64px; box-shadow: 0 30px 80px -45px rgba(34,29,21,0.35); }
+  .canvas { max-width: 1080px; margin: 0 auto; background: var(--bg); border-radius: 18px; padding: 84px 64px; box-shadow: 0 30px 80px -45px color-mix(in oklab, var(--ink) 35%, transparent); }
 
   .gx { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 64px; align-items: center; }
-  .gx-copy .kicker { font: 700 11px/1 Inter, sans-serif; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); display: inline-flex; align-items: center; gap: 7px; margin-bottom: 18px; }
+  .gx-copy .kicker { font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); display: inline-flex; align-items: center; gap: 7px; margin-bottom: 18px; }
   .gx-copy .kicker svg { width: 12px; height: 12px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
   .gx-copy h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 38px; line-height: 1.13; letter-spacing: -0.015em; }
   .gx-copy h2 em { font-style: italic; color: var(--accent); }
@@ -35,11 +35,11 @@
   .gx-cta-row { display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
   .btn-primary { background: var(--accent); color: var(--on-accent); border: 0; border-radius: 10px; padding: 14px 26px; font: 700 15px/1 Inter, sans-serif; cursor: pointer; text-decoration: none; display: inline-block; transition: transform 0.16s var(--ease), filter 0.2s ease; }
   .btn-primary:active { transform: scale(0.97); }
-  @media (hover:hover) { .btn-primary:hover { filter: brightness(1.08); } }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.08); } }
   .gx-cta-note { font-size: 13px; color: var(--muted); }
 
   /* Demo card: a gauntlet run replaying itself */
-  .demo { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 26px 24px; box-shadow: 0 18px 50px -30px rgba(34,29,21,0.3); }
+  .demo { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 26px 24px; box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 18px 50px -30px color-mix(in oklab, var(--ink) 30%, transparent); }
   .demo-k { font: 700 10px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin-bottom: 16px; display: flex; justify-content: space-between; }
   .demo-k span:last-child { color: var(--accent); }
   .demo-concept { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 19px; margin-bottom: 18px; }
@@ -50,7 +50,7 @@
   .dr.on .dr-n { background: var(--accent); color: var(--on-accent); }
   .dr-t b { display: block; font: 650 13.5px/1.25 Inter, sans-serif; }
   .dr-t span { font-size: 12px; color: var(--muted); }
-  .demo-seal { margin-top: 16px; text-align: center; font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); opacity: 0; transform: scale(0.92); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease); }
+  .demo-seal { margin-top: 16px; text-align: center; font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); opacity: 0; transform: scale(0.96); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease); }
   .demo-seal.on { opacity: 1; transform: scale(1); }
 
   @media (max-width: 880px) {

--- a/mockups/landing-gauntlet-section.html
+++ b/mockups/landing-gauntlet-section.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>certanvil.com · Reword Gauntlet section mockup</title>
+<style>
+  /* certanvil.com landing tokens (locked brand: cream + bronze + Fraunces) */
+  :root {
+    --bg: #f7f5f0; --surface: #ffffff; --ink: #221d15; --ink-soft: #5a5347;
+    --muted: #8d8678; --border: rgba(34,29,21,0.12); --border-soft: rgba(34,29,21,0.07);
+    --accent: #8a5a14; --accent-bright: #b07a24; --on-accent: #fff8ec;
+    --pass: #2f7d44; --fail: #b3372f;
+    --ease: cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: #e9e5dc; color: var(--ink); font: 400 15px/1.55 Inter, -apple-system, sans-serif; padding: 40px 20px 70px; }
+  .stage-head { max-width: 1080px; margin: 0 auto 24px; }
+  .stage-eyebrow { font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 8px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; color: var(--ink); }
+  .stage-sub { color: var(--muted); font-size: 13px; margin-top: 7px; max-width: 72ch; }
+  .stage-sub b { color: var(--ink); }
+
+  /* The section as it will sit on certanvil.com (after the pricing teaser) */
+  .canvas { max-width: 1080px; margin: 0 auto; background: var(--bg); border-radius: 18px; padding: 84px 64px; box-shadow: 0 30px 80px -45px rgba(34,29,21,0.35); }
+
+  .gx { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 64px; align-items: center; }
+  .gx-copy .kicker { font: 700 11px/1 Inter, sans-serif; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); display: inline-flex; align-items: center; gap: 7px; margin-bottom: 18px; }
+  .gx-copy .kicker svg { width: 12px; height: 12px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .gx-copy h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 38px; line-height: 1.13; letter-spacing: -0.015em; }
+  .gx-copy h2 em { font-style: italic; color: var(--accent); }
+  .gx-copy .lede { color: var(--ink-soft); font-size: 16px; line-height: 1.6; margin: 18px 0 6px; max-width: 46ch; }
+  .gx-copy .lede b { color: var(--ink); }
+  .gx-proof { font-size: 13.5px; color: var(--muted); margin: 14px 0 26px; }
+  .gx-cta-row { display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
+  .btn-primary { background: var(--accent); color: var(--on-accent); border: 0; border-radius: 10px; padding: 14px 26px; font: 700 15px/1 Inter, sans-serif; cursor: pointer; text-decoration: none; display: inline-block; transition: transform 0.16s var(--ease), filter 0.2s ease; }
+  .btn-primary:active { transform: scale(0.97); }
+  @media (hover:hover) { .btn-primary:hover { filter: brightness(1.08); } }
+  .gx-cta-note { font-size: 13px; color: var(--muted); }
+
+  /* Demo card: a gauntlet run replaying itself */
+  .demo { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 26px 24px; box-shadow: 0 18px 50px -30px rgba(34,29,21,0.3); }
+  .demo-k { font: 700 10px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin-bottom: 16px; display: flex; justify-content: space-between; }
+  .demo-k span:last-child { color: var(--accent); }
+  .demo-concept { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 19px; margin-bottom: 18px; }
+  .demo-rungs { display: flex; flex-direction: column; gap: 10px; }
+  .dr { display: flex; align-items: center; gap: 12px; border: 1px solid var(--border-soft); border-radius: 11px; padding: 11px 14px; opacity: 0.35; transform: translateX(6px); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease), border-color 0.5s ease; }
+  .dr.on { opacity: 1; transform: translateX(0); border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); }
+  .dr-n { width: 24px; height: 24px; border-radius: 50%; display: grid; place-items: center; flex: none; font: 800 11px/1 Inter, sans-serif; background: color-mix(in oklab, var(--accent) 11%, transparent); color: var(--accent); }
+  .dr.on .dr-n { background: var(--accent); color: var(--on-accent); }
+  .dr-t b { display: block; font: 650 13.5px/1.25 Inter, sans-serif; }
+  .dr-t span { font-size: 12px; color: var(--muted); }
+  .demo-seal { margin-top: 16px; text-align: center; font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); opacity: 0; transform: scale(0.92); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease); }
+  .demo-seal.on { opacity: 1; transform: scale(1); }
+
+  @media (max-width: 880px) {
+    .canvas { padding: 54px 26px; }
+    .gx { grid-template-columns: 1fr; gap: 38px; }
+    .gx-copy h2 { font-size: 30px; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dr, .demo-seal { transition: none !important; opacity: 1 !important; transform: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<div class="stage-head">
+  <p class="stage-eyebrow">certanvil.com · landing · after the pricing teaser</p>
+  <h1 class="stage-title">Reword Gauntlet: landing section</h1>
+  <p class="stage-sub">Slots in right after the pricing teaser band, where the "why Pro" story peaks. The demo card replays a five-rung run on a loop (4s cycle), so the mechanic explains itself without a word of instruction. <b>Lift 1:1 into landing/index.html</b>: section markup + scoped styles, same pattern as every landing lift.</p>
+</div>
+
+<div class="canvas">
+  <section class="gx">
+    <div class="gx-copy">
+      <span class="kicker"><svg viewBox="0 0 24 24"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>Reword Gauntlet &middot; Pro</span>
+      <h2>Memorized the practice test? The real exam <em>re-words everything.</em></h2>
+      <p class="lede">The Gauntlet asks one concept five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it <b>in any wording</b>. Miss one, and it rebuilds the whole run with fresh questions. There's nothing to memorize.</p>
+      <p class="gx-proof">Built from how people actually fail: candidates who ace question banks, then meet an exam that never repeats itself.</p>
+      <div class="gx-cta-row">
+        <a class="btn-primary" href="/pricing">Go Pro — unlimited</a>
+        <span class="gx-cta-note">Works on every cert in the library, automatically.</span>
+      </div>
+    </div>
+    <div class="demo" aria-hidden="true">
+      <div class="demo-k"><span>The Gauntlet</span><span id="demoCount">Rung 1 / 5</span></div>
+      <div class="demo-concept">HTTPS rides port 443</div>
+      <div class="demo-rungs" id="demoRungs">
+        <div class="dr"><span class="dr-n">1</span><span class="dr-t"><b>Plain</b><span>Which port does HTTPS use?</span></span></div>
+        <div class="dr"><span class="dr-n">2</span><span class="dr-t"><b>Scenario</b><span>A storefront needs encrypted checkout traffic allowed&hellip;</span></span></div>
+        <div class="dr"><span class="dr-n">3</span><span class="dr-t"><b>Best-of</b><span>Which rule BEST limits the exposure&hellip;</span></span></div>
+        <div class="dr"><span class="dr-n">4</span><span class="dr-t"><b>Not-trap</b><span>Which of these is NOT carried over 443&hellip;</span></span></div>
+        <div class="dr"><span class="dr-n">5</span><span class="dr-t"><b>Twisted</b><span>Two services share a host; only one handshake&hellip;</span></span></div>
+      </div>
+      <div class="demo-seal" id="demoSeal">&#10003; Concept cracked</div>
+    </div>
+  </section>
+</div>
+
+<script>
+  // Looping demo: rungs light up in sequence, seal stamps, brief hold, reset.
+  (function () {
+    var rungs = Array.prototype.slice.call(document.querySelectorAll('#demoRungs .dr'));
+    var seal = document.getElementById('demoSeal');
+    var count = document.getElementById('demoCount');
+    var reduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduced) { count.textContent = '5 / 5'; return; }
+    var i = 0;
+    function tick() {
+      if (i < rungs.length) {
+        rungs[i].classList.add('on');
+        count.textContent = 'Rung ' + (i + 1) + ' / 5';
+        i++;
+        setTimeout(tick, 650);
+      } else {
+        seal.classList.add('on');
+        count.textContent = 'Cracked';
+        setTimeout(function () {
+          rungs.forEach(function (r) { r.classList.remove('on'); });
+          seal.classList.remove('on');
+          i = 0;
+          setTimeout(tick, 700);
+        }, 2100);
+      }
+    }
+    setTimeout(tick, 600);
+  })();
+</script>
+</body>
+</html>

--- a/mockups/reword-gauntlet.html
+++ b/mockups/reword-gauntlet.html
@@ -5,29 +5,30 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>CertAnvil · Reword Gauntlet E2E mockup</title>
 <style>
-  /* ── Tokens (cert-ios lift grammar) ─────────────────────────────────── */
+  /* ── Tokens (brand OKLCH per BRAND.md §3 / dg-system.css; --accent-deep
+        carries the text-accent role: bright bronze on dark, deep on light) ── */
   :root, [data-theme="dark"] {
-    --bg: #0b0b11; --surface: #15151d; --surface-2: #1c1c26;
-    --ink: #f2f0eb; --ink-soft: #b9b5ac; --muted: #807c74;
-    --border: rgba(242,240,235,0.11); --border-soft: rgba(242,240,235,0.07);
-    --accent: #e8a33d; --accent-deep: #f0b35a; --on-accent: #181308;
-    --pass: #4ade80; --fail: #f87171;
-    --ease: cubic-bezier(0.23, 1, 0.32, 1);
-    --page-bg: #060609; --page-ink: #f2f0eb; --page-dim: #8a8680;
+    --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+    --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+    --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+    --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+    --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25);
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
+    --page-bg: oklch(0.13 0.008 275); --page-ink: oklch(0.96 0.006 275); --page-dim: oklch(0.66 0.012 275);
   }
   [data-theme="light"] {
-    --bg: #faf8f4; --surface: #ffffff; --surface-2: #f1ede5;
-    --ink: #1c1914; --ink-soft: #4f4a42; --muted: #8a847a;
-    --border: rgba(28,25,20,0.13); --border-soft: rgba(28,25,20,0.07);
-    --accent: #a8741f; --accent-deep: #8a5e16; --on-accent: #fff8ec;
-    --pass: #15803d; --fail: #b91c1c;
-    --page-bg: #efece5; --page-ink: #1c1914; --page-dim: #8a847a;
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+    --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+    --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25);
+    --page-bg: oklch(0.94 0.008 85); --page-ink: oklch(0.22 0.015 280); --page-dim: oklch(0.50 0.013 280);
   }
   * { box-sizing: border-box; margin: 0; }
   body { background: var(--page-bg); color: var(--page-ink); font: 400 14px/1.5 Inter, -apple-system, sans-serif; padding: 34px 22px 60px; }
 
   .stage-head { max-width: 1180px; margin: 0 auto 26px; }
-  .stage-eyebrow { font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 9px; }
+  .stage-eyebrow { font: 800 10.5px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 9px; }
   .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 25px; letter-spacing: -0.012em; }
   .stage-sub { color: var(--page-dim); font-size: 13px; margin-top: 8px; max-width: 76ch; line-height: 1.55; }
   .stage-sub b { color: var(--page-ink); }
@@ -53,9 +54,9 @@
   .footer { padding: 0 22px 26px; display: flex; flex-direction: column; gap: 9px; }
 
   /* shared atoms */
-  .pill { font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 14%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); border-radius: 999px; padding: 4px 8px; display: inline-flex; align-items: center; gap: 4px; }
+  .pill { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 14%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); border-radius: 999px; padding: 4px 8px; display: inline-flex; align-items: center; gap: 4px; }
   .pill svg { width: 10px; height: 10px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
-  .cta { width: 100%; border: 0; border-radius: 12px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 14.5px/1 Inter, sans-serif; display: inline-flex; align-items: center; justify-content: center; gap: 8px; box-shadow: 0 10px 24px -14px color-mix(in oklab, var(--accent) 75%, transparent); transition: transform 0.16s var(--ease); }
+  .cta { width: 100%; border: 0; border-radius: 12px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 14.5px/1 Inter, sans-serif; display: inline-flex; align-items: center; justify-content: center; gap: 8px; transition: transform 0.16s var(--ease); }
   .cta:active { transform: scale(0.97); }
   .ghost { width: 100%; background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 13px; color: var(--ink); font: 600 13px/1 Inter, sans-serif; cursor: pointer; transition: transform 0.16s var(--ease); }
   .ghost:active { transform: scale(0.97); }
@@ -68,7 +69,7 @@
   .rung.done .rung-bar i { transform: scaleX(1); transition: transform 0.45s var(--ease); }
   .rung.missed .rung-bar i { transform: scaleX(1); background: var(--fail); transition: transform 0.45s var(--ease); }
   .rung.live .rung-bar { box-shadow: 0 0 0 1.5px color-mix(in oklab, var(--accent) 55%, transparent); }
-  .rung-name { font: 700 8.5px/1 Inter, sans-serif; letter-spacing: 0.07em; text-transform: uppercase; color: var(--muted); margin-top: 6px; }
+  .rung-name { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); margin-top: 6px; }
   .rung.live .rung-name { color: var(--accent-deep); }
   .rung.done .rung-name { color: var(--ink-soft); }
 
@@ -87,14 +88,14 @@
   .cracked-n { font: 800 22px/1 Inter, sans-serif; color: var(--accent-deep); font-variant-numeric: tabular-nums; }
   .cracked-t { font-size: 12.5px; color: var(--ink-soft); line-height: 1.4; }
   .ladder-preview { display: flex; gap: 5px; margin: 16px 2px 0; }
-  .ladder-preview span { flex: 1; font: 700 8.5px/1 Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); text-align: center; padding-top: 8px; border-top: 3px solid var(--surface-2); }
+  .ladder-preview span { flex: 1; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); text-align: center; padding-top: 8px; border-top: 3px solid var(--surface-2); }
 
   /* ── Unit 2: In-rung ───────────────────────────────────────────────── */
   .q-card { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 17px 16px; }
-  .q-type { display: inline-flex; align-items: center; gap: 6px; font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 10px; }
+  .q-type { display: inline-flex; align-items: center; gap: 6px; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 10px; }
   .q-type::before { content: ""; width: 7px; height: 7px; border-radius: 2px; background: var(--accent); display: inline-block; }
   .q-text { font-size: 15px; line-height: 1.5; font-weight: 550; }
-  .q-text mark { background: color-mix(in oklab, var(--fail) 26%, transparent); color: inherit; padding: 1px 5px; border-radius: 5px; font-weight: 750; animation: hingeIn 0.5s var(--ease) 0.25s both; }
+  .q-text mark { background: color-mix(in oklab, var(--fail) 26%, transparent); color: inherit; padding: 1px 5px; border-radius: 5px; font-weight: 700; animation: hingeIn 0.5s var(--ease) 0.25s both; }
   @keyframes hingeIn { from { background: transparent; } to { background: color-mix(in oklab, var(--fail) 26%, transparent); } }
   .opts { display: flex; flex-direction: column; gap: 9px; margin-top: 14px; }
   .opt { text-align: left; border: 1px solid var(--border); background: var(--surface); border-radius: 12px; padding: 13px 14px; color: var(--ink); font: 500 13.5px/1.4 Inter, sans-serif; cursor: pointer; display: flex; gap: 10px; transition: transform 0.14s var(--ease), border-color 0.14s ease; }
@@ -113,8 +114,8 @@
   .seal-wrap { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; }
   .seal { width: 130px; height: 130px; border-radius: 50%; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 15%, transparent); border: 2px solid var(--accent); color: var(--accent); animation: sealIn 0.55s var(--ease) both; }
   .seal svg { width: 56px; height: 56px; stroke: currentColor; fill: none; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
-  @keyframes sealIn { 0% { transform: scale(0.7) rotate(-7deg); opacity: 0; } 70% { transform: scale(1.05) rotate(1deg); } 100% { transform: scale(1) rotate(0); opacity: 1; } }
-  .seal-k { font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent-deep); margin: 20px 0 8px; }
+  @keyframes sealIn { 0% { transform: scale(0.9) rotate(-7deg); opacity: 0; } 70% { transform: scale(1.05) rotate(1deg); } 100% { transform: scale(1) rotate(0); opacity: 1; } }
+  .seal-k { font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent-deep); margin: 20px 0 8px; }
   .seal-concept { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 22px; letter-spacing: -0.012em; max-width: 24ch; }
   .seal-sub { color: var(--ink-soft); font-size: 13px; margin-top: 10px; }
   .seal-sub b { color: var(--ink); }
@@ -124,10 +125,11 @@
   .seal-ladder i:nth-child(4) { animation-delay: 0.24s; } .seal-ladder i:nth-child(5) { animation-delay: 0.32s; }
   @keyframes rungPop { from { transform: scaleX(0); } to { transform: scaleX(1); } }
   .streak-line { display: inline-flex; align-items: center; gap: 7px; margin-top: 16px; font: 650 12.5px/1 Inter, sans-serif; color: var(--ink-soft); border: 1px solid var(--border-soft); border-radius: 999px; padding: 8px 14px; background: var(--surface); }
+  .streak-line svg { width: 13px; height: 13px; stroke: var(--accent); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; flex: none; }
 
   /* ── Unit 4: Near-miss ─────────────────────────────────────────────── */
   .miss-head { text-align: center; margin-top: 12px; }
-  .miss-score { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; }
+  .miss-score { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum", "tnum"; }
   .miss-score b { color: var(--accent); }
   .miss-callout { font-size: 13.5px; color: var(--ink-soft); margin-top: 7px; }
   .miss-callout b { color: var(--fail); }
@@ -141,7 +143,7 @@
   .rr-t span { font-size: 11.5px; color: var(--muted); }
   .miss-promise { font-size: 12px; color: var(--muted); text-align: center; margin-top: 10px; }
 
-  .flag { position: absolute; bottom: 84px; right: -33px; transform: rotate(-90deg); transform-origin: center; font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted); }
+  .flag { position: absolute; bottom: 84px; right: -33px; transform: rotate(-90deg); transform-origin: center; font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
 
   @media (prefers-reduced-motion: reduce) { .seal, .seal-ladder i, .rung-bar i, .q-text mark { animation: none !important; transition: none !important; } }
 </style>
@@ -250,7 +252,7 @@
           <div class="seal-concept">VLSM subnet sizing</div>
           <div class="seal-ladder"><i></i><i></i><i></i><i></i><i></i></div>
           <p class="seal-sub">Five wordings, five answers. <b>That's 15 in your collection.</b></p>
-          <span class="streak-line">&#9889; Streak +1 &middot; 5 questions toward today's goal</span>
+          <span class="streak-line"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.07-2.14-.22-4.05 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.15.43-2.29 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></svg> Streak +1 &middot; 5 questions toward today's goal</span>
         </div>
       </div>
       <div class="footer">

--- a/mockups/reword-gauntlet.html
+++ b/mockups/reword-gauntlet.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CertAnvil · Reword Gauntlet E2E mockup</title>
+<style>
+  /* ── Tokens (cert-ios lift grammar) ─────────────────────────────────── */
+  :root, [data-theme="dark"] {
+    --bg: #0b0b11; --surface: #15151d; --surface-2: #1c1c26;
+    --ink: #f2f0eb; --ink-soft: #b9b5ac; --muted: #807c74;
+    --border: rgba(242,240,235,0.11); --border-soft: rgba(242,240,235,0.07);
+    --accent: #e8a33d; --accent-deep: #f0b35a; --on-accent: #181308;
+    --pass: #4ade80; --fail: #f87171;
+    --ease: cubic-bezier(0.23, 1, 0.32, 1);
+    --page-bg: #060609; --page-ink: #f2f0eb; --page-dim: #8a8680;
+  }
+  [data-theme="light"] {
+    --bg: #faf8f4; --surface: #ffffff; --surface-2: #f1ede5;
+    --ink: #1c1914; --ink-soft: #4f4a42; --muted: #8a847a;
+    --border: rgba(28,25,20,0.13); --border-soft: rgba(28,25,20,0.07);
+    --accent: #a8741f; --accent-deep: #8a5e16; --on-accent: #fff8ec;
+    --pass: #15803d; --fail: #b91c1c;
+    --page-bg: #efece5; --page-ink: #1c1914; --page-dim: #8a847a;
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: var(--page-bg); color: var(--page-ink); font: 400 14px/1.5 Inter, -apple-system, sans-serif; padding: 34px 22px 60px; }
+
+  .stage-head { max-width: 1180px; margin: 0 auto 26px; }
+  .stage-eyebrow { font: 700 10.5px/1 Inter, sans-serif; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 9px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 25px; letter-spacing: -0.012em; }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin-top: 8px; max-width: 76ch; line-height: 1.55; }
+  .stage-sub b { color: var(--page-ink); }
+  .theme-toggle { position: fixed; top: 22px; right: 22px; z-index: 50; background: var(--surface); color: var(--ink); border: 1px solid var(--border); border-radius: 999px; padding: 9px 14px; font: 650 12px/1 Inter, sans-serif; cursor: pointer; }
+
+  .phones { display: flex; flex-wrap: wrap; gap: 30px; justify-content: center; max-width: 1900px; margin: 0 auto; }
+  .unit { width: 390px; }
+  .unit-label { font: 700 11px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--page-dim); margin: 0 0 10px 6px; }
+  .unit-note { font-size: 12px; color: var(--page-dim); line-height: 1.5; margin: 12px 6px 0; }
+  .unit-note b { color: var(--page-ink); }
+
+  .phone { width: 390px; border-radius: 46px; padding: 10px; background: #000; box-shadow: 0 24px 70px -30px rgba(0,0,0,0.7); }
+  .screen { position: relative; border-radius: 38px; background: var(--bg); color: var(--ink); overflow: hidden; min-height: 760px; display: flex; flex-direction: column; }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 112px; height: 26px; border-radius: 16px; background: #000; z-index: 5; }
+  .statusbar { display: flex; justify-content: space-between; padding: 16px 26px 4px; font: 650 12.5px/1 Inter, sans-serif; }
+
+  .hdr { display: flex; align-items: center; justify-content: space-between; padding: 12px 18px 8px; }
+  .hdr h1 { font: 650 16px/1 Inter, sans-serif; letter-spacing: -0.01em; }
+  .hdr .back, .hdr .x { background: none; border: 0; color: var(--ink-soft); width: 34px; height: 34px; cursor: pointer; }
+  .hdr svg { width: 21px; height: 21px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+
+  .body { flex: 1; padding: 8px 22px 18px; display: flex; flex-direction: column; }
+  .footer { padding: 0 22px 26px; display: flex; flex-direction: column; gap: 9px; }
+
+  /* shared atoms */
+  .pill { font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 14%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); border-radius: 999px; padding: 4px 8px; display: inline-flex; align-items: center; gap: 4px; }
+  .pill svg { width: 10px; height: 10px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .cta { width: 100%; border: 0; border-radius: 12px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 14.5px/1 Inter, sans-serif; display: inline-flex; align-items: center; justify-content: center; gap: 8px; box-shadow: 0 10px 24px -14px color-mix(in oklab, var(--accent) 75%, transparent); transition: transform 0.16s var(--ease); }
+  .cta:active { transform: scale(0.97); }
+  .ghost { width: 100%; background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 13px; color: var(--ink); font: 600 13px/1 Inter, sans-serif; cursor: pointer; transition: transform 0.16s var(--ease); }
+  .ghost:active { transform: scale(0.97); }
+
+  /* ── Ladder (the run's spine) ───────────────────────────────────────── */
+  .ladder { display: flex; gap: 6px; margin: 6px 0 14px; }
+  .rung { flex: 1; text-align: center; }
+  .rung-bar { height: 5px; border-radius: 3px; background: var(--surface-2); overflow: hidden; position: relative; }
+  .rung-bar i { position: absolute; inset: 0; border-radius: 3px; transform: scaleX(0); transform-origin: left; background: var(--accent); }
+  .rung.done .rung-bar i { transform: scaleX(1); transition: transform 0.45s var(--ease); }
+  .rung.missed .rung-bar i { transform: scaleX(1); background: var(--fail); transition: transform 0.45s var(--ease); }
+  .rung.live .rung-bar { box-shadow: 0 0 0 1.5px color-mix(in oklab, var(--accent) 55%, transparent); }
+  .rung-name { font: 700 8.5px/1 Inter, sans-serif; letter-spacing: 0.07em; text-transform: uppercase; color: var(--muted); margin-top: 6px; }
+  .rung.live .rung-name { color: var(--accent-deep); }
+  .rung.done .rung-name { color: var(--ink-soft); }
+
+  /* ── Unit 1: Entry ──────────────────────────────────────────────────── */
+  .gauntlet-mark { width: 64px; height: 64px; margin: 18px auto 14px; border-radius: 50%; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 13%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 36%, transparent); color: var(--accent); }
+  .gauntlet-mark svg { width: 30px; height: 30px; stroke: currentColor; fill: none; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+  .entry-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 25px; letter-spacing: -0.014em; text-align: center; }
+  .entry-title i { color: var(--accent); }
+  .entry-lede { text-align: center; color: var(--ink-soft); font-size: 13.5px; line-height: 1.55; margin: 9px auto 18px; max-width: 30ch; }
+  .target { border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 15px 16px; }
+  .target-k { font: 700 10px/1 Inter, sans-serif; letter-spacing: 0.13em; text-transform: uppercase; color: var(--muted); margin-bottom: 7px; }
+  .target-v { font: 650 15.5px/1.3 Inter, sans-serif; }
+  .target-why { font-size: 12px; color: var(--muted); margin-top: 5px; }
+  .target-switch { background: none; border: 0; padding: 10px 0 0; color: var(--accent-deep); font: 650 12.5px/1 Inter, sans-serif; cursor: pointer; }
+  .cracked-row { display: flex; align-items: center; gap: 10px; margin-top: 14px; padding: 13px 15px; border: 1px solid var(--border-soft); border-radius: 14px; background: var(--surface); }
+  .cracked-n { font: 800 22px/1 Inter, sans-serif; color: var(--accent-deep); font-variant-numeric: tabular-nums; }
+  .cracked-t { font-size: 12.5px; color: var(--ink-soft); line-height: 1.4; }
+  .ladder-preview { display: flex; gap: 5px; margin: 16px 2px 0; }
+  .ladder-preview span { flex: 1; font: 700 8.5px/1 Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); text-align: center; padding-top: 8px; border-top: 3px solid var(--surface-2); }
+
+  /* ── Unit 2: In-rung ───────────────────────────────────────────────── */
+  .q-card { border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 17px 16px; }
+  .q-type { display: inline-flex; align-items: center; gap: 6px; font: 800 9.5px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); margin-bottom: 10px; }
+  .q-type::before { content: ""; width: 7px; height: 7px; border-radius: 2px; background: var(--accent); display: inline-block; }
+  .q-text { font-size: 15px; line-height: 1.5; font-weight: 550; }
+  .q-text mark { background: color-mix(in oklab, var(--fail) 26%, transparent); color: inherit; padding: 1px 5px; border-radius: 5px; font-weight: 750; animation: hingeIn 0.5s var(--ease) 0.25s both; }
+  @keyframes hingeIn { from { background: transparent; } to { background: color-mix(in oklab, var(--fail) 26%, transparent); } }
+  .opts { display: flex; flex-direction: column; gap: 9px; margin-top: 14px; }
+  .opt { text-align: left; border: 1px solid var(--border); background: var(--surface); border-radius: 12px; padding: 13px 14px; color: var(--ink); font: 500 13.5px/1.4 Inter, sans-serif; cursor: pointer; display: flex; gap: 10px; transition: transform 0.14s var(--ease), border-color 0.14s ease; }
+  .opt:active { transform: scale(0.985); }
+  .opt b { color: var(--muted); font-weight: 700; }
+  .opt.right { border-color: color-mix(in oklab, var(--pass) 55%, transparent); background: color-mix(in oklab, var(--pass) 9%, var(--surface)); }
+  .opt.wrong { border-color: color-mix(in oklab, var(--fail) 55%, transparent); background: color-mix(in oklab, var(--fail) 9%, var(--surface)); }
+  .verdict { margin-top: 13px; border-radius: 13px; padding: 13px 15px; border: 1px solid color-mix(in oklab, var(--fail) 30%, var(--border)); background: color-mix(in oklab, var(--fail) 6%, var(--surface)); }
+  .verdict.good { border-color: color-mix(in oklab, var(--pass) 30%, var(--border)); background: color-mix(in oklab, var(--pass) 6%, var(--surface)); }
+  .verdict-k { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 6px; color: var(--fail); }
+  .verdict.good .verdict-k { color: var(--pass); }
+  .verdict p { font-size: 12.5px; line-height: 1.55; color: var(--ink-soft); }
+  .verdict p b { color: var(--ink); }
+
+  /* ── Unit 3: Cracked ───────────────────────────────────────────────── */
+  .seal-wrap { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; }
+  .seal { width: 130px; height: 130px; border-radius: 50%; display: grid; place-items: center; background: color-mix(in oklab, var(--accent) 15%, transparent); border: 2px solid var(--accent); color: var(--accent); animation: sealIn 0.55s var(--ease) both; }
+  .seal svg { width: 56px; height: 56px; stroke: currentColor; fill: none; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
+  @keyframes sealIn { 0% { transform: scale(0.7) rotate(-7deg); opacity: 0; } 70% { transform: scale(1.05) rotate(1deg); } 100% { transform: scale(1) rotate(0); opacity: 1; } }
+  .seal-k { font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent-deep); margin: 20px 0 8px; }
+  .seal-concept { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 22px; letter-spacing: -0.012em; max-width: 24ch; }
+  .seal-sub { color: var(--ink-soft); font-size: 13px; margin-top: 10px; }
+  .seal-sub b { color: var(--ink); }
+  .seal-ladder { display: flex; gap: 6px; margin-top: 18px; width: 78%; }
+  .seal-ladder i { flex: 1; height: 5px; border-radius: 3px; background: var(--accent); animation: rungPop 0.4s var(--ease) both; }
+  .seal-ladder i:nth-child(2) { animation-delay: 0.08s; } .seal-ladder i:nth-child(3) { animation-delay: 0.16s; }
+  .seal-ladder i:nth-child(4) { animation-delay: 0.24s; } .seal-ladder i:nth-child(5) { animation-delay: 0.32s; }
+  @keyframes rungPop { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+  .streak-line { display: inline-flex; align-items: center; gap: 7px; margin-top: 16px; font: 650 12.5px/1 Inter, sans-serif; color: var(--ink-soft); border: 1px solid var(--border-soft); border-radius: 999px; padding: 8px 14px; background: var(--surface); }
+
+  /* ── Unit 4: Near-miss ─────────────────────────────────────────────── */
+  .miss-head { text-align: center; margin-top: 12px; }
+  .miss-score { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; }
+  .miss-score b { color: var(--accent); }
+  .miss-callout { font-size: 13.5px; color: var(--ink-soft); margin-top: 7px; }
+  .miss-callout b { color: var(--fail); }
+  .rung-report { display: flex; flex-direction: column; gap: 8px; margin: 18px 0 6px; }
+  .rr { display: flex; align-items: center; gap: 11px; border: 1px solid var(--border-soft); border-radius: 12px; padding: 11px 13px; background: var(--surface); }
+  .rr-ic { width: 22px; height: 22px; border-radius: 50%; display: grid; place-items: center; flex: none; }
+  .rr-ic svg { width: 13px; height: 13px; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+  .rr.ok .rr-ic { background: color-mix(in oklab, var(--pass) 14%, transparent); color: var(--pass); }
+  .rr.bad .rr-ic { background: color-mix(in oklab, var(--fail) 14%, transparent); color: var(--fail); }
+  .rr-t b { display: block; font: 650 13px/1.2 Inter, sans-serif; }
+  .rr-t span { font-size: 11.5px; color: var(--muted); }
+  .miss-promise { font-size: 12px; color: var(--muted); text-align: center; margin-top: 10px; }
+
+  .flag { position: absolute; bottom: 84px; right: -33px; transform: rotate(-90deg); transform-origin: center; font: 800 9px/1 Inter, sans-serif; letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted); }
+
+  @media (prefers-reduced-motion: reduce) { .seal, .seal-ladder i, .rung-bar i, .q-text mark { animation: none !important; transition: none !important; } }
+</style>
+</head>
+<body>
+
+<button class="theme-toggle" id="themeToggle" type="button">Light / Dark</button>
+
+<div class="stage-head">
+  <p class="stage-eyebrow">Cert app · all platforms · Pro</p>
+  <h1 class="stage-title">Reword Gauntlet: the full run</h1>
+  <p class="stage-sub">One concept, asked five ways: <b>Plain → Scenario → Best-of → Not-trap → Twisted</b>. The run always finishes all five rungs; the concept cracks only on a clean 5/5. A miss names the rung type that got you, and the retry generates <b>five fresh wordings</b>. That is the whole point. Concept is AI-picked from the weakest topic at generation; exemplar banks ground the phrasing per cert. Pro-only at every entry. Cracks persist to <b>STORAGE.GAUNTLET_CRACKED</b> (cloud-synced), count toward the streak, and questions count toward Today's goal.</p>
+</div>
+
+<div class="phones">
+
+  <!-- ① ENTRY -->
+  <div class="unit">
+    <p class="unit-label">① Entry</p>
+    <div class="phone"><div class="screen">
+      <div class="notch"></div>
+      <div class="statusbar"><span>9:41</span><span>●●●</span></div>
+      <div class="hdr">
+        <button class="back" type="button" aria-label="Back"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <h1>Reword Gauntlet</h1>
+        <span class="pill"><svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>Pro</span>
+      </div>
+      <div class="body">
+        <div class="gauntlet-mark"><svg viewBox="0 0 24 24"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg></div>
+        <h2 class="entry-title">Beat the concept in <i>every</i> disguise</h2>
+        <p class="entry-lede">Five questions on one concept. The wording never repeats.</p>
+        <div class="target">
+          <div class="target-k">Today's target</div>
+          <div class="target-v">Subnetting &amp; IP Addressing</div>
+          <div class="target-why">Your weakest topic right now</div>
+          <button class="target-switch" type="button">Pick a different topic</button>
+        </div>
+        <div class="cracked-row">
+          <span class="cracked-n">14</span>
+          <span class="cracked-t">concepts cracked so far.<br>Each one survived all five wordings.</span>
+        </div>
+        <div class="ladder-preview">
+          <span>Plain</span><span>Scenario</span><span>Best-of</span><span>Not-trap</span><span>Twisted</span>
+        </div>
+      </div>
+      <div class="footer">
+        <button class="cta" type="button">Start the Gauntlet</button>
+      </div>
+      <div class="flag">Concept · gauntlet entry</div>
+    </div></div>
+    <p class="unit-note"><b>Free users</b> reach this screen via the locked tile and get the standard Pro gate card on Start. Loading state after Start: <b>"Forging five disguises…"</b> on the shared loading page.</p>
+  </div>
+
+  <!-- ② IN-RUNG -->
+  <div class="unit">
+    <p class="unit-label">② Rung 4 of 5, answered wrong</p>
+    <div class="phone"><div class="screen">
+      <div class="notch"></div>
+      <div class="statusbar"><span>9:43</span><span>●●●</span></div>
+      <div class="hdr">
+        <button class="x" type="button" aria-label="Quit run"><svg viewBox="0 0 24 24"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+        <h1>VLSM subnet sizing</h1>
+        <span style="font:650 12px/1 Inter,sans-serif;color:var(--muted)">4/5</span>
+      </div>
+      <div class="body">
+        <div class="ladder">
+          <div class="rung done"><div class="rung-bar"><i></i></div><div class="rung-name">Plain</div></div>
+          <div class="rung done"><div class="rung-bar"><i></i></div><div class="rung-name">Scenario</div></div>
+          <div class="rung done"><div class="rung-bar"><i></i></div><div class="rung-name">Best-of</div></div>
+          <div class="rung missed live"><div class="rung-bar"><i></i></div><div class="rung-name">Not-trap</div></div>
+          <div class="rung"><div class="rung-bar"><i></i></div><div class="rung-name">Twisted</div></div>
+        </div>
+        <div class="q-card">
+          <span class="q-type">Not-trap</span>
+          <p class="q-text">Which of the following is <mark>NOT</mark> a valid host address in the 192.168.10.64/27 subnet?</p><!-- hinge highlight: the one word the rung pivots on -->
+          <div class="opts">
+            <button class="opt" type="button"><b>A</b>192.168.10.70</button>
+            <button class="opt wrong" type="button"><b>B</b>192.168.10.90</button>
+            <button class="opt right" type="button"><b>C</b>192.168.10.96</button>
+            <button class="opt" type="button"><b>D</b>192.168.10.65</button>
+          </div>
+        </div>
+        <div class="verdict">
+          <div class="verdict-k">The hinge: "NOT"</div>
+          <p>/27 gives hosts .65-.94 here, so <b>.96 sits outside the range</b>. The question wanted the address that <b>doesn't</b> belong. .90 is valid, which is exactly why it looks tempting.</p>
+        </div>
+      </div>
+      <div class="footer">
+        <button class="cta" type="button">Last rung &rarr;</button>
+      </div>
+      <div class="flag">Concept · in-rung feedback</div>
+    </div></div>
+    <p class="unit-note">The rung label teaches the <b>trap taxonomy by name</b>; the hinge word gets a highlight in the stem AND named in the verdict. Right answers get the same verdict card in green ("The hinge: 'BEST'. Three options work, one is cheapest").</p>
+  </div>
+
+  <!-- ③ CRACKED -->
+  <div class="unit">
+    <p class="unit-label">③ Cracked, clean 5/5</p>
+    <div class="phone"><div class="screen">
+      <div class="notch"></div>
+      <div class="statusbar"><span>9:46</span><span>●●●</span></div>
+      <div class="body">
+        <div class="seal-wrap">
+          <div class="seal"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></div>
+          <div class="seal-k">Concept cracked</div>
+          <div class="seal-concept">VLSM subnet sizing</div>
+          <div class="seal-ladder"><i></i><i></i><i></i><i></i><i></i></div>
+          <p class="seal-sub">Five wordings, five answers. <b>That's 15 in your collection.</b></p>
+          <span class="streak-line">&#9889; Streak +1 &middot; 5 questions toward today's goal</span>
+        </div>
+      </div>
+      <div class="footer">
+        <button class="cta" type="button">Next target &rarr;</button>
+        <button class="ghost" type="button">Back to Drills</button>
+      </div>
+      <div class="flag">Concept · cracked</div>
+    </div></div>
+    <p class="unit-note">Seal stamps in with a 0.55s overshoot; the five rungs pop in sequence (staggered 80ms). <b>Reduced-motion users get the final state instantly.</b> "Next target" re-enters the loop with the next weakest topic pre-loaded.</p>
+  </div>
+
+  <!-- ④ NEAR-MISS -->
+  <div class="unit">
+    <p class="unit-label">④ Near-miss, 4/5</p>
+    <div class="phone"><div class="screen">
+      <div class="notch"></div>
+      <div class="statusbar"><span>9:46</span><span>●●●</span></div>
+      <div class="body">
+        <div class="miss-head">
+          <div class="miss-score">Cracked <b>4 of 5</b></div>
+          <p class="miss-callout">The <b>Not-trap</b> got you. One rung from the seal.</p>
+        </div>
+        <div class="rung-report">
+          <div class="rr ok"><span class="rr-ic"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><span class="rr-t"><b>Plain</b><span>Straight definition</span></span></div>
+          <div class="rr ok"><span class="rr-ic"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><span class="rr-t"><b>Scenario</b><span>Real-world setup</span></span></div>
+          <div class="rr ok"><span class="rr-ic"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><span class="rr-t"><b>Best-of</b><span>One word decides it</span></span></div>
+          <div class="rr bad"><span class="rr-ic"><svg viewBox="0 0 24 24"><path d="M18 6 6 18M6 6l12 12"/></svg></span><span class="rr-t"><b>Not-trap</b><span>The negation flip</span></span></div>
+          <div class="rr ok"><span class="rr-ic"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><span class="rr-t"><b>Twisted</b><span>Trickiest phrasing</span></span></div>
+        </div>
+        <p class="miss-promise">Run it again and every question is re-worded from scratch. There's nothing to memorize. That's the point.</p>
+      </div>
+      <div class="footer">
+        <button class="cta" type="button">Run it again</button>
+        <button class="ghost" type="button">Different concept</button>
+      </div>
+      <div class="flag">Concept · near-miss</div>
+    </div></div>
+    <p class="unit-note">The open loop ("one rung from the seal") is deliberate: the retry is one tap and regenerates everything. Attempts count is stored per concept, so the eventual crack can say <b>"took 3 runs. Earned."</b></p>
+  </div>
+
+</div>
+
+<script>
+  (function () {
+    var root = document.documentElement;
+    try { var saved = localStorage.getItem('ca-theme'); if (saved) root.setAttribute('data-theme', saved); } catch (e) {}
+    document.getElementById('themeToggle').addEventListener('click', function () {
+      var next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+      root.setAttribute('data-theme', next);
+      try { localStorage.setItem('ca-theme', next); } catch (e) {}
+    });
+  })();
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.47.0",
+  "version": "7.48.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.47.0
+   Network+ AI Quiz — styles.css  v7.48.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.47.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.47.0';
+// Service Worker v7.48.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.48.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -4018,7 +4018,8 @@ test('v4.54.0 JS: goSetup calls renderHeroV2',
   // v4.99.38: window bumped from 1500 → 2000 after _portDrillTeardown
   // shell-callable hook added in goSetup body.
   // v4.99.42: window bumped 2000 → 2500 after 3rd teardown hook (_subnetTrainerTeardown).
-  /function goSetup\([\s\S]{0,2500}renderHeroV2/.test(js));
+  // v7.48.0: window bumped 2500 → 2900 after the gauntlet-mode reset block in goSetup.
+  /function goSetup\([\s\S]{0,2900}renderHeroV2/.test(js));
 // v4.81.20: tombstone — focus-banner v2 structure was retired (the function
 // is now a compat shim that delegates to renderTodayPlan). The CSS for
 // .focus-banner-v2 + .fb-* classes is retained for the (now hidden)


### PR DESCRIPTION
## What

The Reword Gauntlet (v7.48.0): one AI-picked concept from your weakest topic, asked five ways (Plain → Scenario → Best-of → Not-trap → Twisted). The run always finishes all five rungs; the concept cracks only on a clean 5/5. A miss names the rung type that got you, and "Run it again" regenerates five fresh wordings. Pro-only at Start.

Spec: `docs/planning/REWORD-GAUNTLET-SPEC-2026-06-11.md` (approved 2026-06-11). Mockups brand-audited against `design/brand/BRAND.md` before lifting (report: `audit-workspace/brand-audit.md`).

## How

- `_fetchGauntletRun()`: ONE metered `CLAUDE_MODEL` call (topic + exemplar slice + 5-rung recipe → `{concept, rungs[5]}` with per-rung shape validation incl. `hinge`; any bad rung fails the whole run, friendly retry, nothing recorded)
- Run rides the existing quiz engine as `gauntletMode`: rung ladder replaces the dot strip, hinge word highlighted in the stem + named in the verdict, first answer freezes each rung result, `addToWrongBank` no-ops (parallel to bank/SR per spec)
- `STORAGE.GAUNTLET_CRACKED` (+ cloud flush), history entry feeds Today's goal, streak credit, cracked/near-miss verdict screens per mockup
- Entry points: Drills hero card, Home Practice option, entry screen viewable by free users with `_gateProOnly` on Start; offline note, double-tap guard, quota pre-check
- Landing: `#gauntlet` section with looping five-rung demo (placed at the why-Pro peak between proof-of-product and why-ready; the spec's "pricing teaser band" doesn't exist on the live landing)
- Sec-P7: all new handlers via `data-action` delegation (ratchet ceilings untouched)
- Four formal audit passes run on the BUILT surfaces with fixes (contrast token swap, ladder class reconciliation, em-dash removals, zero-state pill copy)

## Checks

- UAT 4109/4109 (incl. goSetup pin widened 2500→2900 with dated comment)
- tech-debt breaches pre-existing (identical with this diff stashed); none of the 9 dead functions are new
- Preview-verified on 4182 both themes: entry, simulated run, hinge verdicts, near-miss, cracked, free-tier gate, drills pill
- bump-version 7.48.0 across all surfaces + dg-system.css?v hand-bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)