### PR TITLE
Landing: scrub stale v4.98.8 from a code comment

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -3172,7 +3172,8 @@
      #site-footer (new scoping-root id; class="foot" kept so the bare
      .foot rule is beaten per-property; no script.js / UAT contract on
      the footer). Fresh .fzx-* classes → zero production .foot-* bleed.
-     id="foot-version" PRESERVED verbatim ("v4.98.8"). The C/A monogram
+     id="foot-version" was removed 2026-06-12 (hardcoded, never updated;
+     version footers are banned on marketing pages). The C/A monogram
      path mirrors the topbar logo for brand consistency; the auth-wired
      topbar itself is untouched. [data-theme="dark"] matches the prod
      theme system; fonts from the hero-v2 head. #faq above untouched.


### PR DESCRIPTION
Follow-through on #456 — the badge element was removed but an old comment still claimed it was preserved and carried the literal string. Zero occurrences remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)