### PR TITLE
v7.49.0 — Gauntlet run topic strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.49.0 | Gauntlet run topic strip — the topic shows above the ladder throughout the run |
 | v7.48.1 | Gauntlet back routing — desktop returns Home, never the mobile-only drills page |
 | v7.48.0 | Reword Gauntlet — flagship drill: one concept five ways, crack on 5/5, Pro-only |
 | v7.47.0 | Mistake Autopsy — wrong-bank questions return re-worded, beating the concept not the question |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.48.1
+// Network+ AI Quiz — app.js  v7.49.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.48.1';
+const APP_VERSION = '7.49.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -6782,15 +6782,23 @@ function _renderGauntletLadder() {
   const el = document.getElementById('gauntlet-ladder');
   const dots = document.getElementById('quiz-prog-dots');
   const chip = document.getElementById('gauntlet-rung-chip');
+  const topicEl = document.getElementById('gauntlet-run-topic');
   if (!el) return;
   if (!gauntletMode || !_gauntletRun) {
     el.classList.add('is-hidden');
     if (dots) dots.classList.remove('is-hidden');
     if (chip) chip.classList.add('is-hidden');
+    if (topicEl) topicEl.classList.add('is-hidden');
     return;
   }
   if (dots) dots.classList.add('is-hidden');
   el.classList.remove('is-hidden');
+  // v7.49.0: name the battlefield — topic visible throughout the run (Simi).
+  // The precise concept stays hidden until the verdict: it IS the answer key.
+  if (topicEl) {
+    topicEl.innerHTML = '<span>The Gauntlet</span> · ' + escHtml(_gauntletRun.topic);
+    topicEl.classList.remove('is-hidden');
+  }
   // Build the five rung nodes ONCE, then reconcile classes in place — an
   // innerHTML rebuild would restart the bar-fill transition on every
   // already-done rung at each advance (emil pass 2, 2026-06-12).

--- a/dg-system.css
+++ b/dg-system.css
@@ -3743,6 +3743,9 @@ html.cl-locked,html.cl-locked body{overflow:hidden;}
 .gnt-ladder-preview{display:flex;gap:5px;margin:16px 2px 22px;}
 .gnt-ladder-preview span{flex:1;font:800 10px/1 Inter,sans-serif;letter-spacing:0.05em;text-transform:uppercase;color:var(--text-dim);text-align:center;padding-top:8px;border-top:3px solid var(--surface3);}
 /* ── in-rung ladder (rides #page-quiz in place of the dot strip) ── */
+/* v7.49.0: topic strip above the ladder — names the run's topic throughout */
+.gnt-run-topic{max-width:760px;margin:10px auto 6px;text-align:center;font:800 10px/1 Inter,sans-serif;letter-spacing:0.12em;text-transform:uppercase;color:var(--text-dim);}
+.gnt-run-topic span{color:var(--accent);}
 .gnt-ladder{display:flex;gap:6px;max-width:760px;margin:6px auto 14px;}
 .gnt-rung{flex:1;text-align:center;}
 .gnt-rung-bar{height:5px;border-radius:3px;background:var(--surface3);overflow:hidden;position:relative;}

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.48.0">
+<link rel="stylesheet" href="dg-system.css?v=7.49.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic
@@ -764,7 +764,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.48.1</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.49.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>
@@ -984,7 +984,10 @@
   <div class="quiz-prog-dots" id="quiz-prog-dots" role="progressbar" aria-label="Per-question progress"></div>
 
   <!-- v7.48.0: Reword Gauntlet rung ladder — replaces the dot strip during a
-       gauntlet run (rendered by _renderGauntletLadder, hidden otherwise) -->
+       gauntlet run (rendered by _renderGauntletLadder, hidden otherwise).
+       v7.49.0: topic strip above it — the TOPIC shows during the run; the
+       precise concept stays hidden (it contains the answers) until cracked. -->
+  <div class="gnt-run-topic is-hidden" id="gauntlet-run-topic"></div>
   <div class="gnt-ladder is-hidden" id="gauntlet-ladder" aria-label="Gauntlet rung progress"></div>
 
   <div class="q-card">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.48.1",
+  "version": "7.49.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.48.1
+   Network+ AI Quiz — styles.css  v7.49.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.48.1 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.48.1';
+// Service Worker v7.49.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.49.0';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
The run's topic now shows above the rung ladder throughout the Gauntlet (it was only visible on the entry screen). The precise concept stays hidden until cracked/near-miss — it contains the answers. UAT 4114/4114, preview-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)