### PR TITLE
v7.50.0 — Why-Not: the second flagship drill + combined landing section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.50.0 | Why-Not — second flagship drill: score the reasons, not just the answer; combined landing section |
 | v7.49.0 | Gauntlet run topic strip — the topic shows above the ladder throughout the run |
 | v7.48.1 | Gauntlet back routing — desktop returns Home, never the mobile-only drills page |
 | v7.48.0 | Reword Gauntlet — flagship drill: one concept five ways, crack on 5/5, Pro-only |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.49.0
+// Network+ AI Quiz — app.js  v7.50.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.49.0';
+const APP_VERSION = '7.50.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -1163,6 +1163,14 @@ let _gauntletReturn = 'setup'; // v7.48.1: where Back/exit returns to — 'drill
                                // drills page; #page-drills is unstyled on
                                // desktop (cert-ios lift surface), so desktop
                                // users must route back to Home
+
+// v7.50.0 — Why-Not session state (second flagship drill)
+let whyNotMode = false;   // a Why-Not round's question is riding the quiz engine
+let _wnSession = null;    // { topic, rounds, roundIdx, points, roundResults: [] }
+let _wnRound = null;      // { wrongLetters, wrongIdx, answerRight, reasons: {}, map }
+let _wnBusy = false;      // in-flight guard on Start
+let _wnTopic = null;      // entry-screen topic override (null = weakest)
+let _wnReturn = 'setup';  // origin-aware back routing (the v7.48.1 lesson)
 
 // Multi-select state (regular quiz)
 let msSelections = [];
@@ -2453,6 +2461,12 @@ function goSetup() {
   // no penalty. Reset the mode + restore the standard quiz chrome.
   gauntletMode = false;
   _gauntletRun = null;
+  // v7.50.0: quitting a Why-Not session mid-run = same contract (no penalty);
+  // the ladder renderer's idle path restores the shared quiz chrome (dots,
+  // topic strip) for both drills.
+  whyNotMode = false;
+  _wnSession = null;
+  _wnRound = null;
   if (typeof _renderGauntletLadder === 'function') { try { _renderGauntletLadder(); } catch (_) {} }
   navOpen = false;
   // v4.54.1: renderHistoryPanel moved to renderAnalytics (Recent Performance now lives on Analytics page)
@@ -3566,6 +3580,8 @@ function addToWrongBank(q, chosen) {
   // v7.48.0: Gauntlet runs are parallel to the wrong-bank loop — a gauntlet
   // miss is answered by "Run it again" (fresh wordings), not bank/SR enrolment.
   if (typeof gauntletMode !== 'undefined' && gauntletMode) return;
+  // v7.50.0: Why-Not sessions are parallel to bank/SR too (same spec rule)
+  if (typeof whyNotMode !== 'undefined' && whyNotMode) return;
   // v4.74.0: also enroll into the spaced-repetition queue. SR runs ahead
   // of the dedup check below — we WANT a repeated miss on the same
   // question to re-trigger SR (resets interval, drops ease) even though
@@ -6939,6 +6955,437 @@ function gauntletExit() {
   gauntletBack(); // v7.48.1: origin-aware — never the unstyled drills page on desktop
 }
 
+// ══════════════════════════════════════════
+// WHY-NOT (v7.50.0) — the second flagship drill
+// ══════════════════════════════════════════
+// Research-verified pain (FLAGSHIP-DRILL-RESEARCH-2026-06-11, pain 4): the
+// tools people praise explain why every option is right or wrong. Why-Not
+// turns that into the game: answer the question, then each wrong option
+// returns and you pick WHY it loses from three reasons (one true, two
+// tempting fakes). Round = 4 points (answer + 3 reasons). Session = 3
+// rounds, one topic, breadth — the Gauntlet owns concept depth. Spec:
+// docs/planning/WHY-NOT-DRILL-SPEC-2026-06-12.md. Pro-only at Start;
+// parallel to bank/SR; reasons are a MENU, scoring is exact-match.
+const WHY_NOT_ROUNDS = 3;
+
+// Entry points (Drills flagship card + Home Practice option). Entry screen
+// viewable by free users; the Pro gate fires on Start — the Gauntlet pattern.
+function startWhyNot() {
+  _wnTopic = null;
+  const active = document.querySelector('.page.active');
+  _wnReturn = (active && active.id === 'page-drills') ? 'drills' : 'setup';
+  renderWhyNotEntry();
+  showPage('whynot');
+}
+
+function whyNotBack() {
+  if (_wnReturn === 'drills') showPage('drills');
+  else goSetup();
+}
+
+function renderWhyNotEntry() {
+  const backLabel = document.getElementById('wn-back-label');
+  if (backLabel) backLabel.textContent = _wnReturn === 'drills' ? 'Drills' : 'Home';
+  const w = getWeakTopic();
+  let topicName = _wnTopic || (w && w.topic) || null;
+  if (!topicName && typeof getTodaysFocusTopics === 'function') {
+    const f = getTodaysFocusTopics(1);
+    const first = Array.isArray(f) ? f[0] : null;
+    topicName = typeof first === 'string' ? first : (first && first.topic) || null;
+  }
+  if (!topicName) topicName = Object.keys((typeof TOPIC_DOMAINS !== 'undefined' && TOPIC_DOMAINS) || {})[0] || MIXED_TOPIC;
+  const nameEl = document.getElementById('wn-topic-name');
+  if (nameEl) nameEl.textContent = topicName;
+  const whyEl = document.getElementById('wn-topic-why');
+  if (whyEl) whyEl.textContent = _wnTopic ? 'Your pick' : ((w && w.topic === topicName) ? 'Your weakest topic right now' : 'A good place to start');
+  const listEl = document.getElementById('wn-topic-list');
+  if (listEl) listEl.classList.add('is-hidden');
+}
+
+function whyNotToggleTopicList() {
+  const el = document.getElementById('wn-topic-list');
+  if (!el) return;
+  if (!el.classList.contains('is-hidden')) { el.classList.add('is-hidden'); return; }
+  const topics = Object.keys((typeof TOPIC_DOMAINS !== 'undefined' && TOPIC_DOMAINS) || {});
+  el.innerHTML = topics.map(t =>
+    '<button type="button" class="gnt-topic-opt" data-action="whyNotChooseTopic" data-args="' + escAttr(JSON.stringify([t])) + '">' + escHtml(t) + '</button>'
+  ).join('');
+  el.classList.remove('is-hidden');
+}
+
+function whyNotChooseTopic(t) {
+  _wnTopic = t;
+  renderWhyNotEntry();
+}
+
+// One metered call per SESSION: 3 questions inside the topic, each carrying
+// its full interrogation kit. Any malformed piece rejects the whole session
+// (friendly retry, nothing recorded) — the Gauntlet validation contract.
+async function _fetchWhyNotSession(topicName) {
+  const exemplars = (typeof _pickExemplarsForTopic === 'function') ? _pickExemplarsForTopic(topicName, 3) : [];
+  const exemplarBlock = (exemplars && exemplars.length && typeof _formatExemplarsForPrompt === 'function')
+    ? _formatExemplarsForPrompt(exemplars) : '';
+  const prompt =
+    'Write a 3-question "Why-Not" drill session for the certification exam topic "' + topicName + '". ' +
+    'Each question is a 4-option multiple-choice exam question (plain text options, no letter prefixes, exactly one correct, vary the correct position across the three).\n\n' +
+    'For EACH of the three WRONG options of each question, provide an interrogation kit:\n' +
+    '- "reason": the one TRUE reason that option loses, stated in one plain sentence\n' +
+    '- "fakes": exactly 2 tempting but FACTUALLY FALSE reasons. A fake must be false about the option itself, not merely a weaker argument. Make them genuinely tempting.\n' +
+    '- "note": 1-2 sentences shown after the pick, naming why the true reason decides it and why the fakes are false.\n\n' +
+    'Wrong options should lose for DIFFERENT kinds of reasons across a question (different job, missing a must-have the question demands, wrong scope, true-but-not-best, wrong layer).\n' +
+    (exemplarBlock ? '\n' + exemplarBlock + '\n' : '') +
+    '\nReturn ONLY JSON:\n' +
+    '{"rounds":[{"question":"...","options":["...","...","...","..."],"answer":"A","explanation":"...","whynot":{"B":{"reason":"...","fakes":["...","..."],"note":"..."},"C":{...},"D":{...}}}]}\n' +
+    '"answer" is the letter (A-D) of the correct option by position. The "whynot" object has EXACTLY the three wrong letters as keys. Exactly 3 rounds.';
+
+  const res = await _claudeFetch({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true'
+    },
+    // _metered: true — counts toward quota + the global kill-switch.
+    body: JSON.stringify({ model: CLAUDE_MODEL, max_tokens: MAX_TOKENS_GENERATION, messages: [{ role: 'user', content: prompt }], _metered: true })
+  });
+  if (!res.ok) throw new Error('whynot API error ' + res.status);
+  const data = await res.json();
+  const raw = (data.content && data.content[0] && data.content[0].text) || '';
+  const m = raw.match(/\{[\s\S]*\}/);
+  if (!m) throw new Error('whynot: no JSON object in response');
+  const parsed = JSON.parse(m[0]);
+  const rounds = (parsed && Array.isArray(parsed.rounds)) ? parsed.rounds : [];
+  const isStr = s => typeof s === 'string' && s.length > 0;
+  const ok = rounds.length === WHY_NOT_ROUNDS && rounds.every(r => {
+    if (!r || typeof r.question !== 'string' || r.question.length <= 20) return false;
+    if (!Array.isArray(r.options) || r.options.length !== 4 || !r.options.every(o => isStr(o))) return false;
+    if (typeof r.answer !== 'string' || !/^[A-D]$/.test(r.answer.trim().toUpperCase())) return false;
+    if (!isStr(r.explanation)) return false;
+    const ans = r.answer.trim().toUpperCase();
+    const wrong = ['A', 'B', 'C', 'D'].filter(l => l !== ans);
+    if (!r.whynot || typeof r.whynot !== 'object') return false;
+    return wrong.every(l => {
+      const k = r.whynot[l];
+      return k && isStr(k.reason) && Array.isArray(k.fakes) && k.fakes.length === 2 &&
+        k.fakes.every(f => isStr(f)) && isStr(k.note);
+    });
+  });
+  if (!ok) throw new Error('whynot: malformed session shape');
+  return rounds;
+}
+
+// Start CTA. opts: { topic } — used by the loop-closers.
+async function whyNotStart(opts) {
+  opts = opts || {};
+  if (_wnBusy) return; // double-tap guard
+  if (typeof _gateProOnly === 'function' && !_gateProOnly('Why-Not', {
+    title: 'Why-Not is a Pro feature',
+    body: 'The right answer is one point. Knowing why the wrong ones are wrong is the other three. Go Pro to run Why-Not on every cert in the library.'
+  })) return;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    showToast('Why-Not builds fresh case files, so it needs a connection.', 'info');
+    return;
+  }
+  if (typeof _canMakeMeteredCall === 'function' && !_canMakeMeteredCall('Why-Not')) return;
+
+  let topicName = opts.topic || _wnTopic || null;
+  if (!topicName) { const w = getWeakTopic(); topicName = (w && w.topic) || null; }
+  if (!topicName && typeof getTodaysFocusTopics === 'function') {
+    const f = getTodaysFocusTopics(1);
+    const first = Array.isArray(f) ? f[0] : null;
+    topicName = typeof first === 'string' ? first : (first && first.topic) || null;
+  }
+  if (!topicName) topicName = Object.keys((typeof TOPIC_DOMAINS !== 'undefined' && TOPIC_DOMAINS) || {})[0] || MIXED_TOPIC;
+
+  apiKey = (document.getElementById('api-key') || { value: '' }).value.trim();
+  _wnBusy = true;
+  const lp = document.getElementById('load-progress');
+  if (lp) lp.classList.add('is-hidden');
+  showPage('loading');
+  const lm = document.getElementById('loading-msg');
+  if (lm) lm.textContent = 'Building the case files…';
+  if (typeof _loadingProgressBegin === 'function') _loadingProgressBegin('Building the case files…');
+
+  let rounds;
+  try {
+    rounds = await _fetchWhyNotSession(topicName);
+  } catch (e) {
+    _wnBusy = false;
+    if (typeof _loadingProgressFinish === 'function') { try { _loadingProgressFinish(); } catch (_) {} }
+    renderWhyNotEntry();
+    showPage('whynot');
+    try { showToast('The forge misfired. Nothing was used up. Hit Start to try again.', 'error'); } catch (_) {}
+    return;
+  }
+  if (typeof _loadingProgressFinish === 'function') { try { _loadingProgressFinish(); } catch (_) {} }
+  _wnBusy = false;
+
+  _wnSession = { topic: topicName, rounds, roundIdx: 0, points: 0, roundResults: [] };
+  _wnBeginRound(0);
+}
+
+// Phase one: the round's question rides the existing quiz engine, exactly
+// like a 1-question Gauntlet. finish() hands off to _wnFinishQuestion().
+function _wnBeginRound(i) {
+  const r = _wnSession.rounds[i];
+  _wnSession.roundIdx = i;
+  _wnRound = { answerRight: undefined, wrongLetters: [], wrongIdx: 0, reasons: {}, map: null };
+  whyNotMode = true;
+  gauntletMode = false;
+  wrongDrillMode = false;
+  examMode = false;
+  sessionMode = false;
+  activeQuizTopic = _wnSession.topic;
+  questions = [{
+    question: r.question,
+    // letterize — renderMCQ reads q.options[letter] (the v7.48.1 contract)
+    options: _letterizeOptions(r.options),
+    answer: r.answer.trim().toUpperCase(),
+    explanation: r.explanation,
+    topic: _wnSession.topic,
+    difficulty: 'Exam Level',
+    type: 'mcq'
+  }];
+  current = 0; score = 0; streak = 0; bestStreak = 0; answered = 0; log = [];
+  quizFlags = [false];
+  if (i === 0) _sessionStartTs = Date.now();
+  showCacheNotice(false);
+  showPage('quiz');
+  render();
+  _wnQuizChrome();
+}
+
+// Quiz-page chrome for a Why-Not question: topic strip on, dot strip off
+// (reuses the v7.49 gauntlet strip element; the ladder stays gauntlet-only).
+function _wnQuizChrome() {
+  const topicEl = document.getElementById('gauntlet-run-topic');
+  const dots = document.getElementById('quiz-prog-dots');
+  if (topicEl) {
+    topicEl.innerHTML = '<span>Why-Not</span> · ' + escHtml(_wnSession.topic) + ' · Round ' + (_wnSession.roundIdx + 1) + ' of ' + WHY_NOT_ROUNDS;
+    topicEl.classList.remove('is-hidden');
+  }
+  if (dots) dots.classList.add('is-hidden');
+}
+
+// Phase one done — the answer point is frozen; move to the reason picker.
+function _wnFinishQuestion() {
+  const r = _wnSession.rounds[_wnSession.roundIdx];
+  const ans = r.answer.trim().toUpperCase();
+  if (_wnRound.answerRight === undefined) _wnRound.answerRight = false;
+  _wnRound.wrongLetters = ['A', 'B', 'C', 'D'].filter(l => l !== ans);
+  _wnRound.wrongIdx = 0;
+  renderWhyNotPicker();
+  showPage('whynot-round');
+}
+
+// The reason picker: one wrong option at a time, three shuffled reasons.
+function renderWhyNotPicker() {
+  const root = document.getElementById('wn-round-root');
+  if (!root || !_wnSession || !_wnRound) return;
+  const r = _wnSession.rounds[_wnSession.roundIdx];
+  const letter = _wnRound.wrongLetters[_wnRound.wrongIdx];
+  const kit = r.whynot[letter];
+  const optText = r.options[['A', 'B', 'C', 'D'].indexOf(letter)];
+  // shuffle [true, fake, fake]; remember where the true reason landed
+  const entries = [{ t: kit.reason, real: true }, { t: kit.fakes[0], real: false }, { t: kit.fakes[1], real: false }]
+    .sort(() => Math.random() - 0.5);
+  _wnRound.map = entries;
+  const segs = ['answer'].concat(_wnRound.wrongLetters).map((k, i) => {
+    if (i === 0) return '<i class="' + (_wnRound.answerRight ? 'done' : 'bad') + '"></i>';
+    const li = i - 1;
+    if (li < _wnRound.wrongIdx) return '<i class="' + (_wnRound.reasons[_wnRound.wrongLetters[li]] ? 'done' : 'bad') + '"></i>';
+    return '<i class="' + (li === _wnRound.wrongIdx ? 'live' : '') + '"></i>';
+  }).join('');
+  root.innerHTML =
+    '<p class="wn-strip"><span>Why-Not</span> · ' + escHtml(_wnSession.topic) + ' · Round ' + (_wnSession.roundIdx + 1) + ' of ' + WHY_NOT_ROUNDS + '</p>' +
+    '<div class="wn-answered">' + (_wnRound.answerRight
+      ? '<span class="wn-tick ok">✓</span><span>You answered: <b>' + escHtml(r.options[['A','B','C','D'].indexOf(r.answer.trim().toUpperCase())]) + '</b>. Right. Now earn the other three points.</span>'
+      : '<span class="wn-tick bad">✗</span><span>The answer was <b>' + escHtml(r.options[['A','B','C','D'].indexOf(r.answer.trim().toUpperCase())]) + '</b>. The reasons below still score.</span>') +
+    '</div>' +
+    '<div class="wn-card">' +
+      '<div class="wn-target"><span class="wn-lt">' + letter + '</span><b>' + escHtml(optText) + '</b></div>' +
+      '<p class="wn-ask">Why does it lose?</p>' +
+      entries.map((e, i) =>
+        '<button type="button" class="wn-reason" id="wn-reason-' + i + '" data-action="whyNotPickReason" data-args="[' + i + ']">' + escHtml(e.t) + '</button>'
+      ).join('') +
+      '<div class="wn-note is-hidden" id="wn-note"></div>' +
+    '</div>' +
+    '<div class="wn-prog">' + segs + '</div>' +
+    '<div class="gnt-result-footer">' +
+      '<button type="button" class="btn btn-primary gnt-cta is-hidden" id="wn-next-btn" data-action="whyNotNextTarget">Next →</button>' +
+      '<button type="button" class="btn gnt-ghost" data-action="whyNotExit">Leave session</button>' +
+    '</div>';
+}
+
+function whyNotPickReason(i) {
+  if (!_wnSession || !_wnRound || !_wnRound.map) return;
+  if (_wnRound.reasons[_wnRound.wrongLetters[_wnRound.wrongIdx]] !== undefined) return; // already picked
+  const r = _wnSession.rounds[_wnSession.roundIdx];
+  const letter = _wnRound.wrongLetters[_wnRound.wrongIdx];
+  const kit = r.whynot[letter];
+  const pick = _wnRound.map[i];
+  const right = !!(pick && pick.real);
+  _wnRound.reasons[letter] = right;
+  if (right) _wnSession.points++;
+  _wnRound.map.forEach((e, j) => {
+    const btn = document.getElementById('wn-reason-' + j);
+    if (!btn) return;
+    btn.setAttribute('disabled', '');
+    if (e.real) btn.classList.add('is-right');
+    else if (j === i) btn.classList.add('is-wrong-pick');
+  });
+  const note = document.getElementById('wn-note');
+  if (note) {
+    note.className = 'wn-note ' + (right ? 'good' : 'bad');
+    note.innerHTML = '<b>' + (right ? 'Right reason' : 'Wrong reason') + '</b>' + escHtml(kit.note);
+  }
+  const nextBtn = document.getElementById('wn-next-btn');
+  if (nextBtn) {
+    const last = _wnRound.wrongIdx >= _wnRound.wrongLetters.length - 1;
+    nextBtn.textContent = last ? 'See the round verdict →'
+      : 'Next: why does ' + _wnRound.wrongLetters[_wnRound.wrongIdx + 1] + ' lose? →';
+    nextBtn.classList.remove('is-hidden');
+  }
+  // progress segment repaint
+  const prog = document.querySelector('#wn-round-root .wn-prog');
+  if (prog && prog.children[_wnRound.wrongIdx + 1]) {
+    prog.children[_wnRound.wrongIdx + 1].className = right ? 'done' : 'bad';
+  }
+}
+
+function whyNotNextTarget() {
+  if (!_wnSession || !_wnRound) return;
+  if (_wnRound.wrongIdx < _wnRound.wrongLetters.length - 1) {
+    _wnRound.wrongIdx++;
+    renderWhyNotPicker();
+    const sh = document.querySelector('#page-whynot-round .gnt-shell');
+    if (sh) sh.scrollTop = 0;
+    window.scrollTo(0, 0);
+  } else {
+    _wnFinishRound();
+  }
+}
+
+// Round done: bank the result, show the round verdict (or roll into the
+// session verdict after round 3).
+function _wnFinishRound() {
+  const answerPt = _wnRound.answerRight ? 1 : 0;
+  if (_wnRound.answerRight) _wnSession.points++;
+  const reasonPts = _wnRound.wrongLetters.filter(l => _wnRound.reasons[l]).length;
+  _wnSession.roundResults.push({
+    answerRight: !!_wnRound.answerRight,
+    reasons: Object.assign({}, _wnRound.reasons),
+    points: answerPt + reasonPts
+  });
+  renderWhyNotVerdict();
+  showPage('whynot-verdict');
+}
+
+function renderWhyNotVerdict() {
+  const root = document.getElementById('wn-verdict-root');
+  if (!root || !_wnSession) return;
+  const i = _wnSession.roundIdx;
+  const r = _wnSession.rounds[i];
+  const res = _wnSession.roundResults[i];
+  const ans = r.answer.trim().toUpperCase();
+  const lastRound = i >= WHY_NOT_ROUNDS - 1;
+  const missedReasons = _wnRound.wrongLetters.filter(l => !res.reasons[l]);
+  const optName = l => escHtml(r.options[['A', 'B', 'C', 'D'].indexOf(l)]);
+  const callout = res.points === 4
+    ? 'Clean sweep. Answer and all three reasons.'
+    : (!res.answerRight && missedReasons.length === 0)
+      ? 'You missed the answer but diagnosed every wrong option. The understanding is there.'
+      : missedReasons.length === 1 && res.answerRight
+        ? 'You knew the answer. You misdiagnosed why <b>' + optName(missedReasons[0]) + '</b> loses.'
+        : missedReasons.length
+          ? 'The reasons need work: ' + missedReasons.map(optName).join(' and ') + ' got past you.'
+          : 'The reasons were all right. The answer got away.';
+  const rows = [
+    '<div class="gnt-rr ' + (res.answerRight ? 'ok' : 'bad') + '"><span class="gnt-rr-ic"><svg viewBox="0 0 24 24" aria-hidden="true">' +
+      (res.answerRight ? '<path d="M20 6 9 17l-5-5"/>' : '<path d="M18 6 6 18M6 6l12 12"/>') +
+      '</svg></span><span class="gnt-rr-t"><b>The answer: ' + escHtml(r.options[['A','B','C','D'].indexOf(ans)]) + '</b><span>' + (res.answerRight ? 'Picked first time' : 'Missed on the first pick') + '</span></span></div>'
+  ].concat(_wnRound.wrongLetters.map(l => {
+    const ok = !!res.reasons[l];
+    const optText = r.options[['A', 'B', 'C', 'D'].indexOf(l)];
+    return '<div class="gnt-rr ' + (ok ? 'ok' : 'bad') + '"><span class="gnt-rr-ic"><svg viewBox="0 0 24 24" aria-hidden="true">' +
+      (ok ? '<path d="M20 6 9 17l-5-5"/>' : '<path d="M18 6 6 18M6 6l12 12"/>') +
+      '</svg></span><span class="gnt-rr-t"><b>' + escHtml(optText) + '</b><span>' + escHtml(r.whynot[l].reason) + '</span></span></div>';
+  })).join('');
+  root.innerHTML =
+    '<div class="wn-vd-head">' +
+      '<div class="wn-vd-score">You earned <b>' + res.points + ' of 4</b></div>' +
+      '<p class="wn-vd-call">' + callout + '</p>' +
+    '</div>' +
+    '<div class="gnt-rung-report">' + rows + '</div>' +
+    '<div class="gnt-result-footer">' +
+      '<button type="button" class="btn btn-primary gnt-cta" data-action="' + (lastRound ? 'whyNotFinishSession' : 'whyNotNextRound') + '">' + (lastRound ? 'Session verdict →' : 'Next round →') + '</button>' +
+      '<button type="button" class="btn gnt-ghost" data-action="whyNotExit">Leave session</button>' +
+    '</div>';
+}
+
+function whyNotNextRound() {
+  if (!_wnSession) { startWhyNot(); return; }
+  // bounds guard: past the last round, the only valid move is the session
+  // verdict (the real button already says so; this protects double-fires)
+  if (_wnSession.roundIdx + 1 >= WHY_NOT_ROUNDS) { whyNotFinishSession(); return; }
+  _wnBeginRound(_wnSession.roundIdx + 1);
+}
+
+// Session complete: history feeds Today's goal (3 questions answered),
+// streak credits like any finished session, then the session verdict.
+function whyNotFinishSession() {
+  if (!_wnSession) { startWhyNot(); return; }
+  const answersRight = _wnSession.roundResults.filter(x => x.answerRight).length;
+  const pct = Math.round((answersRight / WHY_NOT_ROUNDS) * 100);
+  try { saveToHistory({ date: new Date().toISOString(), topic: _wnSession.topic, difficulty: 'Exam Level', score: answersRight, total: WHY_NOT_ROUNDS, pct, mode: 'whynot' }); } catch (_) {}
+  try { updateStreak(); renderStreakBadge(); } catch (_) {}
+  try { if (typeof _writeReadinessSnapshot === 'function') _writeReadinessSnapshot(); } catch (_) {}
+  try { renderStatsCard(); renderReadinessCard(); } catch (_) {}
+  whyNotMode = false;
+  if (typeof _renderGauntletLadder === 'function') { try { _renderGauntletLadder(); } catch (_) {} }
+  const root = document.getElementById('wn-verdict-root');
+  if (root) {
+    const pts = _wnSession.points;
+    const perRound = _wnSession.roundResults.map((x, i) =>
+      '<div class="gnt-rr ' + (x.points === 4 ? 'ok' : 'bad') + '"><span class="gnt-rr-ic"><svg viewBox="0 0 24 24" aria-hidden="true">' +
+      (x.points === 4 ? '<path d="M20 6 9 17l-5-5"/>' : '<path d="M18 6 6 18M6 6l12 12"/>') +
+      '</svg></span><span class="gnt-rr-t"><b>Round ' + (i + 1) + '</b><span>' + x.points + ' of 4</span></span></div>'
+    ).join('');
+    root.innerHTML =
+      '<div class="wn-vd-head">' +
+        '<div class="wn-vd-score">Session: <b>' + pts + ' of 12</b></div>' +
+        '<p class="wn-vd-call">' + escHtml(_wnSession.topic) + ' · 3 questions answered toward today’s goal</p>' +
+      '</div>' +
+      '<div class="gnt-rung-report">' + perRound + '</div>' +
+      '<div class="gnt-result-footer">' +
+        '<button type="button" class="btn btn-primary gnt-cta" data-action="whyNotNextTopic">Next target →</button>' +
+        '<button type="button" class="btn gnt-ghost" data-action="whyNotExit">' + (_wnReturn === 'drills' ? 'Back to Drills' : 'Back to Home') + '</button>' +
+      '</div>';
+  }
+  _wnSession = null;
+  _wnRound = null;
+  // the user is usually ALREADY on the verdict page (round verdict re-uses
+  // it) — re-showing the active page can race the transition animation
+  var _act = document.querySelector('.page.active');
+  if (!_act || _act.id !== 'page-whynot-verdict') showPage('whynot-verdict');
+}
+
+function whyNotNextTopic() {
+  _wnTopic = null;
+  _wnSession = null;
+  _wnRound = null;
+  whyNotStart({});
+}
+
+function whyNotExit() {
+  whyNotMode = false;
+  _wnSession = null;
+  _wnRound = null;
+  if (typeof _renderGauntletLadder === 'function') { try { _renderGauntletLadder(); } catch (_) {} }
+  whyNotBack();
+}
+
 // Drills-page hero card pill ("N cracked").
 function renderGauntletDrillsCard() {
   const pill = document.getElementById('drills-gauntlet-pill');
@@ -8699,6 +9146,11 @@ function showExplanation(q, isRight, entryOverride) {
     if (typeof _gauntletApplyHinge === 'function') _gauntletApplyHinge(q);
     if (typeof _renderGauntletLadder === 'function') _renderGauntletLadder();
   }
+  // v7.50.0 Why-Not: freeze the answer point on the FIRST answer, same
+  // contract as the Gauntlet (re-picks stay study aids).
+  if (whyNotMode && _wnRound && _wnRound.answerRight === undefined) {
+    _wnRound.answerRight = isRight;
+  }
   document.getElementById('exp-label').textContent = label;
   document.getElementById('exp-text').textContent  = q.explanation;
   // v4.54.8: per-choice wrongExplain paragraph. If the question carries a
@@ -8736,7 +9188,7 @@ function showExplanation(q, isRight, entryOverride) {
   // after the current question.
   // v7.48.0: suppressed in gauntlet runs — injecting follow-up questions
   // would corrupt the fixed 5-rung structure.
-  if (!isRight && !gauntletMode && typeof followUpOnMistake === 'function') {
+  if (!isRight && !gauntletMode && !whyNotMode && typeof followUpOnMistake === 'function') {
     extraHtml += '<button class="explain-btn explain-btn-followup" onclick="followUpOnMistake()">Drill this concept</button>';
   }
 
@@ -8801,6 +9253,9 @@ function finish() {
   // v7.48.0: a Gauntlet run has its own verdict surface (cracked / near-miss)
   // instead of the standard results page.
   if (gauntletMode && _gauntletRun) { _finishGauntlet(); return; }
+  // v7.50.0: a Why-Not round's question finishing hands off to phase two
+  // (the reason picker) instead of the results page.
+  if (whyNotMode && _wnSession) { _wnFinishQuestion(); return; }
   // v4.42.0: snapshot streak BEFORE updateStreak so we can detect an
   // increment and flag a pulse animation for the next goSetup() render.
   const _prevStreakBefore = (function(){ try { return getStreak().current || 0; } catch (_) { return 0; } })();

--- a/design/brand/BRAND.md
+++ b/design/brand/BRAND.md
@@ -349,6 +349,7 @@ The locked do-not list:
 - ❌ **No purple.** `#5b4fdb` / `#7c6ff7` / `#a99df9` / `#3d3870` are dead. The accent is bronze, the suffix-as-fallback `var(--accent2, #5b4fdb)` is the AI-tell — eliminate.
 - ❌ **No card-spam.** A grid of 4+ identical soft-shadow cards is the editorial-premium AI-tell. De-card to hairline rows or replace with a real data-viz.
 - ❌ **No em-dashes** (`—`). Use middle-dot (`·`) or the Inter natural punctuation.
+- ❌ **No left-accent-border callouts** (`border-left: 3-4px solid <accent/status>` on a tinted note box). The classic AI "callout" tell (Simi, 2026-06-12). Verdicts/notes use a FULL tinted hairline via `color-mix` + tinted surface + symmetric radius — see the Gauntlet verdict card family.
 - ❌ **No throat-clearing copy.** "Here's what..." / "It's worth noting..." → cut. State directly.
 - ❌ **No vague declaratives.** "The implications are significant" → name the specific implication.
 - ❌ **No gradient backgrounds on chrome.** Surfaces are `var(--surface)`; gradients are reserved for the single bronze NBM fill + the readiness-bar fill.

--- a/dg-system.css
+++ b/dg-system.css
@@ -3797,3 +3797,46 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 .gnt-cta{border-radius:12px;padding:14px;font:700 14.5px/1 Inter,sans-serif;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1);}
 .gnt-cta:active{transform:scale(0.97);}
 @media (prefers-reduced-motion:reduce){.gnt-seal,.gnt-seal-ladder i,.gnt-rung-bar i,mark.gnt-hinge{animation:none!important;transition:none!important;}}
+
+/* ════════════════════════════════════════════════════════════════════════
+   v7.50.0 · WHY-NOT — reason picker + verdict screens
+   Lift of mockups/why-not-drill.html (four-pass audited 2026-06-12) onto
+   the app tokens, reusing the gnt-* anatomy (shell, hdr, target, topic
+   list, rung-report rows, footers). Literal easing curve (portal lesson).
+   NOTE: no left-accent-border callouts anywhere — full tinted hairlines
+   (the 2026-06-12 BRAND.md anti-slop rule).
+   ═══════════════════════════════════════════════════════════════════════ */
+.wn-strip{text-align:center;font:800 10px/1 Inter,sans-serif;letter-spacing:0.12em;text-transform:uppercase;color:var(--text-dim);margin:6px 0 14px;}
+.wn-strip span{color:var(--accent);}
+.wn-answered{display:flex;align-items:center;gap:9px;border:1px solid color-mix(in oklab,var(--green) 30%,var(--dg-rule-soft));background:color-mix(in oklab,var(--green) 8%,transparent);border-radius:11px;padding:10px 13px;font:550 13px/1.4 Inter,sans-serif;color:var(--text-mid);margin-bottom:14px;}
+.wn-answered b{color:var(--text);}
+.wn-tick{width:20px;height:20px;border-radius:50%;display:grid;place-items:center;flex:none;font-size:11px;color:var(--bg);}
+.wn-tick.ok{background:var(--green);}
+.wn-tick.bad{background:var(--red);}
+.wn-answered:has(.wn-tick.bad){border-color:color-mix(in oklab,var(--red) 30%,var(--dg-rule-soft));background:color-mix(in oklab,var(--red) 7%,transparent);}
+.wn-card{background:var(--surface);border:1px solid var(--dg-rule-soft);border-radius:16px;padding:16px 15px;}
+.wn-target{display:flex;align-items:center;gap:10px;border:1px solid color-mix(in oklab,var(--red) 40%,var(--dg-rule-soft));border-radius:11px;padding:10px 12px;margin-bottom:13px;}
+.wn-lt{width:22px;height:22px;border-radius:50%;background:var(--red);color:var(--bg);display:grid;place-items:center;flex:none;font:800 11px/1 Inter,sans-serif;}
+.wn-target b{font:650 14px/1.3 Inter,sans-serif;color:var(--text);}
+.wn-ask{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:18px;letter-spacing:-0.01em;color:var(--text);margin:2px 1px 12px;}
+.wn-reason{display:block;width:100%;text-align:left;border:1px solid var(--dg-rule-soft);background:var(--bg);border-radius:11px;padding:11px 13px;font:550 13px/1.45 Inter,sans-serif;color:var(--text-mid);margin-bottom:8px;cursor:pointer;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1);}
+.wn-reason:active{transform:scale(0.985);}
+.wn-reason.is-right{border-color:color-mix(in oklab,var(--green) 55%,transparent);background:color-mix(in oklab,var(--green) 10%,transparent);color:var(--text);}
+.wn-reason.is-wrong-pick{border-color:color-mix(in oklab,var(--red) 50%,transparent);background:color-mix(in oklab,var(--red) 8%,transparent);color:var(--text);}
+.wn-reason[disabled]{cursor:default;}
+.wn-note{border:1px solid var(--dg-rule-soft);border-radius:11px;padding:10px 13px;margin-top:12px;font-size:12.5px;color:var(--text-mid);}
+.wn-note.good{border-color:color-mix(in oklab,var(--green) 32%,var(--dg-rule-soft));background:color-mix(in oklab,var(--green) 8%,transparent);}
+.wn-note.bad{border-color:color-mix(in oklab,var(--red) 32%,var(--dg-rule-soft));background:color-mix(in oklab,var(--red) 7%,transparent);}
+.wn-note b{display:block;font:800 10px/1 Inter,sans-serif;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:5px;}
+.wn-note.good b{color:var(--green);}
+.wn-note.bad b{color:var(--red);}
+.wn-prog{display:flex;gap:6px;margin-top:14px;max-width:560px;}
+.wn-prog i{flex:1;height:4px;border-radius:3px;background:var(--surface3);}
+.wn-prog i.done{background:var(--green);}
+.wn-prog i.bad{background:var(--red);}
+.wn-prog i.live{background:var(--accent);}
+.wn-vd-head{text-align:center;margin-top:12px;}
+.wn-vd-score{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:26px;letter-spacing:-0.012em;color:var(--text);font-variant-numeric:lining-nums tabular-nums;font-feature-settings:"lnum","tnum";}
+.wn-vd-score b{color:var(--accent);}
+.wn-vd-call{font-size:13.5px;color:var(--text-mid);margin:8px auto 18px;max-width:38ch;}
+.wn-vd-call b{color:var(--red);}

--- a/docs/planning/WHY-NOT-DRILL-SPEC-2026-06-12.md
+++ b/docs/planning/WHY-NOT-DRILL-SPEC-2026-06-12.md
@@ -8,7 +8,7 @@
 3. **Score is out of 4** — answer + 3 reasons. Verdict names the exact miss ("You knew the answer. You misdiagnosed why port 80 loses.").
 4. **Fake-reason rule:** fakes must be factually FALSE about the option, not merely weaker arguments. Generation prompt rule + Report button covers the rest.
 5. **Reason taxonomy (for coaching, Phase B):** different job · missing the must-have · wrong scope · true-but-not-BEST · wrong layer · overkill/overspend. The blind-spot chip surfaces the user's most-misdiagnosed type.
-6. **Session shape:** 3 rounds per session by default (the slow, deep drill; the Gauntlet stays the fast loop).
+6. **Session shape: 3 rounds, fixed in v1 (locked with Simi, 2026-06-12).** A round = 4 scored decisions (answer + 3 reasons), so a session is 12 decisions, already 2.4x a Gauntlet run, at ~5-7 minutes. Rationale: end before fatigue (peak-end), depth-per-question IS the product, and the single-call generation stays small enough to validate reliably. "Next target" is the opt-in continuation. A session-length setting waits for proven demand (the SR session-size playbook). Symmetry: Gauntlet = 5 rungs deep on one concept; Why-Not = 3 rounds wide across one topic.
 7. **Gating:** Pro-only at Start, same `_gateProOnly` pattern. Entry: Drills page flagship card (under the Gauntlet) + Home Practice option.
 8. **Generation:** one metered `CLAUDE_MODEL` call per round; Gauntlet-style whole-round shape validation (malformed = friendly retry, nothing consumed). **Letterize option arrays at the boundary** (the v7.48.1 contract, UAT-pinned).
 9. **Parallel to bank/SR** in v1, like the Gauntlet (no addToWrongBank writes during rounds).

--- a/docs/planning/WHY-NOT-DRILL-SPEC-2026-06-12.md
+++ b/docs/planning/WHY-NOT-DRILL-SPEC-2026-06-12.md
@@ -13,6 +13,15 @@
 8. **Generation:** one metered `CLAUDE_MODEL` call per round; Gauntlet-style whole-round shape validation (malformed = friendly retry, nothing consumed). **Letterize option arrays at the boundary** (the v7.48.1 contract, UAT-pinned).
 9. **Parallel to bank/SR** in v1, like the Gauntlet (no addToWrongBank writes during rounds).
 
+## Full flow (locked with Simi, 2026-06-12 evening)
+1. **Entry screen mirrors the Gauntlet's**: "Today's target: <weakest TOPIC>" via the same weak-spot data, "Pick a different topic" reuses the same topic list, Start carries the Pro gate. Same code paths (`getWeakTopic`, the gnt topic-picker pattern).
+2. **Topic-level targeting, NOT concept-level** (the deliberate difference): the Gauntlet = one concept, five wordings (depth). Why-Not = 3 different questions inside the topic, wrong answers interrogated (breadth). No overlap between the flagships; matches the landing story.
+3. Start → loading page → ONE metered call generates the whole session (3 questions + per-wrong-option reason sets), Gauntlet-style validation.
+4. **Topic strip throughout** (reuse the v7.49 strip): "WHY-NOT · <TOPIC> · ROUND n OF 3".
+5. Round = answer normally → 3 reason picks → round verdict ("You earned 3 of 4").
+6. After round 3: session summary (x of 12 + blind-spot chip in Phase B) → "Next target" (next weakest topic) / "Different topic" / Home.
+7. **No "Run it again"** retry: Why-Not has no crack condition; "Next round/target" always generates fresh questions.
+
 ## Build phases
 - **Phase A (shippable alone):** generation + validation, reason-picker card (visual cousin of the Gauntlet verdict card), round scoring + verdict screen, entries, Pro gate, history/streak/goal hooks.
 - **Phase B:** reason-type accuracy stat (the only new stored number) + blind-spot chip + weak-spot feed.

--- a/docs/planning/WHY-NOT-DRILL-SPEC-2026-06-12.md
+++ b/docs/planning/WHY-NOT-DRILL-SPEC-2026-06-12.md
@@ -1,0 +1,27 @@
+# Why-Not — Design Spec (second flagship drill)
+**Approved by Simi 2026-06-12 ("im happy to build this out"). Mockups four-pass audited same day.**
+**Research base:** `FLAGSHIP-DRILL-RESEARCH-2026-06-11.md` (Desktop), pain point 4 + drill #5. Deep dive: `~/.agent/diagrams/why-not-drill-deep-dive.html`.
+
+## Product decisions (locked)
+1. **A round = 1 question + 3 interrogations.** Phase one: a normal 4-option MCQ (existing quiz screens, untouched). Phase two: each wrong option returns one at a time and the user picks WHY it loses.
+2. **Reasons are a menu, never free text.** Per wrong option: 1 true reason + 2 plausible fakes, all generated in the same AI call. Scoring is exact-match: instant, free, never argues. (The Gauntlet trick: AI in generation, dumb scoring.)
+3. **Score is out of 4** — answer + 3 reasons. Verdict names the exact miss ("You knew the answer. You misdiagnosed why port 80 loses.").
+4. **Fake-reason rule:** fakes must be factually FALSE about the option, not merely weaker arguments. Generation prompt rule + Report button covers the rest.
+5. **Reason taxonomy (for coaching, Phase B):** different job · missing the must-have · wrong scope · true-but-not-BEST · wrong layer · overkill/overspend. The blind-spot chip surfaces the user's most-misdiagnosed type.
+6. **Session shape:** 3 rounds per session by default (the slow, deep drill; the Gauntlet stays the fast loop).
+7. **Gating:** Pro-only at Start, same `_gateProOnly` pattern. Entry: Drills page flagship card (under the Gauntlet) + Home Practice option.
+8. **Generation:** one metered `CLAUDE_MODEL` call per round; Gauntlet-style whole-round shape validation (malformed = friendly retry, nothing consumed). **Letterize option arrays at the boundary** (the v7.48.1 contract, UAT-pinned).
+9. **Parallel to bank/SR** in v1, like the Gauntlet (no addToWrongBank writes during rounds).
+
+## Build phases
+- **Phase A (shippable alone):** generation + validation, reason-picker card (visual cousin of the Gauntlet verdict card), round scoring + verdict screen, entries, Pro gate, history/streak/goal hooks.
+- **Phase B:** reason-type accuracy stat (the only new stored number) + blind-spot chip + weak-spot feed.
+- **Phase C:** cross-pollination with the Gauntlet (blind spots steer topic picks; Why-Not as maintenance on cracked concepts).
+
+## Mockups (four-pass audited, they ARE the pages)
+- `mockups/why-not-drill.html` — ① reason picker (post-pick verdict, 4-segment round progress), ② round verdict (Fraunces "3 of 4", per-option rows, blind-spot chip), ③ Drills page with both flagship cards.
+- `mockups/landing-flagship-drills.html` — **REPLACES the v7.48 #gauntlet landing section 1:1.** Simi's call: ONE Pro section for both flagships, not two. Shared headline ("The exam has two tricks. Now you have two drills."), two demo panels (condensed Gauntlet loop + Why-Not reason-pick loop, staggered), one CTA ("Go Pro — unlimited", the approved verbatim survivor).
+- **Lift rules:** landing tokens MUST be scoped to the section id + dark block (landing :root is legacy purple); app screens use the starter-token values which match dg-system live tokens.
+
+## Out of scope v1
+Free-text reasons, per-option timers, Why-Not on PBQ types, multi-select questions (MCQ-only rounds), readiness integration.

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.49.0">
+<link rel="stylesheet" href="dg-system.css?v=7.50.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic
@@ -405,6 +405,8 @@
           <button type="button" class="opt" onclick="applyPreset('bulk45')"><span class="on">45 Questions</span><span class="od">Marathon mixed, about 38 min</span></button>
           <!-- v7.48.0: Reword Gauntlet entry (flagship drill) -->
           <button type="button" class="opt" data-action="startRewordGauntlet"><span class="on">Reword Gauntlet</span><span class="od">One concept, five disguises</span></button>
+          <!-- v7.50.0: Why-Not entry (second flagship) -->
+          <button type="button" class="opt" data-action="startWhyNot"><span class="on">Why-Not</span><span class="od">Score the reasons, not just the answer</span></button>
         </div>
       </section>
 
@@ -764,7 +766,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.49.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.50.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>
@@ -1234,6 +1236,13 @@
     <button type="button" class="drills-btn" id="drills-gauntlet-btn" data-action="startRewordGauntlet">Run the Gauntlet</button>
   </div>
 
+  <!-- v7.50.0: Why-Not — the second flagship -->
+  <div class="drills-card gnt-drills-hero" id="drills-whynot-card">
+    <div class="drills-card-head"><span class="drills-card-title">Why-Not <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill">Flagship drill</span></div>
+    <p class="drills-card-note">Score the reasons, not just the answer. Every wrong option comes back: say why it loses.</p>
+    <button type="button" class="drills-btn" id="drills-whynot-btn" data-action="startWhyNot">Run Why-Not</button>
+  </div>
+
   <div class="drills-card" id="drills-mistakes-card">
     <div class="drills-card-head"><span class="drills-card-title">Drill Mistakes <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill" id="drills-mistakes-pill">0 saved</span></div>
     <p class="drills-card-note" id="drills-mistakes-note">Your missed questions come back re-worded, so you beat the concept &mdash; not the question. Right twice in a row and it leaves the bank for good.</p>
@@ -1286,6 +1295,42 @@
 
 <div id="page-gauntlet-result" class="page">
   <div class="gnt-shell gnt-shell-result" id="gnt-result-root"></div>
+</div>
+
+<!-- ══════════════════════════════════════════
+     WHY-NOT (v7.50.0) — entry + reason picker + verdicts
+     Lifted from mockups/why-not-drill.html (four-pass audited 2026-06-12).
+     Entry viewable by free users; the Pro gate fires on Start. Reuses the
+     gnt-* anatomy; wn-* covers the picker/verdict specifics.
+══════════════════════════════════════════ -->
+<div id="page-whynot" class="page">
+  <div class="gnt-shell">
+    <div class="gnt-hdr">
+      <button type="button" class="back-btn" data-action="whyNotBack" aria-label="Back"><svg viewBox="0 0 24 24" aria-hidden="true" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg><span class="back-btn-label" id="wn-back-label">Back</span></button>
+      <h1 class="gnt-hdr-title">Why-Not</h1>
+      <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span>
+    </div>
+    <div class="gnt-mark" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20z"></path><path d="M9.5 9a2.5 2.5 0 0 1 4.86.83c0 1.67-2.5 2.5-2.5 2.5"></path><path d="M12 17h.01"></path></svg></div>
+    <h2 class="gnt-entry-title">Prove the wrong answers <i>wrong</i></h2>
+    <p class="gnt-entry-lede">The right answer is one point. Why the others lose is the other three.</p>
+    <div class="gnt-target">
+      <div class="gnt-target-k">Today's target</div>
+      <div class="gnt-target-v" id="wn-topic-name">&mdash;</div>
+      <div class="gnt-target-why" id="wn-topic-why"></div>
+      <button type="button" class="gnt-target-switch" data-action="whyNotToggleTopicList">Pick a different topic</button>
+      <div class="gnt-topic-list is-hidden" id="wn-topic-list"></div>
+    </div>
+    <div class="gnt-ladder-preview" aria-hidden="true"><span>Round 1</span><span>Round 2</span><span>Round 3</span></div>
+    <button type="button" class="btn btn-primary gnt-cta" id="wn-start-btn" data-action="whyNotStart">Start Why-Not</button>
+  </div>
+</div>
+
+<div id="page-whynot-round" class="page">
+  <div class="gnt-shell" id="wn-round-root"></div>
+</div>
+
+<div id="page-whynot-verdict" class="page">
+  <div class="gnt-shell gnt-shell-result" id="wn-verdict-root"></div>
 </div>
 
 <!-- ══════════════════════════════════════════

--- a/landing/index.html
+++ b/landing/index.html
@@ -2168,11 +2168,11 @@
 </section>
 
 <!-- ══════════════════════════════════════════
-     REWORD GAUNTLET (v7.48.0) · flagship-drill pitch where the "why Pro"
-     story peaks. Lift of mockups/landing-gauntlet-section.html
-     (brand-audited 2026-06-12). The demo card replays a five-rung run on
-     a loop; the loop starts on first scroll-into-view (same IO pattern as
-     the neighbouring sections). gx- prefix, fully scoped under #gauntlet.
+     THE FLAGSHIP DRILLS (v7.50.0) · one Pro section, two proofs (Simi:
+     combined, not two sections). Replaces the v7.48 gauntlet-only section.
+     Lift of mockups/landing-flagship-drills.html (four-pass audited
+     2026-06-12). Two demo loops staggered; IO start + safety net.
+     gx-/wd- prefixes; #gauntlet id kept (anchor + analytics stability).
 ══════════════════════════════════════════ -->
 <style>
   /* Scoped brand tokens (BRAND.md §3) — landing's :root --accent is still the
@@ -2209,20 +2209,33 @@
     --on-accent:oklch(0.18 0.020 275);
   }
   #gauntlet .gx-wrap{max-width:1080px;margin:0 auto}
-  #gauntlet .gx{display:grid;grid-template-columns:1.05fr 0.95fr;gap:64px;align-items:center}
   #gauntlet .gx-kicker{font:800 11px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent);display:inline-flex;align-items:center;gap:7px;margin-bottom:18px}
   #gauntlet .gx-kicker svg{width:12px;height:12px;stroke:currentColor;fill:none;stroke-width:2.4;stroke-linecap:round;stroke-linejoin:round}
-  #gauntlet h2{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:38px;line-height:1.13;letter-spacing:-0.015em;color:var(--ink)}
+  #gauntlet h2{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:38px;line-height:1.13;letter-spacing:-0.015em;color:var(--ink);max-width:22ch}
   #gauntlet h2 em{font-style:italic;color:var(--accent)}
-  #gauntlet .gx-lede{color:var(--ink-soft);font-size:16px;line-height:1.6;margin:18px 0 6px;max-width:46ch}
+  #gauntlet .gx-lede{color:var(--ink-soft);font-size:16px;line-height:1.6;margin:16px 0 0;max-width:58ch}
   #gauntlet .gx-lede b{color:var(--ink)}
-  #gauntlet .gx-proof{font-size:13.5px;color:var(--muted);margin:14px 0 26px}
-  #gauntlet .gx-cta-row{display:flex;align-items:center;gap:18px;flex-wrap:wrap}
+  #gauntlet .gx-proof{font-size:13.5px;color:var(--muted);margin:12px 0 0}
+  #gauntlet .gx-cta-row{display:flex;align-items:center;gap:18px;flex-wrap:wrap;margin-top:34px}
+  /* v7.50.0 — two flagship panels (Simi: one Pro section, two proofs) */
+  #gauntlet .gx-panels{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:34px}
+  #gauntlet .gx-panel{background:var(--surface);border:1px solid var(--border);border-radius:16px;padding:22px 21px;box-shadow:0 1px 0 color-mix(in oklab,var(--ink) 4%,transparent),0 18px 50px -30px color-mix(in oklab,var(--ink) 30%,transparent);display:flex;flex-direction:column}
+  #gauntlet .gx-panel-eyebrow{font:800 10px/1 Inter,sans-serif;letter-spacing:0.13em;text-transform:uppercase;color:var(--accent);margin-bottom:9px}
+  #gauntlet .gx-panel h3{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:21px;letter-spacing:-0.01em;color:var(--ink);margin-bottom:7px}
+  #gauntlet .gx-panel-line{font-size:13.5px;color:var(--ink-soft);line-height:1.55;margin-bottom:16px}
+  #gauntlet .gx-panel-line b{color:var(--ink)}
+  #gauntlet .wd-target{display:flex;align-items:center;gap:8px;border:1px solid color-mix(in oklab,var(--fail) 40%,var(--border-soft));border-radius:9px;padding:7px 10px;margin-bottom:9px;font:650 12px/1.2 Inter,sans-serif;color:var(--ink)}
+  #gauntlet .wd-target i{width:20px;height:20px;border-radius:50%;background:var(--fail);color:var(--bg);display:grid;place-items:center;flex:none;font:800 10px/1 Inter,sans-serif;font-style:normal}
+  #gauntlet .wd-r{border:1px solid var(--border-soft);border-radius:9px;padding:7px 10px;font:500 11.5px/1.4 Inter,sans-serif;color:var(--ink-soft);margin-bottom:7px;opacity:0.35;transform:translateX(6px);transition:opacity 0.5s cubic-bezier(0.16,1,0.3,1),transform 0.5s cubic-bezier(0.16,1,0.3,1),border-color 0.5s ease,background-color 0.5s ease}
+  #gauntlet .wd-r.on{opacity:1;transform:translateX(0)}
+  #gauntlet .wd-r.win{border-color:color-mix(in oklab,var(--pass) 55%,transparent);background:color-mix(in oklab,var(--pass) 9%,transparent);color:var(--ink)}
+  #gauntlet .wd-seal{margin-top:11px;text-align:center;font:800 10px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--pass);opacity:0;transform:scale(0.96);transition:opacity 0.5s cubic-bezier(0.16,1,0.3,1),transform 0.5s cubic-bezier(0.16,1,0.3,1)}
+  #gauntlet .wd-seal.on{opacity:1;transform:scale(1)}
   #gauntlet .gx-btn{background:var(--accent);color:var(--on-accent);border:0;border-radius:10px;padding:14px 26px;font:700 15px/1 Inter,sans-serif;cursor:pointer;text-decoration:none;display:inline-block;transition:transform 0.16s cubic-bezier(0.16,1,0.3,1),filter 0.2s ease}
   #gauntlet .gx-btn:active{transform:scale(0.97)}
   @media (hover:hover) and (pointer:fine){#gauntlet .gx-btn:hover{filter:brightness(1.08)}}
   #gauntlet .gx-cta-note{font-size:13px;color:var(--muted)}
-  #gauntlet .gx-demo{background:var(--surface);border:1px solid var(--border);border-radius:16px;padding:26px 24px;box-shadow:0 1px 0 color-mix(in oklab,var(--ink) 4%,transparent),0 18px 50px -30px color-mix(in oklab,var(--ink) 30%,transparent)}
+  #gauntlet .gx-demo{background:var(--bg);border:1px solid var(--border-soft);border-radius:12px;padding:14px 13px 12px;margin-top:auto}
   #gauntlet .gx-demo-k{font:800 10px/1 Inter,sans-serif;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-bottom:16px;display:flex;justify-content:space-between}
   #gauntlet .gx-demo-k span:last-child{color:var(--accent)}
   #gauntlet .gx-demo-concept{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:19px;color:var(--ink);margin-bottom:18px}
@@ -2237,7 +2250,7 @@
   #gauntlet .gx-seal.on{opacity:1;transform:scale(1)}
   @media (max-width:880px){
     #gauntlet{padding:64px 20px}
-    #gauntlet .gx{grid-template-columns:1fr;gap:38px}
+    #gauntlet .gx-panels{grid-template-columns:1fr}
     #gauntlet h2{font-size:30px}
   }
   @media (prefers-reduced-motion:reduce){
@@ -2247,65 +2260,114 @@
 
 <section class="gauntlet-section" id="gauntlet">
   <div class="gx-wrap">
-    <div class="gx">
-      <div class="gx-copy">
-        <span class="gx-kicker"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 17l6-6-6-6"></path><path d="M12 19h8"></path></svg>Reword Gauntlet &middot; Pro</span>
-        <h2>Memorized the practice test? The real exam <em>re-words everything.</em></h2>
-        <p class="gx-lede">The Gauntlet asks one concept five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it <b>in any wording</b>. Miss one, and it rebuilds the whole run with fresh questions. There's nothing to memorize.</p>
-        <p class="gx-proof">Built from how people actually fail: candidates who ace question banks, then meet an exam that never repeats itself.</p>
-        <div class="gx-cta-row">
-          <a class="gx-btn" href="/pricing">Go Pro — unlimited</a>
-          <span class="gx-cta-note">Works on every cert in the library, automatically.</span>
+    <div class="gx-copy">
+      <span class="gx-kicker"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 17l6-6-6-6"></path><path d="M12 19h8"></path></svg>The Pro drills</span>
+      <h2>The exam has two tricks. Now you have <em>two drills.</em></h2>
+      <p class="gx-lede">Real exams beat question-bank grinders two ways: they <b>re-word everything</b> you practised, and they make <b>every wrong answer look right</b>. One drill trains each.</p>
+      <p class="gx-proof">Built from how people actually fail: the wording flips, and the look-alike options.</p>
+    </div>
+    <div class="gx-panels">
+      <div class="gx-panel" aria-hidden="true">
+        <p class="gx-panel-eyebrow">Reword Gauntlet</p>
+        <h3>Beat the concept in every disguise.</h3>
+        <p class="gx-panel-line">One concept, asked five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it <b>in any wording</b>. Miss one, and it rebuilds the run with fresh questions.</p>
+        <div class="gx-demo">
+          <div class="gx-demo-k"><span>The Gauntlet</span><span id="gx-demo-count">Rung 1 / 5</span></div>
+          <div class="gx-demo-concept">HTTPS rides port 443</div>
+          <div class="gx-rungs" id="gx-demo-rungs">
+            <div class="gx-dr"><span class="gx-dr-n">1</span><span class="gx-dr-t"><b>Plain</b><span>Which port does HTTPS use?</span></span></div>
+            <div class="gx-dr"><span class="gx-dr-n">2</span><span class="gx-dr-t"><b>Scenario</b><span>A storefront needs encrypted checkout traffic allowed&hellip;</span></span></div>
+            <div class="gx-dr"><span class="gx-dr-n">3</span><span class="gx-dr-t"><b>Best-of</b><span>Which rule BEST limits the exposure&hellip;</span></span></div>
+            <div class="gx-dr"><span class="gx-dr-n">4</span><span class="gx-dr-t"><b>Not-trap</b><span>Which of these is NOT carried over 443&hellip;</span></span></div>
+            <div class="gx-dr"><span class="gx-dr-n">5</span><span class="gx-dr-t"><b>Twisted</b><span>Two services share a host; only one handshake&hellip;</span></span></div>
+          </div>
+          <div class="gx-seal" id="gx-demo-seal">&#10003; Concept cracked</div>
         </div>
       </div>
-      <div class="gx-demo" aria-hidden="true">
-        <div class="gx-demo-k"><span>The Gauntlet</span><span id="gx-demo-count">Rung 1 / 5</span></div>
-        <div class="gx-demo-concept">HTTPS rides port 443</div>
-        <div class="gx-rungs" id="gx-demo-rungs">
-          <div class="gx-dr"><span class="gx-dr-n">1</span><span class="gx-dr-t"><b>Plain</b><span>Which port does HTTPS use?</span></span></div>
-          <div class="gx-dr"><span class="gx-dr-n">2</span><span class="gx-dr-t"><b>Scenario</b><span>A storefront needs encrypted checkout traffic allowed&hellip;</span></span></div>
-          <div class="gx-dr"><span class="gx-dr-n">3</span><span class="gx-dr-t"><b>Best-of</b><span>Which rule BEST limits the exposure&hellip;</span></span></div>
-          <div class="gx-dr"><span class="gx-dr-n">4</span><span class="gx-dr-t"><b>Not-trap</b><span>Which of these is NOT carried over 443&hellip;</span></span></div>
-          <div class="gx-dr"><span class="gx-dr-n">5</span><span class="gx-dr-t"><b>Twisted</b><span>Two services share a host; only one handshake&hellip;</span></span></div>
+      <div class="gx-panel" aria-hidden="true">
+        <p class="gx-panel-eyebrow">Why-Not</p>
+        <h3>Prove the wrong answers wrong.</h3>
+        <p class="gx-panel-line">The right answer is one point. The other three are knowing <b>why each wrong option loses</b>. Wrong for the wrong reason still counts as a miss, because it would on exam day.</p>
+        <div class="gx-demo">
+          <div class="gx-demo-k"><span>Why-Not</span><span>The answer was VPN</span></div>
+          <div class="wd-target"><i>B</i>Telnet · why does it lose?</div>
+          <div id="wd-demo-reasons">
+            <div class="wd-r">It only works on the local network</div>
+            <div class="wd-r" data-win>It sends everything in plain text, and the question demands encryption</div>
+            <div class="wd-r">It was deprecated, so it no longer exists</div>
+          </div>
+          <div class="wd-seal" id="wd-demo-seal">&#10003; Right reason</div>
         </div>
-        <div class="gx-seal" id="gx-demo-seal">&#10003; Concept cracked</div>
       </div>
+    </div>
+    <div class="gx-cta-row">
+      <a class="gx-btn" href="/pricing">Go Pro — unlimited</a>
+      <span class="gx-cta-note">Both drills run on every cert in the library, automatically.</span>
     </div>
   </div>
   <script>
-    /* Looping demo: rungs light in sequence, seal stamps, hold, reset.
-       Starts on first scroll-into-view (same IO pattern as the other
-       sections); reduced-motion users get the final state instantly. */
+    /* v7.50.0 — two looping demos, staggered so the seals never stamp at the
+       same moment. IO start + safety-net late start (a zero-size viewport or
+       prerender can starve the observer); reduced-motion gets final states. */
     (function(){
       var rungs=Array.prototype.slice.call(document.querySelectorAll('#gx-demo-rungs .gx-dr'));
       var seal=document.getElementById('gx-demo-seal');
       var count=document.getElementById('gx-demo-count');
-      if(!rungs.length||!seal||!count)return;
+      var reasons=Array.prototype.slice.call(document.querySelectorAll('#wd-demo-reasons .wd-r'));
+      var wdSeal=document.getElementById('wd-demo-seal');
+      if(!rungs.length||!seal||!count||!reasons.length||!wdSeal)return;
       var reduced=window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      if(reduced){count.textContent='5 / 5';return;}
-      var i=0,started=false;
-      function tick(){
-        if(i<rungs.length){
-          rungs[i].classList.add('on');
-          count.textContent='Rung '+(i+1)+' / 5';
-          i++;
-          setTimeout(tick,650);
+      if(reduced){
+        count.textContent='5 / 5';
+        reasons.forEach(function(r){if(r.hasAttribute('data-win'))r.classList.add('win');});
+        return;
+      }
+      var gi=0;
+      function gTick(){
+        if(gi<rungs.length){
+          rungs[gi].classList.add('on');
+          count.textContent='Rung '+(gi+1)+' / 5';
+          gi++;
+          setTimeout(gTick,650);
         }else{
           seal.classList.add('on');
           count.textContent='Cracked';
           setTimeout(function(){
             rungs.forEach(function(r){r.classList.remove('on');});
             seal.classList.remove('on');
-            i=0;
-            setTimeout(tick,700);
-          },2100);
+            gi=0;
+            setTimeout(gTick,900);
+          },2300);
         }
       }
-      function start(){ if(started)return; started=true; setTimeout(tick,600); }
+      var wi=0;
+      function wTick(){
+        if(wi<reasons.length){
+          reasons[wi].classList.add('on');
+          wi++;
+          setTimeout(wTick,650);
+        }else{
+          var winEl=null;
+          reasons.forEach(function(r){if(r.hasAttribute('data-win'))winEl=r;});
+          setTimeout(function(){
+            if(winEl)winEl.classList.add('win');
+            wdSeal.classList.add('on');
+            setTimeout(function(){
+              reasons.forEach(function(r){r.classList.remove('on','win');});
+              wdSeal.classList.remove('on');
+              wi=0;
+              setTimeout(wTick,900);
+            },2300);
+          },500);
+        }
+      }
+      var started=false;
+      function start(){ if(started)return; started=true; setTimeout(gTick,500); setTimeout(wTick,1100); }
       var s=document.getElementById('gauntlet');
       if('IntersectionObserver' in window){
         var io=new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting){start();io.disconnect();}});},{threshold:0.25});
         io.observe(s);
+        setTimeout(start,4000);
       } else { start(); }
     })();
   </script>

--- a/mockups/landing-flagship-drills.html
+++ b/mockups/landing-flagship-drills.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>certanvil.com · flagship drills section mockup (replaces the gauntlet section)</title>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600&family=Inter:wght@400;500;600;650;700;800&display=swap" rel="stylesheet">
+<style>
+  /* certanvil.com landing tokens (brand OKLCH per BRAND.md §3, light theme).
+     LIFT RULE: when lifting into landing/index.html these MUST be redefined
+     SCOPED TO THE SECTION ID + a [data-theme="dark"] block — landing's :root
+     --accent is still legacy purple (see design/brand/mockup-starter-tokens.css). */
+  :root {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280);
+    --muted: oklch(0.50 0.013 280); --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-bright: oklch(0.80 0.155 64); --on-accent: oklch(0.985 0.010 85);
+    --pass: oklch(0.52 0.13 150); --fail: oklch(0.52 0.19 25);
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: oklch(0.92 0.010 85); color: var(--ink); font: 400 15px/1.55 Inter, -apple-system, sans-serif; padding: 40px 20px 70px; }
+  .stage-head { max-width: 1080px; margin: 0 auto 24px; }
+  .stage-eyebrow { font: 800 10.5px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 8px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; color: var(--ink); }
+  .stage-sub { color: var(--muted); font-size: 13px; margin-top: 7px; max-width: 80ch; }
+  .stage-sub b { color: var(--ink); }
+
+  .canvas { max-width: 1080px; margin: 0 auto; background: var(--bg); border-radius: 18px; padding: 84px 64px; box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 30px 80px -45px color-mix(in oklab, var(--ink) 35%, transparent); }
+
+  /* ── shared header ── */
+  .fx-kicker { font: 800 11px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); display: inline-flex; align-items: center; gap: 7px; margin-bottom: 18px; }
+  .fx-kicker svg { width: 12px; height: 12px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .fx h2 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 38px; line-height: 1.13; letter-spacing: -0.015em; max-width: 22ch; }
+  .fx h2 em { font-style: italic; color: var(--accent); }
+  .fx-lede { color: var(--ink-soft); font-size: 16px; line-height: 1.6; margin: 16px 0 0; max-width: 58ch; }
+  .fx-lede b { color: var(--ink); }
+  .fx-proof { font-size: 13.5px; color: var(--muted); margin: 12px 0 0; }
+
+  /* ── the two panels ── */
+  .fx-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; margin-top: 34px; }
+  .panel { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 22px 21px; box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 18px 50px -30px color-mix(in oklab, var(--ink) 30%, transparent); display: flex; flex-direction: column; }
+  .panel-eyebrow { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.13em; text-transform: uppercase; color: var(--accent); margin-bottom: 9px; }
+  .panel h3 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin-bottom: 7px; }
+  .panel-line { font-size: 13.5px; color: var(--ink-soft); line-height: 1.55; margin-bottom: 16px; }
+  .panel-line b { color: var(--ink); }
+  .panel-demo { border: 1px solid var(--border-soft); border-radius: 12px; padding: 14px 13px 12px; background: var(--bg); margin-top: auto; }
+  .demo-k { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.13em; text-transform: uppercase; color: var(--muted); margin-bottom: 11px; display: flex; justify-content: space-between; }
+  .demo-k span:last-child { color: var(--accent); }
+
+  /* gauntlet mini demo (the proven loop, condensed) */
+  .gd-rungs { display: flex; flex-direction: column; gap: 7px; }
+  .gd-r { display: flex; align-items: center; gap: 9px; border: 1px solid var(--border-soft); border-radius: 9px; padding: 7px 10px; opacity: 0.35; transform: translateX(6px); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease), border-color 0.5s ease; }
+  .gd-r.on { opacity: 1; transform: translateX(0); border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); }
+  .gd-n { width: 20px; height: 20px; border-radius: 50%; display: grid; place-items: center; flex: none; font: 800 10px/1 Inter, sans-serif; background: color-mix(in oklab, var(--accent) 11%, transparent); color: var(--accent); }
+  .gd-r.on .gd-n { background: var(--accent); color: var(--on-accent); }
+  .gd-t { font: 650 11.5px/1.2 Inter, sans-serif; color: var(--ink); }
+  .gd-t small { display: block; font: 400 10.5px/1.3 Inter, sans-serif; color: var(--muted); }
+  .gd-seal { margin-top: 11px; text-align: center; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); opacity: 0; transform: scale(0.96); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease); }
+  .gd-seal.on { opacity: 1; transform: scale(1); }
+
+  /* why-not mini demo */
+  .wd-target { display: flex; align-items: center; gap: 8px; border: 1px solid color-mix(in oklab, var(--fail) 40%, var(--border-soft)); border-radius: 9px; padding: 7px 10px; margin-bottom: 9px; font: 650 12px/1.2 Inter, sans-serif; color: var(--ink); }
+  .wd-target i { width: 20px; height: 20px; border-radius: 50%; background: var(--fail); color: var(--bg); display: grid; place-items: center; flex: none; font: 800 10px/1 Inter, sans-serif; font-style: normal; }
+  .wd-ask { font: 650 12px/1.3 Inter, sans-serif; color: var(--ink-soft); margin-bottom: 8px; }
+  .wd-r { border: 1px solid var(--border-soft); border-radius: 9px; padding: 7px 10px; font: 500 11.5px/1.4 Inter, sans-serif; color: var(--ink-soft); margin-bottom: 7px; opacity: 0.35; transform: translateX(6px); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease), border-color 0.5s ease, background-color 0.5s ease; }
+  .wd-r.on { opacity: 1; transform: translateX(0); }
+  .wd-r.win { border-color: color-mix(in oklab, var(--pass) 55%, transparent); background: color-mix(in oklab, var(--pass) 9%, transparent); color: var(--ink); }
+  .wd-seal { margin-top: 11px; text-align: center; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--pass); opacity: 0; transform: scale(0.96); transition: opacity 0.5s var(--ease), transform 0.5s var(--ease); }
+  .wd-seal.on { opacity: 1; transform: scale(1); }
+
+  /* ── shared CTA ── */
+  .fx-cta-row { display: flex; align-items: center; gap: 18px; flex-wrap: wrap; margin-top: 34px; }
+  .btn-primary { background: var(--accent); color: var(--on-accent); border: 0; border-radius: 10px; padding: 14px 26px; font: 700 15px/1 Inter, sans-serif; cursor: pointer; text-decoration: none; display: inline-block; transition: transform 0.16s var(--ease), filter 0.2s ease; }
+  .btn-primary:active { transform: scale(0.97); }
+  @media (hover:hover) and (pointer:fine) { .btn-primary:hover { filter: brightness(1.08); } }
+  .fx-cta-note { font-size: 13px; color: var(--muted); }
+
+  @media (max-width: 880px) {
+    .canvas { padding: 54px 26px; }
+    .fx-panels { grid-template-columns: 1fr; }
+    .fx h2 { font-size: 30px; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .gd-r, .gd-seal, .wd-r, .wd-seal { transition: none !important; opacity: 1 !important; transform: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<div class="stage-head">
+  <p class="stage-eyebrow">certanvil.com · landing · REPLACES the v7.48 gauntlet section 1:1</p>
+  <h1 class="stage-title">The flagship drills: one section, two proofs</h1>
+  <p class="stage-sub">Simi's call: one Pro section, not two. Shared headline carries the story (the exam's two tricks), each drill gets a demo panel as proof, one CTA closes. The Gauntlet panel reuses the proven five-rung loop, condensed; the Why-Not panel loops a reason-pick. <b>Lift rule: scope all tokens to the section id</b>, light + dark blocks, per mockup-starter-tokens.css.</p>
+</div>
+
+<div class="canvas">
+  <section class="fx">
+    <span class="fx-kicker"><svg viewBox="0 0 24 24"><path d="M4 17l6-6-6-6"></path><path d="M12 19h8"></path></svg>The Pro drills</span>
+    <h2>The exam has two tricks. Now you have <em>two drills.</em></h2>
+    <p class="fx-lede">Real exams beat question-bank grinders two ways: they <b>re-word everything</b> you practised, and they make <b>every wrong answer look right</b>. One drill trains each.</p>
+    <p class="fx-proof">Built from how people actually fail: the wording flips, and the look-alike options.</p>
+
+    <div class="fx-panels">
+      <div class="panel" aria-hidden="true">
+        <p class="panel-eyebrow">Reword Gauntlet</p>
+        <h3>Beat the concept in every disguise.</h3>
+        <p class="panel-line">One concept, asked five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it <b>in any wording</b>. Miss one, and it rebuilds the run with fresh questions.</p>
+        <div class="panel-demo">
+          <div class="demo-k"><span>The Gauntlet</span><span id="gdCount">Rung 1 / 5</span></div>
+          <div class="gd-rungs" id="gdRungs">
+            <div class="gd-r"><span class="gd-n">1</span><span class="gd-t">Plain<small>Which port does HTTPS use?</small></span></div>
+            <div class="gd-r"><span class="gd-n">2</span><span class="gd-t">Scenario<small>Encrypted checkout traffic must be allowed&hellip;</small></span></div>
+            <div class="gd-r"><span class="gd-n">3</span><span class="gd-t">Best-of<small>Which rule BEST limits exposure&hellip;</small></span></div>
+            <div class="gd-r"><span class="gd-n">4</span><span class="gd-t">Not-trap<small>Which is NOT carried over 443&hellip;</small></span></div>
+            <div class="gd-r"><span class="gd-n">5</span><span class="gd-t">Twisted<small>Only one handshake on the host&hellip;</small></span></div>
+          </div>
+          <div class="gd-seal" id="gdSeal">&#10003; Concept cracked</div>
+        </div>
+      </div>
+
+      <div class="panel" aria-hidden="true">
+        <p class="panel-eyebrow">Why-Not</p>
+        <h3>Prove the wrong answers wrong.</h3>
+        <p class="panel-line">The right answer is one point. The other three are knowing <b>why each wrong option loses</b>. Wrong for the wrong reason still counts as a miss, because it would on exam day.</p>
+        <div class="panel-demo">
+          <div class="demo-k"><span>Why-Not</span><span id="wdCount">The answer was VPN</span></div>
+          <div class="wd-target"><i>B</i>Telnet · why does it lose?</div>
+          <div id="wdReasons">
+            <div class="wd-r">It only works on the local network</div>
+            <div class="wd-r" data-win>It sends everything in plain text, and the question demands encryption</div>
+            <div class="wd-r">It was deprecated, so it no longer exists</div>
+          </div>
+          <div class="wd-seal" id="wdSeal">&#10003; Right reason</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="fx-cta-row">
+      <a class="btn-primary" href="/pricing">Go Pro — unlimited</a>
+      <span class="fx-cta-note">Both drills run on every cert in the library, automatically.</span>
+    </div>
+  </section>
+</div>
+
+<script>
+  /* Two looping demos, staggered so they never stamp at the same moment.
+     Same IO-start + reduced-motion contract as the shipped gauntlet section. */
+  (function () {
+    var reduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var gdRungs = Array.prototype.slice.call(document.querySelectorAll('#gdRungs .gd-r'));
+    var gdSeal = document.getElementById('gdSeal');
+    var gdCount = document.getElementById('gdCount');
+    var wdReasons = Array.prototype.slice.call(document.querySelectorAll('#wdReasons .wd-r'));
+    var wdSeal = document.getElementById('wdSeal');
+    if (reduced) {
+      gdCount.textContent = '5 / 5';
+      wdReasons.forEach(function (r) { if (r.hasAttribute('data-win')) r.classList.add('win'); });
+      return;
+    }
+    var gi = 0;
+    function gTick() {
+      if (gi < gdRungs.length) {
+        gdRungs[gi].classList.add('on');
+        gdCount.textContent = 'Rung ' + (gi + 1) + ' / 5';
+        gi++;
+        setTimeout(gTick, 650);
+      } else {
+        gdSeal.classList.add('on');
+        gdCount.textContent = 'Cracked';
+        setTimeout(function () {
+          gdRungs.forEach(function (r) { r.classList.remove('on'); });
+          gdSeal.classList.remove('on');
+          gi = 0;
+          setTimeout(gTick, 900);
+        }, 2300);
+      }
+    }
+    var wi = 0;
+    function wTick() {
+      if (wi < wdReasons.length) {
+        wdReasons[wi].classList.add('on');
+        wi++;
+        setTimeout(wTick, 650);
+      } else {
+        var winEl = wdReasons.filter(function (r) { return r.hasAttribute('data-win'); })[0];
+        setTimeout(function () {
+          if (winEl) winEl.classList.add('win');
+          wdSeal.classList.add('on');
+          setTimeout(function () {
+            wdReasons.forEach(function (r) { r.classList.remove('on', 'win'); });
+            wdSeal.classList.remove('on');
+            wi = 0;
+            setTimeout(wTick, 900);
+          }, 2300);
+        }, 500);
+      }
+    }
+    var started = false;
+    function start() { if (started) return; started = true; setTimeout(gTick, 500); setTimeout(wTick, 1100); }
+    var s = document.querySelector('.fx');
+    if ('IntersectionObserver' in window) {
+      var io = new IntersectionObserver(function (es) {
+        es.forEach(function (e) { if (e.isIntersecting) { start(); io.disconnect(); } });
+      }, { threshold: 0.25 });
+      io.observe(s);
+      // Safety net (the brand reveal-IIFE rule): if the observer never fires
+      // (zero-size viewport, prerender, odd embeds), start anyway. Cheap
+      // class toggles; start() is idempotent.
+      setTimeout(start, 4000);
+    } else { start(); }
+  })();
+</script>
+</body>
+</html>

--- a/mockups/why-not-drill.html
+++ b/mockups/why-not-drill.html
@@ -67,7 +67,7 @@
   .reason { display: block; width: 100%; text-align: left; border: 1px solid var(--border-soft); background: var(--bg); border-radius: 11px; padding: 11px 13px; font: 550 13px/1.45 Inter, sans-serif; color: var(--ink-soft); margin-bottom: 8px; transition: transform 0.16s var(--ease); }
   .reason:active { transform: scale(0.985); }
   .reason.picked-right { border-color: color-mix(in oklab, var(--pass) 55%, transparent); background: color-mix(in oklab, var(--pass) 10%, transparent); color: var(--ink); }
-  .wn-verdict { border-left: 3px solid var(--pass); background: color-mix(in oklab, var(--pass) 8%, transparent); border-radius: 0 10px 10px 0; padding: 10px 13px; margin-top: 12px; font-size: 12.5px; color: var(--ink-soft); }
+  .wn-verdict { border: 1px solid color-mix(in oklab, var(--pass) 32%, var(--border-soft)); background: color-mix(in oklab, var(--pass) 8%, transparent); border-radius: 11px; padding: 10px 13px; margin-top: 12px; font-size: 12.5px; color: var(--ink-soft); }
   .wn-verdict b { display: block; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--pass); margin-bottom: 5px; }
   .wn-progress { display: flex; gap: 6px; margin-top: 14px; }
   .wn-progress i { flex: 1; height: 4px; border-radius: 3px; background: var(--surface-2); }

--- a/mockups/why-not-drill.html
+++ b/mockups/why-not-drill.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Why-Not drill · app mockup</title>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600&family=Inter:wght@400;500;600;650;700;800&display=swap" rel="stylesheet">
+<style>
+  /* ── Tokens: design/brand/mockup-starter-tokens.css, verbatim ─────────── */
+  :root, [data-theme="dark"] {
+    --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+    --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+    --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+    --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+    --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25);
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
+    --page-bg: oklch(0.13 0.008 275); --page-ink: oklch(0.96 0.006 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+    --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+    --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25);
+    --page-bg: oklch(0.94 0.008 85); --page-ink: oklch(0.22 0.015 280); --page-dim: oklch(0.50 0.013 280);
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: var(--page-bg); color: var(--page-ink); font: 400 15px/1.55 Inter, -apple-system, sans-serif; padding: 36px 20px 80px; }
+
+  /* ── stage chrome ── */
+  .stage { max-width: 1240px; margin: 0 auto; }
+  .stage-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 10px; }
+  .stage-eyebrow { font: 800 10.5px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 9px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 26px; letter-spacing: -0.014em; }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin-top: 8px; max-width: 86ch; }
+  .stage-sub b { color: var(--page-ink); }
+  .theme-btn { border: 1px solid var(--border); background: var(--surface); color: var(--ink); border-radius: 999px; padding: 9px 16px; font: 650 12.5px/1 Inter, sans-serif; cursor: pointer; transition: transform 0.16s var(--ease); }
+  .theme-btn:active { transform: scale(0.97); }
+
+  .units { display: grid; grid-template-columns: repeat(auto-fit, minmax(330px, 1fr)); gap: 34px; margin-top: 26px; }
+  .flag { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--page-dim); margin: 0 0 12px 6px; }
+  .unit-note { font-size: 12px; color: var(--page-dim); margin: 12px 6px 0; max-width: 48ch; }
+  .unit-note b { color: var(--page-ink); }
+
+  /* ── phone frame ── */
+  .phone { background: var(--bg); border: 1px solid var(--border-soft); border-radius: 34px; padding: 18px 16px 22px; box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 28px 60px -34px color-mix(in oklab, var(--ink) 30%, transparent); min-height: 660px; display: flex; flex-direction: column; }
+  .statusbar { display: flex; justify-content: space-between; align-items: center; font: 650 11px/1 Inter, sans-serif; color: var(--muted); padding: 2px 8px 14px; }
+  .ph-hdr { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 2px 2px 12px; }
+  .back { display: inline-flex; align-items: center; gap: 5px; font: 650 12px/1 Inter, sans-serif; color: var(--muted); }
+  .back svg { width: 13px; height: 13px; stroke: currentColor; fill: none; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+  .ph-title { font: 650 14px/1 Inter, sans-serif; color: var(--ink); }
+  .pill { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); border: 1px solid color-mix(in oklab, var(--accent) 35%, transparent); border-radius: 999px; padding: 5px 9px; display: inline-flex; align-items: center; gap: 5px; }
+  .pill svg { width: 9px; height: 9px; stroke: currentColor; fill: none; stroke-width: 2.4; }
+
+  /* ── shared run chrome ── */
+  .run-topic { text-align: center; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); margin: 2px 0 12px; }
+  .run-topic span { color: var(--accent); }
+  .answered-strip { display: flex; align-items: center; gap: 8px; border: 1px solid color-mix(in oklab, var(--pass) 30%, var(--border-soft)); background: color-mix(in oklab, var(--pass) 8%, transparent); border-radius: 11px; padding: 9px 12px; font: 550 12.5px/1.35 Inter, sans-serif; color: var(--ink-soft); margin-bottom: 14px; }
+  .answered-strip b { color: var(--ink); }
+  .answered-strip .tick { width: 18px; height: 18px; border-radius: 50%; background: var(--pass); color: var(--bg); display: grid; place-items: center; flex: none; font-size: 11px; }
+
+  .q-card { background: var(--surface); border: 1px solid var(--border-soft); border-radius: 16px; padding: 16px 15px; }
+  .wn-target { display: flex; align-items: center; gap: 10px; border: 1px solid color-mix(in oklab, var(--fail) 40%, var(--border-soft)); border-radius: 11px; padding: 10px 12px; margin-bottom: 13px; }
+  .wn-target .lt { width: 22px; height: 22px; border-radius: 50%; background: var(--fail); color: var(--bg); display: grid; place-items: center; flex: none; font: 800 11px/1 Inter, sans-serif; }
+  .wn-target b { font: 650 14px/1.3 Inter, sans-serif; color: var(--ink); }
+  .wn-ask { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 18px; letter-spacing: -0.01em; color: var(--ink); margin: 2px 1px 12px; }
+  .reason { display: block; width: 100%; text-align: left; border: 1px solid var(--border-soft); background: var(--bg); border-radius: 11px; padding: 11px 13px; font: 550 13px/1.45 Inter, sans-serif; color: var(--ink-soft); margin-bottom: 8px; transition: transform 0.16s var(--ease); }
+  .reason:active { transform: scale(0.985); }
+  .reason.picked-right { border-color: color-mix(in oklab, var(--pass) 55%, transparent); background: color-mix(in oklab, var(--pass) 10%, transparent); color: var(--ink); }
+  .wn-verdict { border-left: 3px solid var(--pass); background: color-mix(in oklab, var(--pass) 8%, transparent); border-radius: 0 10px 10px 0; padding: 10px 13px; margin-top: 12px; font-size: 12.5px; color: var(--ink-soft); }
+  .wn-verdict b { display: block; font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; color: var(--pass); margin-bottom: 5px; }
+  .wn-progress { display: flex; gap: 6px; margin-top: 14px; }
+  .wn-progress i { flex: 1; height: 4px; border-radius: 3px; background: var(--surface-2); }
+  .wn-progress i.done { background: var(--pass); }
+  .wn-progress i.bad { background: var(--fail); }
+  .wn-progress i.live { background: var(--accent); }
+  .wn-prog-k { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin-top: 6px; text-align: center; }
+
+  /* ── verdict screen ── */
+  .vd-wrap { display: flex; flex-direction: column; align-items: center; text-align: center; padding-top: 26px; flex: 1; }
+  .vd-score { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 30px; letter-spacing: -0.014em; color: var(--ink); font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum", "tnum"; }
+  .vd-score b { color: var(--accent); }
+  .vd-call { font-size: 13.5px; color: var(--ink-soft); margin: 8px 0 18px; max-width: 30ch; }
+  .vd-call b { color: var(--fail); }
+  .vd-rows { width: 100%; display: flex; flex-direction: column; gap: 8px; text-align: left; }
+  .vd-row { display: flex; align-items: flex-start; gap: 10px; border: 1px solid var(--border-soft); background: var(--surface); border-radius: 12px; padding: 11px 13px; }
+  .vd-ic { width: 22px; height: 22px; border-radius: 50%; display: grid; place-items: center; flex: none; }
+  .vd-ic svg { width: 12px; height: 12px; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; fill: none; stroke: currentColor; }
+  .vd-row.ok .vd-ic { background: color-mix(in oklab, var(--pass) 14%, transparent); color: var(--pass); }
+  .vd-row.bad .vd-ic { background: color-mix(in oklab, var(--fail) 14%, transparent); color: var(--fail); }
+  .vd-row b { display: block; font: 650 12.5px/1.3 Inter, sans-serif; color: var(--ink); }
+  .vd-row span { font-size: 11.5px; color: var(--muted); }
+  .blindspot { margin-top: 14px; border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border-soft)); background: color-mix(in oklab, var(--accent) 8%, transparent); border-radius: 999px; padding: 8px 14px; font: 650 11.5px/1.3 Inter, sans-serif; color: var(--ink-soft); }
+  .blindspot b { color: var(--accent-deep); }
+  .ph-footer { margin-top: auto; display: flex; flex-direction: column; gap: 9px; padding-top: 18px; }
+  .cta { background: var(--accent); color: var(--on-accent); border: 0; border-radius: 12px; padding: 14px; font: 700 14.5px/1 Inter, sans-serif; text-align: center; transition: transform 0.16s var(--ease); }
+  .cta:active { transform: scale(0.97); }
+  .ghost { background: none; border: 1px solid var(--border); border-radius: 12px; padding: 13px; color: var(--ink); font: 600 13px/1 Inter, sans-serif; text-align: center; transition: transform 0.16s var(--ease); }
+  .ghost:active { transform: scale(0.97); }
+
+  /* ── drills page unit ── */
+  .drills-h1 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 24px; letter-spacing: -0.012em; color: var(--ink); margin: 4px 2px 2px; }
+  .drills-lede { font-size: 12.5px; color: var(--muted); margin: 0 2px 14px; }
+  .dcard { background: var(--surface); border: 1px solid var(--border-soft); border-radius: 16px; padding: 15px 15px 16px; margin-bottom: 12px; }
+  .dcard.flagship { border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); }
+  .dcard-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 7px; }
+  .dcard-title { font: 650 15px/1.2 Inter, sans-serif; color: var(--ink); display: inline-flex; align-items: center; gap: 8px; }
+  .count-pill { font: 650 10.5px/1 Inter, sans-serif; color: var(--muted); border: 1px solid var(--border-soft); border-radius: 999px; padding: 5px 9px; }
+  .dcard-note { font-size: 12.5px; color: var(--muted); line-height: 1.5; margin-bottom: 12px; }
+  .dcard-btn { display: block; width: 100%; background: var(--accent); color: var(--on-accent); border: 0; border-radius: 11px; padding: 12px; font: 700 13.5px/1 Inter, sans-serif; text-align: center; transition: transform 0.16s var(--ease); }
+  .dcard-btn:active { transform: scale(0.97); }
+  .dcard.quiet .dcard-btn { background: none; border: 1px solid var(--border); color: var(--ink); font-weight: 600; }
+
+  /* entrance reveals (one-shot) */
+  .reveal { opacity: 0; transform: translateY(12px); animation: rv 0.55s var(--ease) forwards; }
+  .reveal.d2 { animation-delay: 0.1s; } .reveal.d3 { animation-delay: 0.2s; } .reveal.d4 { animation-delay: 0.3s; }
+  @keyframes rv { to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { .reveal { animation: none; opacity: 1; transform: none; } }
+</style>
+</head>
+<body>
+<div class="stage">
+  <div class="stage-top">
+    <div>
+      <p class="stage-eyebrow">Cert app · all platforms · Pro · second flagship</p>
+      <h1 class="stage-title">Why-Not: score the reasons</h1>
+      <p class="stage-sub">A round is one question plus its interrogation. Phase one is the normal quiz question (existing screens, untouched). Phase two is below: each wrong option comes back and you pick <b>why it loses</b> from three reasons, one true and two tempting fakes. Score is out of 4: the answer plus three reasons. One metered call generates the whole round, Gauntlet-style validation, Pro-gated at Start. <b>These mockups ARE the pages.</b></p>
+    </div>
+    <button type="button" class="theme-btn" id="themeToggle">Light / Dark</button>
+  </div>
+
+  <div class="units">
+
+    <!-- ① reason picker -->
+    <div>
+      <p class="flag">&#9312; The reason picker · right after a correct pick</p>
+      <div class="phone">
+        <div class="statusbar"><span>9:41</span><span>&#9679;&#9679;&#9679;</span></div>
+        <div class="ph-hdr">
+          <span class="back"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg>Menu</span>
+          <span class="ph-title">Why-Not</span>
+          <span class="pill"><svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span>
+        </div>
+        <p class="run-topic"><span>Why-Not</span> · Network Security · Round 2 of 3</p>
+        <div class="answered-strip reveal"><span class="tick">&#10003;</span><span>You answered: <b>VPN</b>. Right. Now earn the other three points.</span></div>
+        <div class="q-card">
+          <div class="wn-target reveal d2"><span class="lt">B</span><b>Telnet</b></div>
+          <p class="wn-ask reveal d2">Why does Telnet lose?</p>
+          <button type="button" class="reason reveal d3">It only works on the local network</button>
+          <button type="button" class="reason picked-right reveal d3">It sends everything in plain text, and the question demands encryption</button>
+          <button type="button" class="reason reveal d3">It was deprecated, so it no longer exists</button>
+          <div class="wn-verdict reveal d4"><b>Right reason</b>The other two sound plausible and are false: Telnet works fine remotely, and it very much still exists. What kills it here is one word in the question: encrypted.</div>
+        </div>
+        <div class="wn-progress"><i class="done"></i><i class="done"></i><i class="live"></i><i></i></div>
+        <p class="wn-prog-k">Answer &#10003; · Telnet &#10003; · Port 80 · SNMP</p>
+        <div class="ph-footer"><button type="button" class="cta">Next: why does port 80 lose? &#8594;</button></div>
+      </div>
+      <p class="unit-note">The chosen reason locks in green; the verdict names why the fakes were tempting. The thin progress bar tracks the round's four points. <b>Wrong picks turn the segment red and show the true reason</b>, same verdict card in fail colors.</p>
+    </div>
+
+    <!-- ② round verdict -->
+    <div>
+      <p class="flag">&#9313; Round verdict · 3 of 4</p>
+      <div class="phone">
+        <div class="statusbar"><span>9:44</span><span>&#9679;&#9679;&#9679;</span></div>
+        <div class="ph-hdr">
+          <span class="back"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg>Menu</span>
+          <span class="ph-title">Why-Not</span>
+          <span class="pill"><svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span>
+        </div>
+        <div class="vd-wrap">
+          <div class="vd-score reveal">You earned <b>3 of 4</b></div>
+          <p class="vd-call reveal d2">You knew the answer. You misdiagnosed why <b>port 80</b> loses.</p>
+          <div class="vd-rows">
+            <div class="vd-row ok reveal d2"><span class="vd-ic"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><span><b>The answer: VPN</b><span>Picked first time</span></span></div>
+            <div class="vd-row ok reveal d3"><span class="vd-ic"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><span><b>Telnet</b><span>Plain text, question demanded encryption</span></span></div>
+            <div class="vd-row bad reveal d3"><span class="vd-ic"><svg viewBox="0 0 24 24"><path d="M18 6 6 18M6 6l12 12"/></svg></span><span><b>Port 80</b><span>You said "deprecated". The real reason: no encryption at all</span></span></div>
+            <div class="vd-row ok reveal d4"><span class="vd-ic"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><span><b>SNMP</b><span>Different job: monitoring, not remote access</span></span></div>
+          </div>
+          <div class="blindspot reveal d4">Watch for: <b>missing the must-have</b>. Twice this week you reached for "deprecated" when the real killer was a missing requirement.</div>
+        </div>
+        <div class="ph-footer">
+          <button type="button" class="cta">Next round &#8594;</button>
+          <button type="button" class="ghost">Back to Home</button>
+        </div>
+      </div>
+      <p class="unit-note">The verdict names the exact miss in one sentence, then the blind-spot chip turns repeated misses into coaching. <b>Reason-type accuracy is the only new stat stored</b>; it feeds weak spots later (Phase B).</p>
+    </div>
+
+    <!-- ③ drills entry -->
+    <div>
+      <p class="flag">&#9314; Drills page · the two flagships together</p>
+      <div class="phone">
+        <div class="statusbar"><span>9:40</span><span>&#9679;&#9679;&#9679;</span></div>
+        <h2 class="drills-h1">Drills</h2>
+        <p class="drills-lede">Short, repeat passes on the things you get wrong.</p>
+        <div class="dcard flagship reveal">
+          <div class="dcard-head"><span class="dcard-title">Reword Gauntlet <span class="pill"><svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="count-pill">14 cracked</span></div>
+          <p class="dcard-note">One concept, asked five ways. Crack all five and you own it in any wording.</p>
+          <button type="button" class="dcard-btn">Run the Gauntlet</button>
+        </div>
+        <div class="dcard flagship reveal d2">
+          <div class="dcard-head"><span class="dcard-title">Why-Not <span class="pill"><svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="count-pill">Flagship drill</span></div>
+          <p class="dcard-note">Score the reasons, not just the answer. Every wrong option comes back: say why it loses.</p>
+          <button type="button" class="dcard-btn">Run Why-Not</button>
+        </div>
+        <div class="dcard quiet reveal d3">
+          <div class="dcard-head"><span class="dcard-title">Drill Mistakes <span class="pill"><svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="count-pill">12 saved</span></div>
+          <p class="dcard-note">Your missed questions come back re-worded, so you beat the concept, not the question.</p>
+          <button type="button" class="dcard-btn">Drill the 12 you missed</button>
+        </div>
+      </div>
+      <p class="unit-note">The two flagships sit together at the top with matching bronze-edged cards; Drill Mistakes drops to the quiet style below. <b>Home Practice tile gains a fourth option</b> ("Why-Not · score the reasons") mirroring the Gauntlet's entry.</p>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  document.getElementById('themeToggle').addEventListener('click', function () {
+    var h = document.documentElement;
+    h.setAttribute('data-theme', h.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  });
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.49.0",
+  "version": "7.50.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.49.0
+   Network+ AI Quiz — styles.css  v7.50.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.49.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.49.0';
+// Service Worker v7.50.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.50.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -1177,7 +1177,8 @@ test('Tier1: renderMarathonSection called in goSetup',
   // v4.99.39: window 1500 → 2500. goSetup has accumulated 3 teardown hooks
   // (_portDrillTeardown, _irwTeardown) pushing renderMarathonSection further
   // down the function body.
-  js.match(/function goSetup\(\)[\s\S]{0,2500}renderMarathonSection\(\)/));
+  // v7.50.0: window 2500 → 2900 after the gauntlet + why-not mode-reset blocks.
+  js.match(/function goSetup\(\)[\s\S]{0,2900}renderMarathonSection\(\)/));
 test('Tier1: renderMarathonSection called on DOMContentLoaded', js.match(/DOMContentLoaded[\s\S]{0,3000}renderMarathonSection\(\)/));
 // Marathon preset buttons still present inside the wrapper
 test('Tier1: Marathon 30-question preset still wired', html.includes("applyPreset('bulk30')"));
@@ -3865,7 +3866,8 @@ test('v4.53.0 JS: domain grid aggregates via TOPIC_DOMAINS lookup',
 // still calls renderSetupDomainGrid + renderTodayPlan.
 test('v4.53.0 JS (retargeted): goSetup calls renderSetupDomainGrid + renderTodayPlan',
   // v4.99.39: windows 1500 → 2500 (same reason as Tier1: teardown-hook accumulation)
-  /function goSetup\([\s\S]{0,2500}renderSetupDomainGrid[\s\S]{0,200}renderTodayPlan|function goSetup\([\s\S]{0,2500}renderTodayPlan[\s\S]{0,200}renderSetupDomainGrid/.test(js));
+  // v7.50.0: 2500 → 2900 after the gauntlet + why-not mode-reset blocks.
+  /function goSetup\([\s\S]{0,2900}renderSetupDomainGrid[\s\S]{0,200}renderTodayPlan|function goSetup\([\s\S]{0,2900}renderTodayPlan[\s\S]{0,200}renderSetupDomainGrid/.test(js));
 
 // CSS \u2014 sidebar
 test('v4.53.0 CSS: body.has-sidebar adds 240px left padding',
@@ -20073,6 +20075,27 @@ console.log('\n\x1b[1m── Security Phase 7 — CSP script-src unsafe-inline r
     /_optionCount\(q\.options\)\s*>=\s*3/.test(js));
   test('v7.48.1 OptShape: gauntlet run validation rejects non-string/empty option elements',
     /r\.options\.every\(o => typeof o === 'string' && o\.length > 0\)/.test(js));
+})();
+
+// ── v7.50.0: Why-Not — the second flagship drill ──
+(function(){
+  test('v7.50.0 WhyNot: core functions defined (start/fetch/picker/verdict)',
+    js.includes('function startWhyNot(') && js.includes('async function _fetchWhyNotSession(') &&
+    js.includes('function whyNotPickReason(') && js.includes('function renderWhyNotVerdict('));
+  test('v7.50.0 WhyNot: finish() branches to the reason picker in whyNotMode',
+    /function finish\(\)[\s\S]{0,900}whyNotMode && _wnSession\) \{ _wnFinishQuestion\(\); return; \}/.test(js));
+  test('v7.50.0 WhyNot: round question letterizes options before the quiz engine',
+    /options: _letterizeOptions\(r\.options\),[\s\S]{0,400}_wnSession\.topic/.test(js) || /_wnBeginRound[\s\S]{0,800}_letterizeOptions\(r\.options\)/.test(js));
+  test('v7.50.0 WhyNot: wrong-bank no-ops during sessions (parallel to bank/SR)',
+    /function addToWrongBank\([\s\S]{0,700}whyNotMode !== 'undefined' && whyNotMode\) return;/.test(js));
+  test('v7.50.0 WhyNot: follow-up drill suppressed in whyNot runs',
+    /!gauntletMode && !whyNotMode && typeof followUpOnMistake/.test(js));
+  test('v7.50.0 WhyNot: session validation pins 3 rounds + 2 factually-false fakes per wrong option',
+    /WHY_NOT_ROUNDS = 3/.test(js) && /k\.fakes\) && k\.fakes\.length === 2/.test(js));
+  test('v7.50.0 WhyNot: pages present (entry, round, verdict)',
+    html.includes('id="page-whynot"') && html.includes('id="page-whynot-round"') && html.includes('id="page-whynot-verdict"'));
+  test('v7.50.0 WhyNot: entries wired via data-action (Sec-P7, no inline onclick)',
+    html.includes('data-action="startWhyNot"') && /data-action="whyNotPickReason"/.test(js));
 })();
 
 // ── Summary ──


### PR DESCRIPTION
## What

**Why-Not** (second flagship, approved 2026-06-12): answer the question, then prove each wrong option wrong. 3 rounds per session on your weakest topic, score out of 4 per round (answer + 3 reason picks from menus of 1 true + 2 factually-false fakes). Pro-only at Start.

**Landing**: the #gauntlet section becomes "The flagship drills" — one Pro section, two demo panels (Gauntlet loop + Why-Not reason-pick loop), one CTA. Simi's explicit call: combined, not two sections.

## How

- One metered call per session, whole-session validation, letterized options (the v7.48.1 UAT-pinned contract)
- Phase 1 rides the existing quiz engine; `finish()` branches to the reason-picker page; verdicts reuse the gnt-* component family
- Gauntlet mechanisms reused: weakest-topic targeting, topic picker, Pro gate, topic strip, origin-aware back routing
- Parallel to bank/SR (guards extended); history feeds Today's goal + streak
- No left-accent-border callouts (the new BRAND.md anti-slop rule) — full tinted hairlines throughout
- Defensive guards: round bounds, same-page showPage, double-pick, first-answer freeze

## Checks

- UAT 4122/4122 incl. 8 new Why-Not contract guards; goSetup pins widened with dated comments
- Preview-verified: entry, full simulated 3-round session (12/12 + mixed-score paths), missed-answer path, both themes, bank isolation, chrome restore
- Landing verified both themes (scoped tokens — bronze, not purple), both demos present, safety-net start
- Spec + four-pass audited mockups already on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)