### PR TITLE
v7.48.1 — Gauntlet hotfixes: 'undefined' answer options + desktop back routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.48.1 | Gauntlet back routing — desktop returns Home, never the mobile-only drills page |
 | v7.48.0 | Reword Gauntlet — flagship drill: one concept five ways, crack on 5/5, Pro-only |
 | v7.47.0 | Mistake Autopsy — wrong-bank questions return re-worded, beating the concept not the question |
 | v7.46.1 | Pro-gate polish — modal rebuilt in house design language, per-feature copy, pill consolidation |

--- a/app.js
+++ b/app.js
@@ -6384,10 +6384,30 @@ function _renderResultsReviewList() {
 // multi-answer entries run verbatim. Any AI failure falls back to the
 // verbatim originals — the drill never breaks because a reword didn't
 // arrive.
+// v7.48.1 — option-shape helpers. The HOUSE format for q.options is a
+// letter-keyed object ({"A":"..."} — the fetchQuestions contract renderMCQ
+// reads via q.options[letter]); AI sub-prompts (reword, gauntlet) return
+// positional ARRAYS. Letterize at the boundary, never hand renderMCQ an
+// array (the 'undefined options' incident, 2026-06-12).
+function _letterizeOptions(arr) {
+  if (!Array.isArray(arr)) return arr;
+  const o = {};
+  arr.forEach((t, i) => { o[String.fromCharCode(65 + i)] = t; });
+  return o;
+}
+function _optionCount(o) {
+  return Array.isArray(o) ? o.length : (o && typeof o === 'object' ? Object.keys(o).length : 0);
+}
+
 async function _fetchRewordedVariants(key, entries) {
   const numbered = entries.map(function (b, i) {
-    const correctIdx = 'ABCDEF'.indexOf((b.answer || 'A').trim().toUpperCase());
-    const correctText = (Array.isArray(b.options) && b.options[correctIdx]) || '';
+    const letter = (b.answer || 'A').trim().toUpperCase();
+    const correctIdx = 'ABCDEF'.indexOf(letter);
+    // bank entries are letter-keyed objects (house format); legacy array
+    // entries still resolve by position (v7.48.1)
+    const correctText = Array.isArray(b.options)
+      ? (b.options[correctIdx] || '')
+      : ((b.options && b.options[letter]) || '');
     return (i + 1) + '. Topic: ' + (b.topic || 'general') +
       '\n   Original question: ' + b.question +
       '\n   The fact being tested (the correct answer): ' + correctText;
@@ -6474,8 +6494,11 @@ async function startWrongDrill() {
 
   // v7.47.0 Mistake Autopsy: re-word the single-answer MCQs (signed-in only —
   // the reword rides the AI proxy). Verbatim fallback on any failure.
+  // v7.48.1: the bank stores HOUSE-FORMAT options (letter-keyed object, the
+  // fetchQuestions contract) — the old Array.isArray filter silently no-oped
+  // the feature for object-shaped entries. Accept both shapes.
   const rewordable = base.filter(q =>
-    (q.type || 'mcq') === 'mcq' && !q.answers && q.answer && Array.isArray(q.options) && q.options.length >= 3);
+    (q.type || 'mcq') === 'mcq' && !q.answers && q.answer && _optionCount(q.options) >= 3);
   if (rewordable.length > 0 && typeof window !== 'undefined' && window._certanvilSignedIn === true) {
     const lp = document.getElementById('load-progress');
     if (lp) lp.classList.add('is-hidden');
@@ -6489,7 +6512,10 @@ async function startWrongDrill() {
         const v = variants[i];
         if (v) {
           q.question = v.question;
-          q.options = v.options;
+          // v7.48.1: renderMCQ reads q.options[letter] — letterize the AI's
+          // array into the house letter-keyed object (the 'undefined options'
+          // class of bug, caught live on the Gauntlet 2026-06-12).
+          q.options = _letterizeOptions(v.options);
           q.answer = v.answer.trim().toUpperCase();
           q.explanation = v.explanation || q.explanation;
           q._reworded = true;
@@ -6668,6 +6694,7 @@ async function _fetchGauntletRun(topicName, forcedConcept) {
     rungs.length === 5 && rungs.every(r =>
       r && typeof r.question === 'string' && r.question.length > 20 &&
       Array.isArray(r.options) && r.options.length === 4 &&
+      r.options.every(o => typeof o === 'string' && o.length > 0) &&
       typeof r.answer === 'string' && /^[A-D]$/.test(r.answer.trim().toUpperCase()) &&
       typeof r.explanation === 'string' && r.explanation.length > 0 &&
       typeof r.hinge === 'string' && r.hinge.length > 0);
@@ -6730,7 +6757,9 @@ async function gauntletStart(opts) {
   activeQuizTopic = topicName;
   questions = run.rungs.map((r, i) => ({
     question: r.question,
-    options: r.options,
+    // v7.48.1: letterize — renderMCQ reads q.options[letter], the AI returns
+    // a positional array. Raw arrays render four 'undefined' options.
+    options: _letterizeOptions(r.options),
     answer: r.answer.trim().toUpperCase(),
     explanation: r.explanation,
     hinge: r.hinge,

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.48.0
+// Network+ AI Quiz — app.js  v7.48.1
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.48.0';
+const APP_VERSION = '7.48.1';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -1158,6 +1158,11 @@ let gauntletMode = false;     // a gauntlet run is riding the quiz engine
 let _gauntletRun = null;      // { concept, topic, results: [bool x5], attempts }
 let _gauntletBusy = false;    // in-flight guard: double-tap on Start
 let _gauntletTopic = null;    // entry-screen topic override (null = weakest)
+let _gauntletReturn = 'setup'; // v7.48.1: where Back/exit returns to — 'drills'
+                               // only when entered FROM the (mobile-only)
+                               // drills page; #page-drills is unstyled on
+                               // desktop (cert-ios lift surface), so desktop
+                               // users must route back to Home
 
 // Multi-select state (regular quiz)
 let msSelections = [];
@@ -6556,11 +6561,26 @@ function loadGauntletCracked() {
 // viewable by free users (funnel tease) — the Pro gate fires on Start.
 function startRewordGauntlet() {
   _gauntletTopic = null;
+  // v7.48.1: remember the entry origin — Back must never route a desktop
+  // user to the mobile-only drills page.
+  const active = document.querySelector('.page.active');
+  _gauntletReturn = (active && active.id === 'page-drills') ? 'drills' : 'setup';
   renderGauntletEntry();
   showPage('gauntlet');
 }
 
+// Back/exit routing for the gauntlet surfaces (entry back button + result
+// screen ghost CTA). 'setup' goes through goSetup() for the full home
+// re-render + mode reset.
+function gauntletBack() {
+  if (_gauntletReturn === 'drills') showPage('drills');
+  else goSetup();
+}
+
 function renderGauntletEntry() {
+  // v7.48.1: back label names the actual destination
+  const backLabel = document.getElementById('gnt-back-label');
+  if (backLabel) backLabel.textContent = _gauntletReturn === 'drills' ? 'Drills' : 'Home';
   const w = getWeakTopic();
   let topicName = _gauntletTopic || (w && w.topic) || null;
   if (!topicName && typeof getTodaysFocusTopics === 'function') {
@@ -6830,7 +6850,7 @@ function renderGauntletResult(cracked, results) {
       '</div>' +
       '<div class="gnt-result-footer">' +
         '<button type="button" class="btn btn-primary gnt-cta" data-action="gauntletNextTarget">Next target →</button>' +
-        '<button type="button" class="btn gnt-ghost" data-action="gauntletExit">Back to Drills</button>' +
+        '<button type="button" class="btn gnt-ghost" data-action="gauntletExit">' + (_gauntletReturn === 'drills' ? 'Back to Drills' : 'Back to Home') + '</button>' +
       '</div>';
   } else {
     const crackCount = results.filter(Boolean).length;
@@ -6879,7 +6899,7 @@ function gauntletNextTarget() {
 function gauntletExit() {
   _gauntletRun = null;
   if (typeof renderGauntletDrillsCard === 'function') { try { renderGauntletDrillsCard(); } catch (_) {} }
-  showPage('drills');
+  gauntletBack(); // v7.48.1: origin-aware — never the unstyled drills page on desktop
 }
 
 // Drills-page hero card pill ("N cracked").

--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.48.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.48.1</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>
@@ -1258,7 +1258,7 @@
 <div id="page-gauntlet" class="page">
   <div class="gnt-shell">
     <div class="gnt-hdr">
-      <button type="button" class="back-btn" data-action="showPage" data-args='["drills"]' aria-label="Back to Drills"><svg viewBox="0 0 24 24" aria-hidden="true" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg><span class="back-btn-label">Drills</span></button>
+      <button type="button" class="back-btn" data-action="gauntletBack" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg><span class="back-btn-label" id="gnt-back-label">Back</span></button>
       <h1 class="gnt-hdr-title">Reword Gauntlet</h1>
       <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.48.0",
+  "version": "7.48.1",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.48.0
+   Network+ AI Quiz — styles.css  v7.48.1
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.48.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.48.0';
+// Service Worker v7.48.1 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.48.1';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20059,6 +20059,22 @@ console.log('\n\x1b[1m── Security Phase 7 — CSP script-src unsafe-inline r
     /loadHistory\(\)\.length\s*===\s*0/.test(js) && /Start your first quiz/.test(js));
 })();
 
+// ── v7.48.1: option-shape contract — renderMCQ reads q.options[letter], so
+//    every AI sub-prompt that returns positional ARRAYS must letterize at
+//    the boundary (the live 'undefined options' Gauntlet incident) ──
+(function(){
+  test('v7.48.1 OptShape: _letterizeOptions helper defined (array → {A..D})',
+    /function _letterizeOptions\([\s\S]{0,300}String\.fromCharCode\(65/.test(js));
+  test('v7.48.1 OptShape: gauntlet rung mapping letterizes options before the quiz engine',
+    /options:\s*_letterizeOptions\(r\.options\)/.test(js));
+  test('v7.48.1 OptShape: reworded variant assignment letterizes options',
+    /q\.options\s*=\s*_letterizeOptions\(v\.options\)/.test(js));
+  test('v7.48.1 OptShape: reword eligibility accepts house letter-keyed options (no Array.isArray-only filter)',
+    /_optionCount\(q\.options\)\s*>=\s*3/.test(js));
+  test('v7.48.1 OptShape: gauntlet run validation rejects non-string/empty option elements',
+    /r\.options\.every\(o => typeof o === 'string' && o\.length > 0\)/.test(js));
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;


### PR DESCRIPTION
Two production fixes for v7.48.0:

1. **'undefined' answer options (the big one):** `renderMCQ` reads `q.options[letter]` (house format `{"A":"..."}`), but the gauntlet rung mapping and the v7.47 Mistake Autopsy reword path passed the AI's positional arrays straight through — every option rendered as 'undefined'. Both boundaries now letterize. Bonus catch: the reword eligibility filter required arrays while the bank stores objects, silently no-oping Mistake Autopsy — fixed, accepts both shapes. 5 new UAT guards pin the contract (4114/4114).

2. **Desktop back routing:** Back/exit from the Gauntlet hardwired the mobile-only drills page (unstyled on desktop). Now origin-aware: Home unless entered from the drills page; labels name the destination.

Both preview-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)