### PR TITLE
feat(diagnostic): in-app conversion ending + account Pass Plan home + plan-to-practice (v7.52.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.52.0 | In-app diagnostic conversion ending + account Pass Plan home (Free/Pro) + plan-to-practice + quota-aware builder |
 | v7.51.1 | En/em-dash cleanup in cert-app visible copy (readiness scale, drills note, exam abandon, quota line, Pro modal) |
 | v7.51.0 | Forged-bronze audit sweep — cert-app brand/emoji/dark-mode fixes + ACL hint-modal close handler |
 | v7.50.0 | Why-Not — second flagship drill: score the reasons, not just the answer; combined landing section |

--- a/app.js
+++ b/app.js
@@ -5417,7 +5417,7 @@ function _renderPassPlanWeakDomains(p) {
   if (!weakHost) return;
   weakHost.innerHTML = p.weakDomains.map(d => {
     const accPct = Math.round(d.accuracy * 100);
-    const onclick = "focusFirstTopicInDomain('" + d.key + "')";
+    const onclick = "_drillWeakDomainToBuilder('" + d.key + "')";
     return '<div class="pass-plan-weak-row">' +
       '<div class="pass-plan-weak-info">' +
       '<div class="pass-plan-weak-name">' + escHtml(d.label) + '</div>' +
@@ -6346,6 +6346,18 @@ function _setWarmupTopic(topic) {
 }
 
 // Helper: scroll-into-view + open the Custom Quiz details panel.
+// v7.52.0: informational quota line in the Custom Quiz builder — free tier only.
+function _renderBuilderQuotaLine() {
+  const el = document.getElementById('cq-quota-line');
+  if (!el) return;
+  if (_srIsFreeTier()) {
+    el.textContent = 'Free plan · ' + _quotaRemainingToday() + ' of ' + _quotaState.daily_limit + ' questions left today';
+    el.hidden = false;
+  } else {
+    el.hidden = true;
+  }
+}
+
 function _jumpToCustomQuiz() {
   // v5.5.4: Custom Quiz is a modal — _cqModalInit portals it to <body> on
   // open so position:fixed can't be broken by an ancestor. Just open it;
@@ -6354,6 +6366,7 @@ function _jumpToCustomQuiz() {
     const cq = document.getElementById('custom-quiz-section');
     if (cq && !cq.open) cq.open = true;
   } catch (_) {}
+  _renderBuilderQuotaLine();
 }
 
 // v5.5.4: Custom Quiz modal — portal + dismissals. The <details> 'toggle'
@@ -12496,6 +12509,18 @@ function prefillDomainTopics(domainKey) {
   // Refresh the Custom Quiz summary bar + jump into view
   if (typeof updateCqSummaryBar === 'function') updateCqSummaryBar();
   if (typeof _jumpToCustomQuiz === 'function') _jumpToCustomQuiz();
+}
+
+// v7.52.0: open the Custom Quiz builder pre-loaded with a weak domain's topics (no auto-start).
+function _drillWeakDomainToBuilder(domainKey) {
+  prefillDomainTopics(domainKey);                  // selects topics + opens builder, no auto-start
+  const rem = _quotaRemainingToday();              // Infinity for Pro/admin; N for free
+  const want = (rem === Infinity) ? 15 : Math.max(5, Math.min(15, rem));
+  qCount = want;
+  document.querySelectorAll('#count-group .chip').forEach(c =>
+    c.classList.toggle('on', c.dataset.v === String(want)));
+  syncChipAriaPressed('#count-group');
+  _renderBuilderQuotaLine();
 }
 
 // ══════════════════════════════════════════

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.51.1
+// Network+ AI Quiz — app.js  v7.52.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.51.1';
+const APP_VERSION = '7.52.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every
@@ -5620,20 +5620,6 @@ function _showProWaitlist() {
   var dismiss = document.getElementById('pro-waitlist-dismiss');
   if (dismiss) dismiss.addEventListener('click', function () { modal.remove(); });
   modal.addEventListener('click', function (e) { if (e.target === modal) modal.remove(); });
-}
-
-// Click-through helper — picks the first topic in a domain and routes to
-// the focus drill (existing wrong-bank-style focus). Topics are looked up
-// via TOPIC_DOMAINS reverse-map.
-function focusFirstTopicInDomain(domainKey) {
-  if (typeof TOPIC_DOMAINS === 'undefined') { goSetup(); return; }
-  const topics = Object.keys(TOPIC_DOMAINS).filter(t => TOPIC_DOMAINS[t] === domainKey);
-  if (topics.length === 0) { goSetup(); return; }
-  if (typeof focusTopic === 'function') {
-    focusTopic(topics[0]);
-  } else {
-    goSetup();
-  }
 }
 
 // "View report" CTA on the home Pass Plan tile.

--- a/app.js
+++ b/app.js
@@ -5708,6 +5708,195 @@ function closePassPlanReview() {
   goSetup();
 }
 
+// v7.52.0: render the account Pass Plan home, tier-aware. Free = one plan
+// card + locked-cert upsell; Pro = a plan per diagnosed cert + "diagnose
+// another". Ported from the approved mockup Section 2.
+function renderPassPlanSection() {
+  var host = document.getElementById('passplan-section');
+  if (!host) return;
+  var isPro = !!_quotaState && (_quotaState.tier === 'pro' ||
+    (typeof _quotaState.daily_limit === 'number' && _quotaState.daily_limit < 0));
+  host.innerHTML = isPro ? _renderPassPlanProHtml() : _renderPassPlanFreeHtml();
+  _wirePassPlanSection(host);
+}
+
+// Short "Taken Jun 14" style date for the Pass Plan cards.
+function _passPlanDate(ms) {
+  if (!ms) return '';
+  try {
+    return 'Taken ' + new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch (_) { return ''; }
+}
+
+// Lock chip SVG (padlock), reused by the Free upsell cert chips.
+function _passPlanLockSvg() {
+  return '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true">' +
+    '<rect x="5" y="11" width="14" height="9" rx="2" stroke="var(--text-dim)" stroke-width="2"/>' +
+    '<path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="var(--text-dim)" stroke-width="2"/></svg>';
+}
+
+// Free tier: one plan card from the on-file diagnostic (or an empty state),
+// then the locked-certs Pro upsell. Stays under 80 lines.
+function _renderPassPlanFreeHtml() {
+  var rec = (typeof loadDiagnostic === 'function') ? loadDiagnostic() : null;
+  var pp = rec && rec.passPlan;
+  var certName = (typeof CERT_PACK !== 'undefined' && CERT_PACK && CERT_PACK.meta && CERT_PACK.meta.name)
+    ? CERT_PACK.meta.name : 'CompTIA Network+';
+  var card;
+  if (pp) {
+    var prob = Math.round((pp.passProbability || 0) * 100);
+    var weak = (pp.weakDomains || []).slice(0, 2).map(function (d) {
+      return '<b>' + escHtml(d.label || d.key || '') + '</b>';
+    }).join(', ');
+    var detail = (typeof pp.correctCount === 'number' && typeof pp.questionCount === 'number')
+      ? (pp.correctCount + ' of ' + pp.questionCount + ' correct')
+      : ((typeof pp.accPct === 'number') ? (pp.accPct + '% accuracy') : '');
+    card =
+      '<div class="plan-card">' +
+        '<div class="pcard-eyebrow"><span>' + escHtml(certName) + '</span><span>' + escHtml(_passPlanDate(pp.completedAt)) + '</span></div>' +
+        '<div class="pcard-main">' +
+          '<div class="prob-ring" style="background:conic-gradient(var(--accent) 0 ' + prob + '%, var(--surface3) ' + prob + '% 100%)">' +
+            '<div class="inner"><span class="pct">' + prob + '%</span><span class="lbl">pass</span></div></div>' +
+          '<div class="pcard-detail">' +
+            (detail ? '<p class="meta">' + escHtml(detail) + '</p>' : '') +
+            (weak ? '<p class="weak">Weakest: ' + weak + '</p>' : '') +
+          '</div>' +
+        '</div>' +
+        '<div class="pcard-cta">' +
+          '<button type="button" class="btn btn-primary btn-sm" data-act="pp-view">View full plan</button>' +
+          '<button type="button" class="btn btn-ghost btn-sm" style="width:auto" data-act="pp-retake">Retake</button>' +
+        '</div>' +
+      '</div>';
+  } else {
+    card =
+      '<div class="plan-card pp-empty">' +
+        '<p class="pp-empty-h">Take the baseline diagnostic</p>' +
+        '<p class="pp-empty-sub">20 questions across every domain build your Pass Plan, your readiness and the topics to drill first.</p>' +
+        '<button type="button" class="btn btn-primary btn-sm" data-act="pp-empty">Start the diagnostic</button>' +
+      '</div>';
+  }
+  return '<div class="sub-label">Your Pass Plan</div>' + card + _passPlanLockedCertsHtml();
+}
+
+// Free upsell: the Pro certs as locked chips + a launch-waitlist button.
+function _passPlanLockedCertsHtml() {
+  var certs = (typeof window.getAvailableCerts === 'function')
+    ? window.getAvailableCerts('user').filter(function (c) { return c.tier === 'pro'; }) : [];
+  if (!certs.length) return '';
+  var chips = certs.map(function (c) {
+    return '<span class="cert-chip">' + _passPlanLockSvg() + escHtml(c.name) + '</span>';
+  }).join('');
+  return '<div class="locked-certs">' +
+    '<p class="locked-h">Every other cert, one plan each</p>' +
+    '<p class="locked-sub">Pro unlocks a baseline diagnostic and Pass Plan for every cert, plus unlimited questions instead of 15 questions a day.</p>' +
+    '<div class="cert-chips">' + chips + '</div>' +
+    '<button type="button" class="btn btn-primary btn-full btn-sm" data-act="pp-pro">Get Pro at launch &middot; $9.99/mo</button>' +
+  '</div>';
+}
+
+// Pro tier: a plan row per diagnosed cert (from the readiness snapshots),
+// plus "diagnose another cert". Stays under 80 lines.
+function _renderPassPlanProHtml() {
+  var snaps = _readReadinessSnapshots();
+  var certs = (typeof window.getAvailableCerts === 'function') ? window.getAvailableCerts('user') : [];
+  var byId = {};
+  certs.forEach(function (c) { byId[c.id] = c; });
+  var ids = Object.keys(snaps).filter(function (id) { return snaps[id]; });
+  var rows = ids.map(function (id) {
+    var s = snaps[id];
+    var meta = byId[id] || { name: id, code: '', glyph: '' };
+    var score = (typeof s.score === 'number') ? Math.round(s.score) : null;
+    var when = '';
+    if (s.computed_at) {
+      try { when = 'Taken ' + new Date(s.computed_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }); }
+      catch (_) { when = ''; }
+    }
+    var bits = [];
+    if (when) bits.push(when);
+    if (s.weak_domain) bits.push('weakest: ' + escHtml(s.weak_domain));
+    var ringPct = (score !== null) ? score : 0;
+    var name = escHtml(meta.name) + (meta.code ? ' ' + escHtml(meta.code) : '');
+    return '<div class="plan-item" data-act="pp-open-cert" data-cert="' + escHtml(id) + '" role="button" tabindex="0">' +
+      '<span class="pi-ring" style="background:conic-gradient(var(--accent) 0 ' + ringPct + '%, var(--surface3) ' + ringPct + '% 100%)">' +
+        '<span class="pi-ring-inner">' + (score !== null ? score : '&ndash;') + '</span></span>' +
+      '<span class="pi-body"><span class="pi-cert">' + name + '</span>' +
+        '<div class="pi-meta">' + (bits.length ? bits.join(' &middot; ') : 'Open this cert') + '</div></span>' +
+      '<span class="pi-go" aria-hidden="true">&rsaquo;</span></div>';
+  }).join('');
+  if (!rows) {
+    rows = '<div class="plan-card pp-empty"><p class="pp-empty-h">No diagnostics yet</p>' +
+      '<p class="pp-empty-sub">Run a baseline diagnostic on any cert to start building plans here.</p></div>';
+  }
+  return '<div class="sub-label">Your Pass Plans</div>' +
+    '<div class="plan-list">' + rows + '</div>' +
+    '<button type="button" class="add-cert" data-act="pp-add">' +
+      '<svg viewBox="0 0 24 24" fill="none" width="15" height="15" aria-hidden="true">' +
+        '<path d="M5 12h14M12 5v14" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"/></svg>' +
+      'Diagnose another cert</button>';
+}
+
+// Bind the Pass Plan section's data-act controls to existing app flows.
+function _wirePassPlanSection(host) {
+  host.querySelectorAll('[data-act]').forEach(function (el) {
+    var act = el.getAttribute('data-act');
+    var run = function (e) {
+      if (e) e.preventDefault();
+      if (act === 'pp-view') { viewPassPlan(); }
+      else if (act === 'pp-retake') { retakeDiagnostic(); }
+      else if (act === 'pp-empty') { startDiagnostic(); }
+      else if (act === 'pp-pro') { _showProWaitlist(); }
+      else if (act === 'pp-add') { _showPassPlanCertPicker(); }
+      else if (act === 'pp-open-cert') {
+        var id = el.getAttribute('data-cert');
+        if (id && typeof tadSwitchCert === 'function') tadSwitchCert(id);
+      }
+    };
+    el.addEventListener('click', run);
+    if (el.getAttribute('role') === 'button') {
+      el.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') run(e);
+      });
+    }
+  });
+}
+
+// v7.52.0: Pro "Diagnose another cert" picker. Lists the certs and switches
+// to the chosen one via tadSwitchCert (Pro-gated internally), which loads
+// that cert so the user can run its baseline diagnostic.
+function _showPassPlanCertPicker() {
+  var certs = (typeof window.getAvailableCerts === 'function') ? window.getAvailableCerts('user') : [];
+  if (!certs.length) return;
+  var prev = document.getElementById('pp-cert-picker');
+  if (prev) prev.remove();
+  var rows = certs.map(function (c) {
+    return '<button type="button" class="pp-pick-row" data-cert="' + escHtml(c.id) + '">' +
+      '<span class="pp-pick-glyph">' + escHtml(c.glyph || '') + '</span>' +
+      '<span class="pp-pick-body"><span class="pp-pick-name">' + escHtml(c.name) + '</span>' +
+      '<span class="pp-pick-code">' + escHtml(c.code || '') + '</span></span></button>';
+  }).join('');
+  var modal = document.createElement('div');
+  modal.id = 'pp-cert-picker';
+  modal.className = 'quota-exceeded-modal';
+  modal.innerHTML =
+    '<div class="dlpb-card" role="dialog" aria-modal="true" aria-label="Diagnose another cert">' +
+      '<h2 class="dlpb-title">Diagnose another cert</h2>' +
+      '<p class="dlpb-lede">Pick a cert to load, then run its baseline diagnostic.</p>' +
+      '<div class="pp-pick-list">' + rows + '</div>' +
+      '<button type="button" class="dlpb-ghost" data-act="pp-pick-close">Close</button>' +
+    '</div>';
+  document.body.appendChild(modal);
+  modal.querySelectorAll('.pp-pick-row').forEach(function (b) {
+    b.addEventListener('click', function () {
+      var id = b.getAttribute('data-cert');
+      modal.remove();
+      if (id && typeof tadSwitchCert === 'function') tadSwitchCert(id);
+    });
+  });
+  var close = modal.querySelector('[data-act="pp-pick-close"]');
+  if (close) close.addEventListener('click', function () { modal.remove(); });
+  modal.addEventListener('click', function (e) { if (e.target === modal) modal.remove(); });
+}
+
 // Render the home-page diagnostic surface. Three states:
 // 1. CTA visible (no diagnostic taken, or session-dismissed=false)
 // 2. Pass Plan tile visible (diagnostic completed)
@@ -10902,6 +11091,12 @@ function getReadinessScore() {
 // Defensive: silently no-ops on any failure so a snapshot write never
 // blocks a quiz/exam from finishing. The score will get rewritten on the
 // next quiz finish anyway.
+// v7.52.0: read the per-cert readiness snapshot map for the Pro multi-plan list.
+function _readReadinessSnapshots() {
+  try { return JSON.parse(localStorage.getItem(STORAGE.READINESS_SNAPSHOTS) || '{}') || {}; }
+  catch (_) { return {}; }
+}
+
 function _writeReadinessSnapshot() {
   try {
     var readiness = getReadinessScore();
@@ -19744,6 +19939,8 @@ function scrollToSettings() {
 // v4.54.1: Settings page render (updates the wrong-bank count badge).
 // Inputs (#api-key + Export/Import) are stateless and just work.
 function renderSettingsPage() {
+  // v7.52.0: account Pass Plan home (Free one-plan + upsell, Pro plan-per-cert)
+  if (typeof renderPassPlanSection === 'function') renderPassPlanSection();
   if (typeof renderWrongBankBtn === 'function') renderWrongBankBtn();
   // v4.54.10: sync the editable Daily Goal input with current value
   if (typeof syncSettingsDailyGoal === 'function') syncSettingsDailyGoal();

--- a/app.js
+++ b/app.js
@@ -5502,6 +5502,124 @@ function renderDiagnosticResult() {
   if (pbqSub && p.pbqRec) pbqSub.textContent = p.pbqRec.sub;
   const pbqCta = document.getElementById('pass-plan-pbq-cta');
   if (pbqCta && p.pbqRec) pbqCta.textContent = p.pbqRec.cta;
+
+  _renderDiagnosticConversion();
+}
+
+// v7.52.0: state-aware conversion moment at the bottom of the Pass Plan.
+// Anonymous → save-it-free panel + Pro waitlist teaser + soft escape.
+// Signed-in free → "saved to your account" + soft Pro line. Pro → hidden.
+function _renderDiagnosticConversion() {
+  const host = document.getElementById('dq-conversion');
+  if (!host) return;
+  const signedIn = window._certanvilSignedIn === true;
+  const isPro = !!_quotaState && (_quotaState.tier === 'pro' ||
+    (typeof _quotaState.daily_limit === 'number' && _quotaState.daily_limit < 0));
+
+  if (isPro) {                              // Pro: nothing to sell
+    host.hidden = true;
+    host.innerHTML = '';
+    return;
+  }
+  host.hidden = false;
+  if (signedIn) {                           // signed-in free: saved + soft Pro line
+    host.innerHTML =
+      '<p class="dq-affirm">' + _checkSvg() + 'Saved to your account</p>' +
+      '<a href="#" class="dq-affirm-link" data-act="dq-view-account">View it on your account page</a>' +
+      '<p class="dq-pro-soft">Want unlimited questions and every cert? ' +
+      '<a href="#" data-act="dq-pro-teaser">Get Pro at launch · $9.99/mo</a></p>';
+  } else {                                  // anonymous: save-free + Pro waitlist + escape
+    host.innerHTML = _dqAnonConversionHtml();
+  }
+  _wireDiagnosticConversion(host);
+}
+
+// Anonymous save-panel + Pro waitlist teaser + escape (ported from mockup Frame 1).
+function _dqAnonConversionHtml() {
+  return '' +
+    '<div class="dq-save-panel">' +
+      '<p class="dq-save-eyebrow">Before you start</p>' +
+      '<h2 class="dq-save-h">Don\'t lose your Pass Plan</h2>' +
+      '<p class="dq-save-sub">Right now it lives only on this device. Save it free and pick up where you left off on any device.</p>' +
+      '<div class="dq-email-row">' +
+        '<input class="dq-email-input" type="email" placeholder="you@email.com" aria-label="Email" data-act="dq-email">' +
+        '<button type="button" class="btn btn-primary" data-act="dq-save-free">Save it free</button>' +
+      '</div>' +
+      '<p class="dq-save-micro"><b>Just your email.</b> No password <span class="dq-sep"></span> no card <span class="dq-sep"></span> 15 questions a day</p>' +
+      '<p class="dq-save-home">' +
+        '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12h14M12 5v14" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"/></svg>' +
+        'It lands on your account page, ready whenever you come back.</p>' +
+    '</div>' +
+    '<div class="dq-pro">' +
+      '<div class="dq-pro-top"><span class="dq-pro-h">Going all in?</span><span class="dq-pro-tag">At launch</span></div>' +
+      '<p class="dq-pro-sub">CertAnvil Pro: unlimited questions, every cert, the topology builder and labs. <span class="dq-pro-price">$9.99/mo</span> when it ships.</p>' +
+      '<button type="button" class="btn btn-ghost dq-btn-ghost" data-act="dq-pro-teaser">Get Pro at launch</button>' +
+    '</div>' +
+    '<a href="#" class="dq-escape" data-act="dq-escape">Start today\'s session without saving</a>';
+}
+
+// Inline green check glyph for the "Saved" affirmation.
+function _checkSvg() {
+  return '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M20 6 9 17l-5-5" ' +
+    'stroke="var(--green)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+}
+
+// Bind the conversion block's data-act controls to existing app flows.
+function _wireDiagnosticConversion(host) {
+  host.querySelectorAll('[data-act]').forEach(function (el) {
+    el.addEventListener('click', function (e) {
+      const act = el.getAttribute('data-act');
+      if (act === 'dq-email') return;       // input, no click action
+      e.preventDefault();
+      if (act === 'dq-save-free') {
+        if (typeof _showSignInPrompt === 'function') {
+          _showSignInPrompt(host, 'Save your Pass Plan free: 15 questions a day, no password, no card.');
+        } else if (typeof buildSignInUrl === 'function') {
+          window.location.href = buildSignInUrl();
+        }
+      } else if (act === 'dq-pro-teaser') {
+        _showProWaitlist();
+      } else if (act === 'dq-escape') {
+        closePassPlanReview();
+      } else if (act === 'dq-view-account') {
+        showPage('settings');
+      }
+    });
+  });
+}
+
+// v7.52.0: App-Store-safe Pro teaser. Reuses the _showProOnlyUI visual shell
+// but carries NO external pricing/purchase link (Apple forbids external
+// purchase links for digital subscriptions). The action is a launch waitlist.
+function _showProWaitlist() {
+  var prev = document.getElementById('pro-only-modal');
+  if (prev) prev.remove();
+  var modal = document.createElement('div');
+  modal.id = 'pro-only-modal';
+  modal.className = 'quota-exceeded-modal';   // reuse overlay scrim
+  modal.innerHTML =
+    '<div class="dlpb-card" role="dialog" aria-modal="true" aria-label="CertAnvil Pro at launch">' +
+      '<div class="dlpb-lockmark" aria-hidden="true">' +
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">' +
+          '<rect x="4" y="11" width="16" height="9" rx="2.5"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path>' +
+        '</svg>' +
+      '</div>' +
+      '<h2 class="dlpb-title">CertAnvil Pro at launch</h2>' +
+      '<p class="dlpb-lede">CertAnvil Pro at launch · unlimited questions · every cert · $9.99/mo</p>' +
+      '<div class="dlpb-actions">' +
+        '<button type="button" class="dlpb-cta" id="pro-waitlist-notify">Notify me at launch</button>' +
+        '<button type="button" class="dlpb-ghost" id="pro-waitlist-dismiss">Not now</button>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(modal);
+  var notify = document.getElementById('pro-waitlist-notify');
+  if (notify) notify.addEventListener('click', function () {
+    if (typeof showToast === 'function') showToast('You\'re on the list · we\'ll let you know when Pro ships', 'info', 4000);
+    modal.remove();
+  });
+  var dismiss = document.getElementById('pro-waitlist-dismiss');
+  if (dismiss) dismiss.addEventListener('click', function () { modal.remove(); });
+  modal.addEventListener('click', function (e) { if (e.target === modal) modal.remove(); });
 }
 
 // Click-through helper — picks the first topic in a domain and routes to

--- a/app.js
+++ b/app.js
@@ -5574,8 +5574,8 @@ function _wireDiagnosticConversion(host) {
       if (act === 'dq-save-free') {
         if (typeof _showSignInPrompt === 'function') {
           _showSignInPrompt(host, 'Save your Pass Plan free: 15 questions a day, no password, no card.');
-        } else if (typeof buildSignInUrl === 'function') {
-          window.location.href = buildSignInUrl();
+        } else if (typeof window.buildSignInUrl === 'function') {
+          window.location.href = window.buildSignInUrl();
         }
       } else if (act === 'dq-pro-teaser') {
         _showProWaitlist();
@@ -12499,8 +12499,12 @@ function prefillDomainTopics(domainKey) {
 
 // v7.52.0: open the Custom Quiz builder pre-loaded with a weak domain's topics (no auto-start).
 function _drillWeakDomainToBuilder(domainKey) {
-  prefillDomainTopics(domainKey);                  // selects topics + opens builder, no auto-start
   const rem = _quotaRemainingToday();              // Infinity for Pro/admin; N for free
+  if (rem === 0) {                                 // free user out of questions today: show the wall, do not open a builder they cannot run
+    if (typeof _gateActivityForQuota === 'function') _gateActivityForQuota('practice quizzes');
+    return;
+  }
+  prefillDomainTopics(domainKey);                  // selects topics + opens builder, no auto-start
   const want = (rem === Infinity) ? 15 : Math.max(5, Math.min(15, rem));
   qCount = want;
   document.querySelectorAll('#count-group .chip').forEach(c =>

--- a/auth-state.js
+++ b/auth-state.js
@@ -100,6 +100,9 @@
     ];
   }
 
+  // v7.52.0: expose the cert registry so app.js can render the Pass Plan account section.
+  window.getAvailableCerts = getAvailableCerts;
+
   function getActiveCertId() {
     try {
       var dev = localStorage.getItem(CERT_OVERRIDE_KEY);

--- a/auth-state.js
+++ b/auth-state.js
@@ -102,6 +102,8 @@
 
   // v7.52.0: expose the cert registry so app.js can render the Pass Plan account section.
   window.getAvailableCerts = getAvailableCerts;
+  // v7.52.0: expose the in-app sign-in URL builder so the conversion block's "Save it free" has a reliable fallback.
+  window.buildSignInUrl = buildSignInUrl;
 
   function getActiveCertId() {
     try {

--- a/dg-system.css
+++ b/dg-system.css
@@ -540,6 +540,9 @@ html[data-theme] body #page-setup details.custom-quiz-section{background:none;bo
 html[data-theme] body #custom-quiz-section .cq-section-head{border-bottom:1px solid var(--border);}
 html[data-theme] body #custom-quiz-section .cq-section-title{color:var(--text-dim);}
 #custom-quiz-section .cq-section-ico,#custom-quiz-section .cq-mode-ico,#custom-quiz-section .cq-generate-ico{display:none!important;}
+/* v7.52.0: quota-aware builder line — bronze-tinted hairline pill (full border, symmetric radius). */
+html[data-theme] body #custom-quiz-section .cq-quota-line{display:block;font-size:11.5px;color:var(--text-mid);background:color-mix(in oklab,var(--accent) 6%,var(--bg));border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border));border-radius:var(--radius-sm);padding:9px 12px;margin:0 0 14px;}
+html[data-theme] body #custom-quiz-section .cq-quota-line[hidden]{display:none!important;}
 html[data-theme] body #custom-quiz-section .topic-quickpicks{border-bottom:1px solid var(--border);}
 html[data-theme] body #custom-quiz-section .topic-domain-prefill{border-bottom:1px solid var(--border);}
 

--- a/dg-system.css
+++ b/dg-system.css
@@ -3856,3 +3856,35 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 .wn-vd-score b{color:var(--accent);}
 .wn-vd-call{font-size:13.5px;color:var(--text-mid);margin:8px auto 18px;max-width:38ch;}
 .wn-vd-call b{color:var(--red);}
+
+/* v7.52.0 diagnostic conversion */
+#dq-conversion{display:block;margin-top:20px}
+#dq-conversion[hidden]{display:none!important}
+#dq-conversion .dq-save-panel{border:1px solid color-mix(in oklab,var(--accent) 32%,var(--border));background:color-mix(in oklab,var(--accent) 6%,var(--bg));border-radius:var(--radius);padding:18px 16px 16px}
+#dq-conversion .dq-save-eyebrow{font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent);margin:0 0 7px}
+#dq-conversion .dq-save-h{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:21px;line-height:1.15;letter-spacing:-0.01em;margin:0 0 7px;color:var(--text)}
+#dq-conversion .dq-save-sub{font-size:13px;line-height:1.5;color:var(--text-mid);margin:0 0 15px}
+#dq-conversion .dq-email-row{display:flex;gap:8px;margin-bottom:10px}
+#dq-conversion .dq-email-input{flex:1;min-width:0;height:46px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg);padding:0 13px;font:500 14px Inter,sans-serif;color:var(--text)}
+#dq-conversion .dq-email-input::placeholder{color:var(--text-dim)}
+#dq-conversion .dq-email-row .btn{height:46px;white-space:nowrap;flex:none}
+#dq-conversion .dq-save-micro{font-size:12px;color:var(--text-dim);display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:0}
+#dq-conversion .dq-save-micro b{color:var(--text-mid);font-weight:600}
+#dq-conversion .dq-sep{width:3px;height:3px;border-radius:50%;background:var(--text-dim);display:inline-block}
+#dq-conversion .dq-save-home{font-size:12px;color:var(--text-dim);margin:9px 0 0;display:flex;align-items:center;gap:6px}
+#dq-conversion .dq-save-home svg{width:13px;height:13px;flex:none}
+#dq-conversion .dq-pro{margin-top:12px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);padding:15px 16px}
+#dq-conversion .dq-pro-top{display:flex;justify-content:space-between;align-items:baseline;gap:10px}
+#dq-conversion .dq-pro-h{font-weight:700;font-size:14px;color:var(--text)}
+#dq-conversion .dq-pro-tag{font-size:10.5px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 30%,var(--border));border-radius:999px;padding:3px 8px}
+#dq-conversion .dq-pro-sub{font-size:12.5px;color:var(--text-mid);margin:5px 0 13px;line-height:1.5}
+#dq-conversion .dq-pro-price{color:var(--text);font-weight:700;font-variant-numeric:lining-nums tabular-nums;font-feature-settings:"lnum","tnum"}
+#dq-conversion .dq-btn-ghost{background:transparent;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 42%,var(--border));width:100%}
+#dq-conversion .dq-btn-ghost:hover{background:var(--accent-dim)}
+#dq-conversion .dq-escape{display:block;text-align:center;margin:16px auto 4px;font-size:13px;font-weight:500;color:var(--text-dim);text-decoration:none;padding:10px}
+#dq-conversion .dq-escape:hover{color:var(--text-mid)}
+#dq-conversion .dq-affirm{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--green);font-weight:600;margin:0 0 6px;justify-content:center}
+#dq-conversion .dq-affirm svg{width:16px;height:16px;flex:none}
+#dq-conversion .dq-affirm-link{display:block;text-align:center;font-size:12.5px;color:var(--accent);font-weight:600;text-decoration:none;margin:0 0 14px}
+#dq-conversion .dq-pro-soft{margin-top:14px;text-align:center;font-size:12.5px;color:var(--text-mid)}
+#dq-conversion .dq-pro-soft a{color:var(--accent);font-weight:600;text-decoration:none}

--- a/dg-system.css
+++ b/dg-system.css
@@ -3888,3 +3888,51 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 #dq-conversion .dq-affirm-link{display:block;text-align:center;font-size:12.5px;color:var(--accent);font-weight:600;text-decoration:none;margin:0 0 14px}
 #dq-conversion .dq-pro-soft{margin-top:14px;text-align:center;font-size:12.5px;color:var(--text-mid)}
 #dq-conversion .dq-pro-soft a{color:var(--accent);font-weight:600;text-decoration:none}
+
+/* v7.52.0: account Pass Plan home (ported from mockup Section 2, app tokens) */
+#passplan-section{padding:0;background:transparent;border:none}
+#passplan-section .sub-label{font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-dim);margin:0 4px 10px}
+#passplan-section .plan-card{border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);padding:16px;margin:0 0 14px}
+#passplan-section .pcard-eyebrow{font-size:10.5px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-dim);display:flex;justify-content:space-between;gap:10px;margin-bottom:12px}
+#passplan-section .pcard-main{display:flex;gap:15px;align-items:center}
+#passplan-section .prob-ring{width:62px;height:62px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center}
+#passplan-section .prob-ring .inner{width:48px;height:48px;border-radius:50%;background:var(--surface);display:flex;flex-direction:column;align-items:center;justify-content:center}
+#passplan-section .prob-ring .pct{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:17px;font-feature-settings:var(--lnum);line-height:1;color:var(--text)}
+#passplan-section .prob-ring .lbl{font-size:8px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.05em}
+#passplan-section .pcard-detail .meta{font-size:12.5px;color:var(--text-mid);margin:0 0 7px;font-feature-settings:var(--lnum)}
+#passplan-section .pcard-detail .weak{font-size:12.5px;color:var(--text);margin:0}
+#passplan-section .pcard-detail .weak b{color:var(--accent)}
+#passplan-section .pcard-cta{display:flex;gap:8px;margin-top:14px}
+#passplan-section .pp-empty{text-align:center}
+#passplan-section .pp-empty-h{font-family:Fraunces,Georgia,serif;font-weight:600;font-size:18px;margin:0 0 6px;color:var(--text)}
+#passplan-section .pp-empty-sub{font-size:12.5px;color:var(--text-mid);line-height:1.5;margin:0 0 14px}
+/* free upsell · locked other certs */
+#passplan-section .locked-certs{border:1px solid color-mix(in oklab,var(--accent) 32%,var(--border));border-radius:var(--radius);background:color-mix(in oklab,var(--accent) 6%,var(--bg));padding:15px 16px}
+#passplan-section .locked-h{font-weight:700;font-size:14px;margin:0 0 4px;color:var(--text)}
+#passplan-section .locked-sub{font-size:12.5px;color:var(--text-mid);margin:0 0 12px;line-height:1.5}
+#passplan-section .cert-chips{display:flex;flex-wrap:wrap;gap:7px;margin-bottom:14px}
+#passplan-section .cert-chip{display:flex;align-items:center;gap:5px;font-size:11.5px;font-weight:600;color:var(--text-dim);border:1px solid var(--border);border-radius:999px;padding:5px 11px;background:var(--bg)}
+#passplan-section .cert-chip svg{width:11px;height:11px;opacity:0.7}
+/* pro · multi-plan list */
+#passplan-section .plan-list{display:flex;flex-direction:column;gap:8px;margin:0 0 12px}
+#passplan-section .plan-item{display:flex;align-items:center;gap:12px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface);padding:11px 13px;cursor:pointer;transition:border-color .15s var(--ease)}
+#passplan-section .plan-item:hover{border-color:color-mix(in oklab,var(--accent) 50%,var(--border))}
+#passplan-section .pi-ring{width:36px;height:36px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center}
+#passplan-section .pi-ring-inner{width:27px;height:27px;border-radius:50%;background:var(--surface);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;font-feature-settings:var(--lnum);color:var(--text)}
+#passplan-section .pi-body{flex:1;min-width:0}
+#passplan-section .pi-cert{font-weight:700;font-size:13px;color:var(--text);display:block}
+#passplan-section .pi-meta{font-size:11.5px;color:var(--text-mid);font-feature-settings:var(--lnum)}
+#passplan-section .pi-go{color:var(--text-dim);font-size:17px;font-weight:600}
+#passplan-section .add-cert{display:flex;align-items:center;justify-content:center;gap:7px;border:1px dashed color-mix(in oklab,var(--accent) 45%,var(--border));border-radius:var(--radius-sm);background:transparent;color:var(--accent);font:700 13px Inter,sans-serif;height:46px;width:100%;cursor:pointer}
+/* pro · diagnose-another picker */
+#pp-cert-picker .pp-pick-list{display:flex;flex-direction:column;gap:8px;margin:12px 0 14px;text-align:left}
+#pp-cert-picker .pp-pick-row{display:flex;align-items:center;gap:11px;width:100%;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface);padding:10px 12px;cursor:pointer;transition:border-color .15s var(--ease)}
+#pp-cert-picker .pp-pick-row:hover{border-color:color-mix(in oklab,var(--accent) 50%,var(--border))}
+#pp-cert-picker .pp-pick-glyph{flex:none;width:34px;height:34px;border-radius:var(--radius-sm);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:12px;color:var(--accent);background:color-mix(in oklab,var(--accent) 10%,var(--bg));border:1px solid color-mix(in oklab,var(--accent) 28%,var(--border))}
+#pp-cert-picker .pp-pick-name{display:block;font-weight:700;font-size:13px;color:var(--text)}
+#pp-cert-picker .pp-pick-code{display:block;font-size:11.5px;color:var(--text-mid);font-feature-settings:var(--lnum)}
+/* desktop reflow · same markup widened (mockup desktop frame) */
+@media (min-width:720px){
+  #passplan-section .plan-list{display:grid;grid-template-columns:repeat(2,1fr);gap:10px}
+  #passplan-section .add-cert{max-width:280px}
+}

--- a/docs/superpowers/plans/2026-06-14-in-app-diagnostic-conversion.md
+++ b/docs/superpowers/plans/2026-06-14-in-app-diagnostic-conversion.md
@@ -1,0 +1,345 @@
+# In-app Diagnostic Conversion + Account Home + Plan-to-Practice — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the in-app Baseline Diagnostic a conversion ending, a permanent home on the account page (Free vs Pro), a path from a plan into pre-loaded practice, and a working re-diagnostic mechanism.
+
+**Architecture:** All new UI lives in the cert-app PWA (`index.html` + `app.js` + `dg-system.css`), wired onto already-shipped tier logic (free 15+5/day v7.40, custom-quiz 15-cap v7.46, one-cert lock v7.33, cross-cert snapshots v7.43). Visual markup/CSS is ported from the approved mockup `mockups/diagnostic-conversion/index.html` (mockups ARE the pages). One minimal export is added to `auth-state.js` (gated lane, satisfied by the feature-branch PR).
+
+**Tech Stack:** Vanilla HTML/JS/CSS SPA, forged-bronze `dg-system` tokens, Supabase-backed cloud state, UAT string assertions (`tests/uat.js`).
+
+**Spec:** `docs/superpowers/specs/2026-06-14-in-app-diagnostic-conversion-design.md`
+**Mockup (visual source of truth):** `mockups/diagnostic-conversion/index.html`
+
+---
+
+## Conventions for every task
+
+- **Branch:** work happens in this worktree on `feat/diagnostic-conversion` (already off `origin/main`).
+- **Local verify:** `cd` to repo root, `python3 -m http.server 3131`, drive `http://localhost:3131/index.html` with the preview tools. NEVER write user localStorage on a prod host.
+- **Brand (audit passes apply to every visible surface):** forged-bronze `--accent` only (never legacy purple), Fraunces display + Inter, full tinted hairlines (no left-accent-border callouts), symmetric radius, zero emoji, zero em-dashes, copy says "15 questions a day".
+- **tech-debt guardrails:** keep every new top-level function under 80 lines (headroom is 46/50); give every new function a caller or a UAT reference (dead-function gate is 0). If `node tests/tech-debt.js` trips the LOC cap, raise it per the v7.16.0 precedent in the same commit.
+- **Commit** after each task with a `feat(diagnostic):` / `chore:` message.
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `index.html` | conversion block container in `#page-diagnostic-result` (after :920); "Your Pass Plan" container in `#page-settings` `.settings-layout`; quota line + reuse of `#custom-quiz-section` |
+| `app.js` | `_renderDiagnosticConversion()`, `renderPassPlanSection()`, `_readReadinessSnapshots()`, `_drillWeakDomainToBuilder()`; repoint weak-domain button; render hooks in `renderDiagnosticResult()` + `renderSettingsPage()` |
+| `dg-system.css` | port conversion-block, account-plan, locked-cert, quota-line styles from the mockup |
+| `auth-state.js` | expose `window.getAvailableCerts` (1 line, gated) |
+| `tests/uat.js` | string/`_fnBody` guards for each new surface |
+| `scripts/bump-version.js` (run) | v7.51.1 → v7.52.0 |
+
+---
+
+## Phase 1 — Conversion block (post-diagnostic moment)
+
+### Task 1: Conversion block markup container
+
+**Files:**
+- Modify: `index.html` (after the `.pass-plan-final-cta` block, currently `:918-920`)
+
+- [ ] **Step 1: Add an empty render target below the final CTA.** Insert immediately after the closing `</div>` of `.pass-plan-final-cta` (after :920), before the `#page-diagnostic-result` page close (:921):
+
+```html
+  <!-- v7.52.0: state-aware conversion block, rendered by _renderDiagnosticConversion() -->
+  <div id="dq-conversion" class="dq-conversion" hidden></div>
+```
+
+- [ ] **Step 2: Verify it parses.** Run the local server, navigate to the app, confirm no console error and the element exists: `document.getElementById('dq-conversion')` is non-null.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add index.html && git commit -m "feat(diagnostic): add conversion block container to result page"
+```
+
+### Task 2: Conversion block styles
+
+**Files:**
+- Modify: `dg-system.css` (append a `/* diagnostic conversion */` block)
+
+- [ ] **Step 1: Port the styles.** From `mockups/diagnostic-conversion/index.html` copy the rules for `.save-panel`, `.save-eyebrow`, `.save-h`, `.save-sub`, `.email-row`/`.email-input`, `.save-micro`, `.save-home`, `.pro` (teaser), `.pro-tag`, `.btn-ghost`, `.escape`, `.affirm`, `.affirm-link`, `.pro-soft`, scoped under `#dq-conversion`. Use the cert-app's existing tokens (`--accent`, `--surface`, `--border`, `--text`, `--text-mid`, `--green`, `--radius`) which are already forged-bronze in `dg-system.css` — do NOT hardcode the mockup's oklch values. Keep buttons reusing the app's `.btn`/`.btn-primary` where possible.
+
+- [ ] **Step 2: Verify in browser.** Temporarily `document.getElementById('dq-conversion').hidden=false` and inject a sample save-panel via preview_eval; screenshot; confirm bronze (not purple), hairline borders, no emoji/em-dash. Revert the temporary change.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add dg-system.css && git commit -m "feat(diagnostic): conversion block styles (ported from approved mockup)"
+```
+
+### Task 3: `_renderDiagnosticConversion()` + render hook
+
+**Files:**
+- Modify: `app.js` — new function near `renderDiagnosticResult()` (`:5446`); add a call at its tail (~`:5501`)
+
+- [ ] **Step 1: Write the function.** Add `_renderDiagnosticConversion()` (keep < 80 lines). Three states via the documented detectors:
+
+```js
+// v7.52.0: state-aware conversion moment at the bottom of the Pass Plan.
+function _renderDiagnosticConversion() {
+  const host = document.getElementById('dq-conversion');
+  if (!host) return;
+  const signedIn = window._certanvilSignedIn === true;
+  const isPro = !!_quotaState && (_quotaState.tier === 'pro' ||
+    (typeof _quotaState.daily_limit === 'number' && _quotaState.daily_limit < 0));
+
+  if (isPro) {                              // Pro: nothing to sell
+    host.hidden = true;
+    return;
+  }
+  host.hidden = false;
+  if (signedIn) {                           // signed-in free: saved + soft Pro line
+    host.innerHTML =
+      '<p class="affirm">' + _checkSvg() + 'Saved to your account</p>' +
+      '<a href="#" class="affirm-link" data-act="dq-view-account">View it on your account page</a>' +
+      '<p class="pro-soft">Want unlimited questions and every cert? ' +
+      '<a href="#" data-act="dq-pro-teaser">Get Pro at launch</a></p>';
+  } else {                                  // anonymous: save-free + Pro waitlist + escape
+    host.innerHTML = _dqAnonConversionHtml();
+  }
+  _wireDiagnosticConversion(host);
+}
+```
+
+- [ ] **Step 2: Add the helpers** `_dqAnonConversionHtml()` (returns the save-panel + pro-teaser + escape markup, ported from the mockup's Frame 1, copy = "Don't lose your Pass Plan" / "Save it free" / "Just your email. No password · no card · 15 questions a day"), `_checkSvg()` (inline green check), and `_wireDiagnosticConversion(host)` which binds:
+  - `[data-act="dq-save-free"]` → `_showSignInPrompt(host, 'Save your Pass Plan free')` (existing, `app.js:7444`) — or navigate to `buildSignInUrl()` if the helper is unavailable.
+  - `[data-act="dq-pro-teaser"]` and the Pro CTA → a new `_showProWaitlist()` that reuses the `_showProOnlyUI` visual shell **without the `certanvil.com/pricing` link** (App Store rule) — body copy "Pro at launch · unlimited · all certs · $9.99/mo", and a "Notify me at launch" action (no external purchase).
+  - `[data-act="dq-escape"]` → `closePassPlanReview()` (existing).
+  - `[data-act="dq-view-account"]` → `showPage('settings')`.
+
+- [ ] **Step 3: Call it from the result renderer.** At the tail of `renderDiagnosticResult()` (after the existing `#pass-plan-*` population, ~`:5501`), add:
+```js
+  _renderDiagnosticConversion();
+```
+
+- [ ] **Step 4: Browser verify all three states.** Use preview_eval to set `window._certanvilSignedIn` and a stub `_quotaState` ({tier:'free'} / {tier:'pro'} / null), re-call `renderDiagnosticResult()`, screenshot each. Confirm: anonymous shows save-panel+escape; free shows saved+pro line; pro hides the block. Confirm "Save it free" triggers the sign-in path and the Pro CTA does NOT navigate to `/pricing`.
+
+- [ ] **Step 5: UAT guards.** In `tests/uat.js` add:
+```js
+test('diagnostic conversion block present', html.includes('id="dq-conversion"'));
+test('conversion renders states', _fnBody(js, '_renderDiagnosticConversion').includes('_certanvilSignedIn'));
+test('Pro teaser has no pricing link', !_fnBody(js, '_showProWaitlist').includes('certanvil.com/pricing'));
+```
+Run `node tests/uat.js`; expect pass.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add app.js tests/uat.js && git commit -m "feat(diagnostic): state-aware conversion moment after the Pass Plan"
+```
+
+---
+
+## Phase 2 — Account-page Pass Plan home (Free vs Pro)
+
+### Task 4: Expose the cert registry (gated, 1 line)
+
+**Files:**
+- Modify: `auth-state.js` (after the `getAvailableCerts` IIFE/function, ~`:101`)
+
+- [ ] **Step 1: Export it on window.**
+```js
+// v7.52.0: expose the cert registry so app.js can render the Pass Plan account section.
+window.getAvailableCerts = getAvailableCerts;
+```
+
+- [ ] **Step 2: Verify.** In the browser console (local), `window.getAvailableCerts('user')` returns the 8-cert array.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add auth-state.js && git commit -m "feat(account): expose getAvailableCerts for the account Pass Plan section (gated)"
+```
+
+### Task 5: Readiness-snapshot reader
+
+**Files:**
+- Modify: `app.js` (near `_writeReadinessSnapshot`, `:10787`)
+
+- [ ] **Step 1: Add a reader** (a writer exists, no reader). Keep tiny:
+```js
+// v7.52.0: read the per-cert readiness snapshot map for the Pro multi-plan list.
+function _readReadinessSnapshots() {
+  try { return JSON.parse(localStorage.getItem(STORAGE.READINESS_SNAPSHOTS) || '{}') || {}; }
+  catch (_) { return {}; }
+}
+```
+
+- [ ] **Step 2: UAT guard.**
+```js
+test('readiness snapshot reader', /function _readReadinessSnapshots\(/.test(js));
+```
+
+- [ ] **Step 3: Commit.**
+```bash
+git add app.js tests/uat.js && git commit -m "feat(account): per-cert readiness snapshot reader"
+```
+
+### Task 6: "Your Pass Plan" section markup container
+
+**Files:**
+- Modify: `index.html` (inside `#page-settings` `.settings-layout`, after `:1518`)
+
+- [ ] **Step 1: Add a settings group at the top of the layout.**
+```html
+  <!-- v7.52.0: Pass Plan home (Free=one plan + upsell, Pro=plan per cert) -->
+  <div class="settings-group" id="settings-passplan-group">
+    <div class="settings-group-num">§ 00</div>
+    <section class="card settings-section" id="passplan-section"></section>
+  </div>
+```
+
+- [ ] **Step 2: Verify** the element exists when `showPage('settings')` is open. Commit.
+```bash
+git add index.html && git commit -m "feat(account): Your Pass Plan section container in settings"
+```
+
+### Task 7: `renderPassPlanSection()` + render hook
+
+**Files:**
+- Modify: `app.js` — new function; call inside `renderSettingsPage()` (`:19628`)
+
+- [ ] **Step 1: Write the renderer** (split into `_renderPassPlanFree()` and `_renderPassPlanPro()` helpers so each stays < 80 lines):
+
+```js
+// v7.52.0: render the account Pass Plan home, tier-aware.
+function renderPassPlanSection() {
+  const host = document.getElementById('passplan-section');
+  if (!host) return;
+  const isPro = !!_quotaState && (_quotaState.tier === 'pro' ||
+    (typeof _quotaState.daily_limit === 'number' && _quotaState.daily_limit < 0));
+  host.innerHTML = isPro ? _renderPassPlanProHtml() : _renderPassPlanFreeHtml();
+  _wirePassPlanSection(host);
+}
+```
+
+- [ ] **Step 2: `_renderPassPlanFreeHtml()`** — one plan card from `loadDiagnostic().passPlan` (pass probability `passProbability`, `accPct`, `completedAt` date, top `weakDomains`), with `View full plan` (→ `viewPassPlan()`) and `Retake` (→ `retakeDiagnostic()`); then the locked-certs upsell: iterate `window.getAvailableCerts('user').filter(c => c.tier === 'pro')` into lock chips + a "Get Pro at launch" action (`_showProWaitlist()`, no `/pricing`). If `loadDiagnostic()` is null, show a "Take the baseline diagnostic" empty state → `startDiagnostic()`. Markup/CSS ported from the mockup Section 2 Free frame.
+
+- [ ] **Step 3: `_renderPassPlanProHtml()`** — read `_readReadinessSnapshots()`, map each present cert id through `window.getAvailableCerts('user')` to its `name`+`code`+`glyph`, render one compact row per cert (readiness `score`, `computed_at` date, `weak_domain`) opening that cert via `tadSwitchCert(id)`; plus a "Diagnose another cert" action → a cert picker that calls `tadSwitchCert(id)` (Pro-gated already). Markup from the mockup Section 2 Pro frames (phone + the desktop reflow is just CSS).
+
+- [ ] **Step 4: `_wirePassPlanSection(host)`** binds the `data-act` buttons: `pp-view` → `viewPassPlan()`; `pp-retake` → `retakeDiagnostic()`; `pp-pro` → `_showProWaitlist()`; `pp-open-cert` → `tadSwitchCert(certId)`; `pp-empty` → `startDiagnostic()`.
+
+- [ ] **Step 5: Hook into settings render.** In `renderSettingsPage()` (`:19628`), add near the other guarded sub-renderers:
+```js
+  if (typeof renderPassPlanSection === 'function') renderPassPlanSection();
+```
+
+- [ ] **Step 6: Styles.** Append account-plan styles to `dg-system.css` ported from the mockup (`.plan-card`, `.prob-ring`, `.pcard-*`, `.locked-certs`, `.cert-chip`, `.plan-list`, `.plan-item`, `.pi-*`, `.add-cert`), scoped under `#passplan-section`, using app tokens.
+
+- [ ] **Step 7: Browser verify both tiers.** Stub `_quotaState` free vs pro + a sample `nplus_diagnostic` and `nplus_readiness_snapshots` (local only), open Settings, screenshot each. Confirm Free shows one plan + locked chips; Pro shows the per-cert list + add. Confirm retake/view/switch handlers fire.
+
+- [ ] **Step 8: UAT guards.**
+```js
+test('account Pass Plan section', html.includes('id="passplan-section"'));
+test('Pass Plan section tier-aware', _fnBody(js, 'renderPassPlanSection').includes('_renderPassPlanProHtml'));
+test('Pro plan list uses snapshots', _fnBody(js, '_renderPassPlanProHtml').includes('_readReadinessSnapshots'));
+```
+Run `node tests/uat.js`; expect pass.
+
+- [ ] **Step 9: Commit.**
+```bash
+git add app.js index.html dg-system.css tests/uat.js && git commit -m "feat(account): Pass Plan home on settings (Free one-plan+upsell, Pro plan-per-cert)"
+```
+
+---
+
+## Phase 3 — Plan to practice (pre-loaded builder)
+
+### Task 8: `_drillWeakDomainToBuilder()` (open builder, no auto-start)
+
+**Files:**
+- Modify: `app.js` — new function modeled on `prefillDomainTopics` (`:12158`); repoint the weak-domain button in `_renderPassPlanWeakDomains` (`:5413-5429`)
+
+- [ ] **Step 1: Write the handler** (keep < 80 lines):
+```js
+// v7.52.0: open the Custom Quiz builder pre-loaded with a weak domain's topics (no auto-start).
+function _drillWeakDomainToBuilder(domainKey) {
+  prefillDomainTopics(domainKey);                 // selects topics + recomputes `topic` + opens builder
+  const rem = _quotaRemainingToday();             // Infinity for Pro; N for free
+  const want = (rem === Infinity) ? 15 : Math.max(5, Math.min(15, rem));
+  qCount = want;
+  document.querySelectorAll('#count-group .chip').forEach(c =>
+    c.classList.toggle('on', c.dataset.v === String(want)));
+  syncChipAriaPressed('#count-group');
+  _renderBuilderQuotaLine();                       // "N of 15 left today" (Task 9)
+}
+```
+
+- [ ] **Step 2: Repoint the weak-domain button.** In `_renderPassPlanWeakDomains` (`:5420`/`:5426`) change the button `onclick` from `focusFirstTopicInDomain('<key>')` (which auto-starts) to `_drillWeakDomainToBuilder('<key>')`. Keep the "Drill all weak topics" primary button → call `_drillWeakDomainToBuilder` for the top weak domain (or extend to select all weak domains' topics).
+
+- [ ] **Step 3: Browser verify.** Open a Pass Plan, click a weak-domain "Fix this →"; confirm the Custom Quiz builder OPENS with that domain's topics pre-selected and the count set, and does NOT immediately start a quiz. Confirm hitting Generate then runs the normal `startQuiz()` flow.
+
+- [ ] **Step 4: UAT guard.**
+```js
+test('weak drill opens builder (no autostart)', _fnBody(js, '_drillWeakDomainToBuilder').includes('prefillDomainTopics') && !_fnBody(js, '_drillWeakDomainToBuilder').includes('startQuiz('));
+```
+
+- [ ] **Step 5: Commit.**
+```bash
+git add app.js tests/uat.js && git commit -m "feat(diagnostic): weak topics open the Custom Quiz builder pre-loaded"
+```
+
+### Task 9: Quota-aware builder line
+
+**Files:**
+- Modify: `index.html` (`#custom-quiz-section`, near `#count-group` `:604`); `app.js` (`_renderBuilderQuotaLine`)
+
+- [ ] **Step 1: Add a quota line element** above `#count-group`:
+```html
+  <div id="cq-quota-line" class="cq-quota-line" hidden></div>
+```
+
+- [ ] **Step 2: Write `_renderBuilderQuotaLine()`** (tiny): if `_srIsFreeTier()`, show `"Free plan · " + _quotaRemainingToday() + " of " + _quotaState.daily_limit + " questions left today"` and reveal; else keep hidden. Call it from `_drillWeakDomainToBuilder` (Task 8) and whenever the builder opens (`_jumpToCustomQuiz`, `:6042`).
+
+- [ ] **Step 3: Style** `.cq-quota-line` from the mockup's `.quota-note` (bronze-tinted hairline pill), scoped, app tokens.
+
+- [ ] **Step 4: Browser verify** with a stubbed free `_quotaState` ({tier:'free', daily_limit:15, used_today:7}); confirm "8 of 15 questions left today" shows and the count chip clamps to ≤ remaining. (The existing v7.46 count-interceptor + `startQuiz` gate enforce the hard cap — no new gate logic.)
+
+- [ ] **Step 5: UAT guard.**
+```js
+test('builder quota line', html.includes('id="cq-quota-line"') && /function _renderBuilderQuotaLine\(/.test(js));
+```
+
+- [ ] **Step 6: Commit.**
+```bash
+git add index.html app.js dg-system.css tests/uat.js && git commit -m "feat(diagnostic): quota-aware Custom Quiz builder line for free users"
+```
+
+---
+
+## Phase 4 — Audit, version, ship
+
+### Task 10: Four audit passes on the real build
+
+- [ ] **Step 1:** Run `/design-taste-frontend` → `/emil-design-eng` → `/humanizer` → `/marketing-psychology` against the three live surfaces (conversion block, account Pass Plan, builder line) in the browser. Fix findings inline (em-dash/emoji scan, bronze-not-purple, hairline-not-callout, copy clarity, loss-aversion framing). Re-screenshot.
+- [ ] **Step 2:** Commit any audit fixes: `git commit -am "polish(diagnostic): four-pass audit fixes on conversion + account surfaces"`.
+
+### Task 11: review-feature (4-agent) pass
+
+- [ ] **Step 1:** Run the in-repo `review-feature` skill (touches accounts + the Pro path → required). Address blocking findings; commit fixes.
+
+### Task 12: Version bump + tech-debt check
+
+- [ ] **Step 1:** `export PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH"` then `node scripts/bump-version.js 7.52.0 "In-app diagnostic conversion + account Pass Plan home + plan-to-practice"`. Re-read CLAUDE.md (the script rewrites it).
+- [ ] **Step 2:** `node tests/uat.js` (expect pass), `node tests/tech-debt.js`. If the function-count or LOC gate trips, fix (split a >80-line function) or raise the cap per the v7.16.0 precedent in the same commit. Confirm no new dead functions (every new function has a caller/UAT).
+- [ ] **Step 3:** Commit: `git commit -am "chore(release): v7.52.0"`.
+
+### Task 13: Ship
+
+- [ ] **Step 1:** Walk `SHIP_CHECKLIST.md` via the in-repo `/ship` skill. This is gated-lane (auth-state.js touched) → push the branch, open the PR (the cert-app, NOT landing), let CI (UAT + Playwright) run on the Supabase/Vercel preview.
+- [ ] **Step 2:** Smoke the Vercel preview in a real browser: full flow (finish diagnostic → conversion states → account Pass Plan → weak-topic drill → builder → retake/switch). Confirm no `/pricing` link in the iOS conversion/Pro surfaces.
+- [ ] **Step 3:** On green + founder "merge", squash-merge → prod deploy → post-deploy prod verification (CLAUDE.md rule).
+
+---
+
+## Self-review (spec coverage)
+
+- Conversion moment, 3 states, free-primary, App-Store-safe Pro waitlist → Tasks 1-3. ✓
+- Account Pass Plan home, Free (one plan + upsell) vs Pro (plan per cert) → Tasks 4-7. ✓
+- Plan → weak topic → pre-loaded builder → Task 8. ✓
+- Quota-aware builder (15/day, separate 5 reviews, soft cap reuse) → Task 9. ✓
+- Re-diagnostic: Retake (7-day soft confirm) + Diagnose another cert (cert switcher) → wired in Task 7. ✓
+- One responsive build; brand; no emoji/em-dash → conventions + Task 10. ✓
+- review-feature + ship + lane → Tasks 11-13. ✓

--- a/docs/superpowers/specs/2026-06-14-in-app-diagnostic-conversion-design.md
+++ b/docs/superpowers/specs/2026-06-14-in-app-diagnostic-conversion-design.md
@@ -87,12 +87,14 @@ When a free user opens the builder from a plan:
 - The landing-web diagnostic funnel (separate, already shipped).
 - Any change to the free 15/day or 5-review limits themselves.
 
-## 8. Open questions to resolve during planning
+## 8. Resolved decisions (2026-06-14, with Simi)
 
-1. **Account surface:** confirm the exact host page (the cert-app `#page-settings`/account area vs a new view) and how navigation reaches it on each platform.
-2. **Pro multi-plan data:** the per-cert plan list needs cross-cert data. Confirm the cloud profile (`profiles.metadata`) stores a diagnostic per cert and how the list is read across subdomains (cross-cert analytics already aggregates readiness — reuse that path).
-3. **Retake cooldown for Pro:** keep the 7-day cooldown for all tiers, or exempt Pro? (Default: keep 7 days for everyone.)
-4. **Lane check:** the UI is fast-lane (app.js/index.html/styles). Verify whether the Pro cross-cert list or the signup trigger touches gated files (auth-state.js, cloud-store.js, RLS/migrations). Any gated touchpoint goes through the gated lane (feature branch → PR + Supabase/preview).
+1. **Account surface:** the Pass Plan home lives on the cert-app **account / settings page** (reuse the existing `#page-settings`/account area, not a new tab).
+2. **Pro multi-plan data:** **yes, aggregate every cert's plan into one account view**, read from the cloud profile (`profiles.metadata`), reusing the cross-cert analytics aggregation path (already shipped, v7.43.0).
+3. **Retake cooldown:** **keep the 7-day cooldown for all tiers** (Pro included). The wait protects score validity, it is not a paywall.
+4. **Lane check:** engineering to verify during the plan (Simi delegated). UI work is fast-lane (app.js/index.html/styles); any touch of gated files (auth-state.js, cloud-store.js, RLS/migrations) for the cross-cert read or the signup trigger routes through the gated lane.
+
+**Reuse note (verified against shipped versions):** the tier infrastructure already exists — free **15 questions + 5 reviews/day** (v7.40.0), **custom quiz already capped at 15 for free** (v7.46.0), **one-cert lock until Pro** (v7.33.0), **cross-cert analytics as a Pro feature** (v7.43.0), account/settings surfaces lifted (v7.37–7.39). This feature is mostly **new UI surfaces wired onto existing tier logic**, not new entitlement plumbing.
 
 ## 9. Build process
 

--- a/docs/superpowers/specs/2026-06-14-in-app-diagnostic-conversion-design.md
+++ b/docs/superpowers/specs/2026-06-14-in-app-diagnostic-conversion-design.md
@@ -1,0 +1,99 @@
+# In-app diagnostic: conversion ending, account-page home, and plan-to-practice
+
+**Date:** 2026-06-14
+**Status:** Design approved (Simi), pending spec review
+**Mockup:** `mockups/diagnostic-conversion/index.html`
+**Platforms:** desktop, Safari, iOS (one responsive PWA build)
+
+---
+
+## 1. Goal
+
+Give the **in-app** Baseline Diagnostic a complete ending and afterlife:
+
+1. After the Pass Plan, a soft moment that moves a new user toward a **free account** (primary) or **Pro** (waitlist).
+2. A **permanent home** for the saved plan on the account page, differing by tier.
+3. A path from a saved plan **into practice** on the exact weak topics.
+4. A working way to **re-run** the diagnostic (same cert, or another cert on Pro).
+
+All of it honours the **free daily limit** so nothing dead-ends.
+
+## 2. Scope: which diagnostic this is
+
+There are two diagnostics in the codebase. This spec is **only** about the **in-app** one (the cert-app PWA: `startDiagnostic()` → `completeDiagnostic()` → `#page-diagnostic-result`). The separate **landing** funnel (`certanvil.com/diagnostic/*`) already has its own conversion and is out of scope here.
+
+## 3. Hard constraints
+
+- **App Store safety:** an iOS app may not link out to web checkout for a digital subscription. The Pro path is a **waitlist teaser with no purchase link** until StoreKit in-app purchase ships (Phase G). The existing in-app "Upgrade" buttons that link to `certanvil.com/pricing` must NOT be reused inside this flow.
+- **Free tier:** **15 new questions/day** plus a **separate 5 daily reviews** (spaced repetition). The 15 is the pool the Custom Quiz builder caps against; the 5 reviews are untouched.
+- **Cert access:** Free = **one cert** (cert-lock). Pro = **all certs**. Certs are separate subdomains ("Pattern A"); cross-cert state aggregates through the cloud profile.
+- **Brand:** forged-bronze (the `dg-system` tokens, never the legacy purple `--accent`), Fraunces + Inter, dual-theme with light as the founder-primary, full tinted hairlines (no left-accent-border callouts), symmetric radius. **Zero emoji, zero em-dashes.**
+- **No new quiz engine.** Reuse the existing Custom Quiz builder and drill paths.
+
+## 4. Surfaces
+
+### 4.1 Conversion moment (bottom of `#page-diagnostic-result`)
+Inline (not a bottom sheet — decided). The full Pass Plan stays as-is; this replaces the lone "Start today's session" button. State-adaptive:
+
+| State | What shows |
+|---|---|
+| **Anonymous** | Bronze-tinted save panel: headline *"Don't lose your Pass Plan"* (loss-aversion), inline email + **Save it free**, micro: *"Just your email. No password · no card · 15 questions a day"*, plus a line that it lands on the account page. Below: a **Pro at launch** waitlist teaser ($9.99/mo, no purchase link). Below: a quiet *"Start today's session without saving"* escape. |
+| **Signed-in Free** | Green *"Saved to your account"* + *"View it on your account page"* link + **Start today's session** + one soft Pro line. No signup nag. |
+| **Pro** | *"Pro · synced and unlimited"* + **Start today's session**. Nothing sold. |
+
+Free is primary; the escape keeps it soft.
+
+### 4.2 Account-page home for the Pass Plan
+A new "Your Pass Plan(s)" surface on the cert-app account/settings page. Responsive (the same surface reflows to desktop).
+
+- **Free:** one plan card (cert, pass probability ring, taken date, score, weakest domains, **View full plan** + **Retake**). Below it, an upsell panel *"A plan for every cert"* showing the other certs as locked chips with **Get Pro at launch · $9.99/mo**. The one-cert limit becomes the pitch at the moment they would want more.
+- **Pro:** a **list** of plans, one per cert run (cert, readiness-coloured ring, taken date, weakest), each opening its full plan, plus **Diagnose another cert**.
+
+### 4.3 Plan → practice
+Opening a saved plan shows the full Pass Plan. The **weakest topics are tappable**. Tapping one (or **Drill all weak topics**) opens the **existing Custom Quiz builder** (`#custom-quiz-section`) **pre-loaded** with those topics. The user confirms difficulty and count, then builds the quiz on exactly those topics.
+
+### 4.4 Quota-aware builder (free)
+When a free user opens the builder from a plan:
+- Show remaining: *"Free plan · N of 15 questions left today."*
+- **Cap the count** options at N remaining; higher counts become **"Unlimited · Pro"** (locked nudge). The build button reflects the cap.
+- At **0 remaining**, show the gentle back-tomorrow wall + Pro nudge instead of launching a quiz that hits the wall mid-run.
+- The 5 daily reviews are a separate pool and are not affected.
+
+### 4.5 Re-diagnostic mechanism
+- **Retake (same cert):** the **Retake** action on a plan re-runs `retakeDiagnostic()`, gated by the existing 7-day cooldown (`DIAGNOSTIC_RETAKE_COOLDOWN_DAYS`). Within the cooldown the control reads "Retake in Nd."
+- **Diagnose another cert (Pro):** opens a cert picker → navigates via the existing cross-subdomain cert switcher to that cert's app → starts its diagnostic.
+- **Free wanting another cert:** routed to the Pro upsell (no other-cert diagnostic until Pro).
+
+## 5. Existing machinery to reuse (no reinvention)
+
+- Result page + flow: `#page-diagnostic-result`, `startDiagnostic()` / `completeDiagnostic()` (app.js).
+- Storage: `STORAGE.DIAGNOSTIC` = `nplus_diagnostic`, `saveDiagnostic()` + `_cloudFlush`, `loadDiagnostic()`.
+- Custom Quiz builder: `#custom-quiz-section` (Topic, Difficulty, Count) + `drillTopic` / `drillDomain`.
+- Retake: `retakeDiagnostic()` + 7-day cooldown constants.
+- Cert switching: the Pattern-A cross-subdomain switcher (auth-state.js).
+- Quota: `_quotaState` (`used_today`, `daily_limit`, `tier`) for the cap and the wall.
+- Free signup: the existing Supabase magic-link auth (auth-state.js / `window.certanvilSupabase`).
+
+## 6. Decisions made
+
+- **Inline** conversion moment (not bottom-sheet).
+- Weak-topic clicks route to the **pre-loaded Custom Quiz builder** (not a blind direct-launch), single topic or full set.
+- Free path uses **magic-link email** (Apple Sign In is Phase G).
+- Pro is a **waitlist teaser** everywhere (App Store safe) until StoreKit.
+
+## 7. Out of scope / Phase G dependencies
+
+- Real StoreKit in-app purchase and Apple Sign In (Phase G).
+- The landing-web diagnostic funnel (separate, already shipped).
+- Any change to the free 15/day or 5-review limits themselves.
+
+## 8. Open questions to resolve during planning
+
+1. **Account surface:** confirm the exact host page (the cert-app `#page-settings`/account area vs a new view) and how navigation reaches it on each platform.
+2. **Pro multi-plan data:** the per-cert plan list needs cross-cert data. Confirm the cloud profile (`profiles.metadata`) stores a diagnostic per cert and how the list is read across subdomains (cross-cert analytics already aggregates readiness — reuse that path).
+3. **Retake cooldown for Pro:** keep the 7-day cooldown for all tiers, or exempt Pro? (Default: keep 7 days for everyone.)
+4. **Lane check:** the UI is fast-lane (app.js/index.html/styles). Verify whether the Pro cross-cert list or the signup trigger touches gated files (auth-state.js, cloud-store.js, RLS/migrations). Any gated touchpoint goes through the gated lane (feature branch → PR + Supabase/preview).
+
+## 9. Build process
+
+Mockup is done and founder-approved. On build: follow mockup-first (done) → the four audit passes (`design-taste-frontend`, `emil-design-eng`, `humanizer`, `marketing-psychology`) on the real build → **`review-feature` (4-agent) review**, since this touches accounts and the Pro path → Ship checklist → post-deploy browser verification.

--- a/index.html
+++ b/index.html
@@ -767,7 +767,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.51.1</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.52.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/index.html
+++ b/index.html
@@ -601,6 +601,7 @@
             <span class="cq-section-ico" aria-hidden="true">&#127919;</span>
             <h3 class="cq-section-title">Questions</h3>
           </div>
+          <div id="cq-quota-line" class="cq-quota-line" hidden></div>
           <div class="chip-group cq-count-group" id="count-group">
             <button class="chip chip-count" data-v="5" type="button">
               <span class="chip-count-num">5</span>

--- a/index.html
+++ b/index.html
@@ -1519,6 +1519,18 @@
        the wrapping structure changes. Section ordering reflects the trust
        hierarchy (read-only health → study cadence → AI → data → destruct). -->
   <div class="settings-layout">
+    <!-- ═══════ § 00 PASS PLAN ═══════ -->
+    <!-- v7.52.0: Pass Plan home (Free=one plan + upsell, Pro=plan per cert), rendered by renderPassPlanSection() -->
+    <div class="settings-group" id="settings-passplan-group" data-group="passplan">
+      <div class="settings-group-head">
+        <span class="settings-group-num">&sect; 00</span>
+        <div class="settings-group-titles">
+          <h2 class="settings-group-h">Your <em>Pass Plan</em></h2>
+          <p class="settings-group-sub">Your baseline diagnostic and where it points you next.</p>
+        </div>
+      </div>
+      <section class="card settings-section" id="passplan-section"></section>
+    </div>
     <!-- ═══════ § 01 STUDY SETUP ═══════ -->
     <div class="settings-group" data-group="study-setup">
       <div class="settings-group-head">

--- a/index.html
+++ b/index.html
@@ -918,6 +918,9 @@
   <div class="pass-plan-final-cta passplan-cta-bar">
     <button class="btn btn-primary btn-full" onclick="closePassPlanReview()">Start today's session →</button>
   </div>
+
+  <!-- v7.52.0: state-aware conversion block, rendered by _renderDiagnosticConversion() -->
+  <div id="dq-conversion" class="dq-conversion" hidden></div>
 </div>
 
 <div id="page-loading" class="page">

--- a/mockups/diagnostic-conversion/index.html
+++ b/mockups/diagnostic-conversion/index.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Diagnostic → Free/Pro conversion · mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:oklch(0.975 0.007 85);
+    --surface:oklch(0.945 0.008 85);
+    --surface3:oklch(0.915 0.008 85);
+    --border:oklch(0.85 0.011 85);
+    --accent:oklch(0.50 0.155 55);
+    --accent-light:oklch(0.58 0.150 55);
+    --accent-dim:color-mix(in oklab, oklch(0.50 0.155 55) 10%, transparent);
+    --accent-tint:color-mix(in oklab, oklch(0.50 0.155 55) 5%, var(--bg));
+    --text:oklch(0.26 0.015 280);
+    --text-mid:oklch(0.42 0.014 280);
+    --text-dim:oklch(0.50 0.013 280);
+    --green:oklch(0.50 0.15 150);
+    --radius:14px; --radius-sm:10px;
+    --ease:cubic-bezier(0.23,1,0.32,1);
+    --lnum:"lnum" 1,"tnum" 1;
+  }
+  *{box-sizing:border-box}
+  body{margin:0; background:var(--bg); color:var(--text); font-family:Inter,-apple-system,system-ui,sans-serif; -webkit-font-smoothing:antialiased; padding:40px 20px 80px}
+  .wrap{max-width:1180px; margin:0 auto}
+  .page-head h1{font-family:Fraunces,serif; font-weight:600; font-size:26px; letter-spacing:-0.01em; margin:0 0 6px}
+  .page-head p{color:var(--text-mid); font-size:14px; line-height:1.6; margin:0; max-width:74ch}
+  .skill-legend{display:flex; gap:8px; flex-wrap:wrap; margin:14px 0 26px}
+  .skill-legend span{font-size:11px; font-weight:600; letter-spacing:0.06em; text-transform:uppercase; color:var(--accent); border:1px solid var(--border); border-radius:999px; padding:5px 11px; background:var(--accent-tint)}
+  .section-h{font-family:Fraunces,serif; font-weight:600; font-size:19px; margin:38px 0 4px; letter-spacing:-0.01em}
+  .section-h.first{margin-top:8px}
+  .section-note{color:var(--text-mid); font-size:13px; margin:0 0 22px; max-width:74ch; line-height:1.55}
+
+  .frames{display:flex; gap:28px; flex-wrap:wrap; align-items:flex-start}
+  .frame-col{flex:0 0 360px; max-width:360px}
+  .frame-col.wide{flex-basis:560px; max-width:560px}
+  .frame-caption{margin:0 0 12px}
+  .frame-caption .state{font-weight:700; font-size:14px; display:flex; align-items:center; gap:8px}
+  .frame-caption .state .dot{width:7px;height:7px;border-radius:50%;background:var(--accent)}
+  .frame-caption .state .dot.pro{background:var(--green)}
+  .frame-caption .why{color:var(--text-mid); font-size:12.5px; line-height:1.55; margin-top:5px}
+
+  .phone{background:var(--bg); border:1px solid var(--border); border-radius:30px; padding:14px; box-shadow:0 24px 60px color-mix(in oklab, var(--text) 9%, transparent); position:relative; overflow:hidden}
+  .desktop{background:var(--bg); border:1px solid var(--border); border-radius:16px; box-shadow:0 24px 60px color-mix(in oklab, var(--text) 9%, transparent); overflow:hidden}
+  .desktop-bar{height:34px; background:var(--surface); border-bottom:1px solid var(--border); display:flex; align-items:center; gap:6px; padding:0 12px}
+  .desktop-bar i{width:9px;height:9px;border-radius:50%;background:var(--surface3)}
+  .desktop-body{padding:22px}
+  .phone-inner{border-radius:18px; overflow:hidden; background:var(--bg)}
+  .topbar{display:flex; align-items:center; gap:8px; padding:6px 4px 16px}
+  .topbar.between{justify-content:space-between}
+  .logo-row{display:flex;align-items:center;gap:8px}
+  .logo-mark{width:24px;height:24px;border-radius:7px;background:var(--surface3);display:flex;align-items:center;justify-content:center}
+  .logo-mark svg{width:16px;height:16px}
+  .logo-name{font-family:Fraunces,serif; font-weight:600; font-size:15px; letter-spacing:-0.01em}
+  .acct-pill{display:flex;align-items:center;gap:7px;border:1px solid var(--border);border-radius:999px;padding:4px 10px 4px 5px;font-size:12px;font-weight:600;color:var(--text-mid)}
+  .acct-av{width:20px;height:20px;border-radius:50%;background:var(--accent);color:var(--bg);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700}
+  .acct-pill.is-pro .acct-av{background:var(--green)}
+  .pro-badge{font-size:10px;font-weight:700;letter-spacing:0.06em;color:var(--green);border:1px solid color-mix(in oklab,var(--green) 35%,var(--border));border-radius:999px;padding:2px 7px}
+
+  .plan-context{padding:0 4px; -webkit-mask-image:linear-gradient(transparent,#000 40%); mask-image:linear-gradient(transparent,#000 40%)}
+  .pc-h{font-family:Fraunces,serif; font-weight:600; font-size:13px; color:var(--text-dim); display:flex; justify-content:space-between; margin:0 0 10px}
+  .pc-row{display:flex; justify-content:space-between; align-items:center; padding:9px 0; border-top:1px solid var(--border); font-size:12.5px; color:var(--text-mid)}
+  .pc-bar{height:5px; width:120px; border-radius:5px; background:var(--surface3); overflow:hidden}
+  .pc-bar i{display:block; height:100%; background:var(--accent); border-radius:5px}
+
+  .conv{padding:20px 4px 6px}
+  .save-panel{border:1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); background:var(--accent-tint); border-radius:var(--radius); padding:18px 16px 16px}
+  .save-eyebrow{font-size:11px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; color:var(--accent); margin:0 0 7px}
+  .save-h{font-family:Fraunces,serif; font-weight:600; font-size:21px; line-height:1.15; letter-spacing:-0.01em; margin:0 0 7px}
+  .save-sub{font-size:13px; line-height:1.5; color:var(--text-mid); margin:0 0 15px}
+  .email-row{display:flex; gap:8px; margin-bottom:10px}
+  .email-input{flex:1; min-width:0; height:46px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg); padding:0 13px; font:500 14px Inter,sans-serif; color:var(--text)}
+  .email-input::placeholder{color:var(--text-dim)}
+  .btn{border:0; border-radius:var(--radius-sm); cursor:pointer; font:700 14px Inter,sans-serif; height:46px; padding:0 18px; display:inline-flex; align-items:center; justify-content:center; gap:7px; transition:filter .15s var(--ease), transform .12s var(--ease); white-space:nowrap}
+  .btn:active{transform:scale(0.97)}
+  .btn-primary{background:var(--accent); color:var(--bg)}
+  .btn-primary:hover{filter:brightness(1.07)}
+  .btn-full{width:100%}
+  .btn-sm{height:38px;font-size:13px;padding:0 14px}
+  .save-micro{font-size:12px; color:var(--text-dim); display:flex; align-items:center; gap:6px; flex-wrap:wrap; margin:0}
+  .save-micro b{color:var(--text-mid); font-weight:600}
+  .save-micro .sep{width:3px;height:3px;border-radius:50%;background:var(--text-dim);display:inline-block}
+  .save-home{font-size:12px;color:var(--text-dim);margin:9px 0 0;display:flex;align-items:center;gap:6px}
+  .save-home svg{width:13px;height:13px;flex:none}
+
+  .pro{margin-top:12px; border:1px solid var(--border); border-radius:var(--radius); background:var(--surface); padding:15px 16px}
+  .pro-top{display:flex; justify-content:space-between; align-items:baseline; gap:10px}
+  .pro-h{font-weight:700; font-size:14px}
+  .pro-tag{font-size:10.5px; font-weight:700; letter-spacing:0.07em; text-transform:uppercase; color:var(--accent); border:1px solid color-mix(in oklab,var(--accent) 30%,var(--border)); border-radius:999px; padding:3px 8px}
+  .pro-sub{font-size:12.5px; color:var(--text-mid); margin:5px 0 13px; line-height:1.5}
+  .pro-price{font-feature-settings:var(--lnum); color:var(--text); font-weight:700}
+  .btn-ghost{background:transparent; color:var(--accent); border:1px solid color-mix(in oklab,var(--accent) 42%,var(--border)); width:100%}
+  .btn-ghost:hover{background:var(--accent-dim)}
+  .escape{display:block; text-align:center; margin:16px auto 4px; font-size:13px; font-weight:500; color:var(--text-dim); text-decoration:none; padding:10px}
+  .escape:hover{color:var(--text-mid)}
+  .affirm{display:flex; align-items:center; gap:8px; font-size:13px; color:var(--green); font-weight:600; margin:0 0 6px; justify-content:center}
+  .affirm svg{width:16px;height:16px}
+  .affirm-link{display:block;text-align:center;font-size:12.5px;color:var(--accent);font-weight:600;text-decoration:none;margin:0 0 14px}
+  .pro-soft{margin-top:14px; text-align:center; font-size:12.5px; color:var(--text-mid)}
+  .pro-soft a{color:var(--accent); font-weight:600; text-decoration:none}
+
+  .sheet-stage{position:relative; height:560px; border-radius:18px; overflow:hidden; background:var(--bg)}
+  .sheet-dim{position:absolute; inset:0; background:color-mix(in oklab,var(--text) 30%,transparent)}
+  .sheet{position:absolute; left:0; right:0; bottom:0; background:var(--bg); border-top-left-radius:20px; border-top-right-radius:20px; padding:10px 16px 18px; box-shadow:0 -14px 40px color-mix(in oklab,var(--text) 14%,transparent)}
+  .sheet-grip{width:38px;height:4px;border-radius:4px;background:var(--border);margin:0 auto 14px}
+  .dimmed-plan{padding:18px 16px 0; filter:saturate(0.7)}
+  .dimmed-plan .pc-h{font-size:15px;color:var(--text)}
+  svg.ca-mark path{stroke-width:7;stroke-linecap:round}
+
+  .acct-title{font-family:Fraunces,serif;font-weight:600;font-size:20px;margin:4px 4px 6px;display:flex;align-items:center;gap:9px}
+  .acct-row{display:flex;justify-content:space-between;align-items:center;padding:13px 4px;border-top:1px solid var(--border);font-size:13px}
+  .acct-row .k{color:var(--text-mid)} .acct-row .v{font-weight:600}
+  .sub-label{font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-dim);margin:14px 4px 10px}
+  .plan-card{border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);padding:16px;margin:0 0 14px}
+  .plan-card .pcard-eyebrow{font-size:10.5px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-dim);display:flex;justify-content:space-between;margin-bottom:12px}
+  .pcard-main{display:flex;gap:15px;align-items:center}
+  .prob-ring{width:62px;height:62px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;background:conic-gradient(var(--accent) 0 72%, var(--surface3) 72% 100%)}
+  .prob-ring .inner{width:48px;height:48px;border-radius:50%;background:var(--surface);display:flex;flex-direction:column;align-items:center;justify-content:center}
+  .prob-ring .pct{font-family:Fraunces,serif;font-weight:600;font-size:17px;font-feature-settings:var(--lnum);line-height:1}
+  .prob-ring .lbl{font-size:8px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.05em}
+  .pcard-detail .meta{font-size:12.5px;color:var(--text-mid);margin:0 0 7px;font-feature-settings:var(--lnum)}
+  .pcard-detail .weak{font-size:12.5px;color:var(--text)}
+  .pcard-detail .weak b{color:var(--accent)}
+  .pcard-cta{display:flex;gap:8px;margin-top:14px}
+
+  /* free upsell · locked other certs */
+  .locked-certs{border:1px solid var(--border);border-radius:var(--radius);background:var(--accent-tint);padding:15px 16px}
+  .locked-h{font-weight:700;font-size:14px;margin:0 0 4px}
+  .locked-sub{font-size:12.5px;color:var(--text-mid);margin:0 0 12px;line-height:1.5}
+  .cert-chips{display:flex;flex-wrap:wrap;gap:7px;margin-bottom:14px}
+  .cert-chip{display:flex;align-items:center;gap:5px;font-size:11.5px;font-weight:600;color:var(--text-dim);border:1px solid var(--border);border-radius:999px;padding:5px 11px;background:var(--bg)}
+  .cert-chip svg{width:11px;height:11px;opacity:0.7}
+
+  /* pro · multi-plan list */
+  .plan-list{display:flex;flex-direction:column;gap:8px;margin:0 0 12px}
+  .plan-item{display:flex;align-items:center;gap:12px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface);padding:11px 13px}
+  .pi-ring{width:36px;height:36px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;font-size:11.5px;font-weight:700;font-feature-settings:var(--lnum);color:var(--bg)}
+  .pi-body{flex:1;min-width:0}
+  .pi-cert{font-weight:700;font-size:13px}
+  .pi-meta{font-size:11.5px;color:var(--text-mid);font-feature-settings:var(--lnum)}
+  .pi-go{color:var(--text-dim);font-size:17px;font-weight:600}
+  .add-cert{display:flex;align-items:center;justify-content:center;gap:7px;border:1px dashed color-mix(in oklab,var(--accent) 45%,var(--border));border-radius:var(--radius-sm);background:transparent;color:var(--accent);font:700 13px Inter,sans-serif;height:46px;width:100%;cursor:pointer}
+
+  /* plan detail · clickable weak topics */
+  .detail-h{font-family:Fraunces,serif;font-weight:600;font-size:18px;margin:2px 4px 2px;display:flex;justify-content:space-between;align-items:baseline}
+  .detail-sub{font-size:12px;color:var(--text-dim);margin:0 4px 16px;font-feature-settings:var(--lnum)}
+  .weak-list{display:flex;flex-direction:column;gap:8px;margin:0 0 14px}
+  .weak-item{display:flex;align-items:center;gap:11px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface);padding:11px 13px;cursor:pointer;transition:border-color .15s var(--ease)}
+  .weak-item:hover{border-color:color-mix(in oklab,var(--accent) 50%,var(--border))}
+  .weak-item .wbar{flex:none;width:44px;height:5px;border-radius:5px;background:var(--surface3);overflow:hidden}
+  .weak-item .wbar i{display:block;height:100%;background:var(--accent)}
+  .weak-item .wname{flex:1;font-weight:600;font-size:13px}
+  .weak-item .wpct{font-size:12px;color:var(--text-mid);font-feature-settings:var(--lnum)}
+  .weak-item .wdrill{font-size:11.5px;font-weight:700;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 40%,var(--border));border-radius:999px;padding:4px 11px}
+
+  /* custom quiz builder */
+  .picker{border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);padding:16px}
+  .picker-h{font-weight:700;font-size:14px;margin:0 0 3px}
+  .picker-note{font-size:12px;color:var(--text-mid);margin:0 0 15px;line-height:1.5}
+  .pick-label{font-size:10.5px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-dim);margin:0 0 8px}
+  .chip-wrap{display:flex;flex-wrap:wrap;gap:7px;margin-bottom:16px}
+  .tchip{font-size:12px;font-weight:600;border-radius:999px;padding:6px 12px;border:1px solid var(--border);color:var(--text-mid);background:var(--bg);cursor:pointer}
+  .tchip.sel{background:var(--accent);color:var(--bg);border-color:var(--accent)}
+  .seg{display:flex;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden;margin-bottom:16px}
+  .seg button{flex:1;border:0;background:var(--bg);color:var(--text-mid);font:600 12.5px Inter,sans-serif;height:38px;cursor:pointer;border-right:1px solid var(--border)}
+  .seg button:last-child{border-right:0}
+  .seg button.on{background:var(--accent);color:var(--bg)}
+  .seg button.locked{color:var(--accent);background:var(--accent-tint);font-weight:700}
+  .quota-note{display:flex;justify-content:space-between;align-items:center;gap:10px;font-size:11.5px;color:var(--text-mid);background:var(--accent-tint);border:1px solid color-mix(in oklab,var(--accent) 22%,var(--border));border-radius:var(--radius-sm);padding:9px 12px;margin:0 0 16px}
+  .quota-note b{color:var(--text);font-weight:700;font-feature-settings:var(--lnum)}
+  .cap-hint{font-weight:600;letter-spacing:0;text-transform:none;color:var(--text-dim);font-size:10px;margin-left:7px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<div class="page-head">
+  <h1>Diagnostic → free / Pro conversion + a permanent home</h1>
+  <p>The full Pass Plan stays as it is. This adds a soft conversion moment at the bottom of the result page, and gives the saved plan a permanent home on the account page that differs by tier: Free keeps one plan (one cert) with a Pro upsell for the rest; Pro keeps a plan for every cert. Light theme (your primary). Free is 15 questions a day plus 5 reviews. Pro is a waitlist teaser with no purchase link, so the app stays App Store safe until StoreKit ships in Phase G. One responsive build covers desktop, Safari, and iOS.</p>
+</div>
+<div class="skill-legend">
+  <span>design-taste</span><span>emil-design-eng</span><span>humanizer</span><span>marketing-psychology</span>
+</div>
+
+<h2 class="section-h first">1 · The conversion moment</h2>
+<p class="section-note">At the bottom of the Pass Plan, where today there is only a single "Start today's session" button.</p>
+
+<div class="frames">
+
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot"></span>Anonymous user · the full moment</div>
+      <div class="why">Loss-aversion leads (they just built this plan: IKEA / endowment). One primary action, inline email kills activation energy, "no card" kills regret. Pro $9.99 anchors so free reads generous.</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="topbar"><span class="logo-mark"><svg viewBox="0 0 100 100" fill="none" class="ca-mark"><path d="M58 12 C42 6,16 16,14 34 C12 52,22 62,42 64" stroke="var(--accent)"/><line x1="30" y1="84" x2="70" y2="16" stroke="var(--text-dim)" stroke-width="5" stroke-linecap="round"/><path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="var(--accent)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="logo-name">CertAnvil</span></div>
+      <div class="plan-context">
+        <div class="pc-h"><span>YOUR PASS PLAN</span><span>72% pass probability</span></div>
+        <div class="pc-row"><span>Subnetting</span><span class="pc-bar"><i style="width:40%"></i></span></div>
+        <div class="pc-row"><span>Network security</span><span class="pc-bar"><i style="width:55%"></i></span></div>
+        <div class="pc-row"><span>14 cards seeded to review</span><span>first session: tomorrow</span></div>
+      </div>
+      <div class="conv">
+        <div class="save-panel">
+          <p class="save-eyebrow">Before you start</p>
+          <h2 class="save-h">Don't lose your Pass Plan</h2>
+          <p class="save-sub">Right now it lives only on this device. Save it free and pick up where you left off on any device.</p>
+          <div class="email-row"><input class="email-input" type="email" placeholder="you@email.com" aria-label="Email"><button class="btn btn-primary">Save it free</button></div>
+          <p class="save-micro"><b>Just your email.</b> No password <span class="sep"></span> no card <span class="sep"></span> 15 questions a day</p>
+          <p class="save-home"><svg viewBox="0 0 24 24" fill="none"><path d="M5 12h14M12 5v14" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"/></svg>It lands on your account page, ready whenever you come back.</p>
+        </div>
+        <div class="pro">
+          <div class="pro-top"><span class="pro-h">Going all in?</span><span class="pro-tag">At launch</span></div>
+          <p class="pro-sub">CertAnvil Pro: unlimited questions, every cert, the topology builder and labs. <span class="pro-price">$9.99/mo</span> when it ships.</p>
+          <button class="btn btn-ghost">Get Pro at launch</button>
+        </div>
+        <a href="#" class="escape">Start today's session without saving</a>
+      </div>
+    </div></div>
+  </div>
+
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot"></span>Signed-in free user</div>
+      <div class="why">Already saved, so no signup pitch. It auto-saves to their account; we point them to where it lives. Pro sits as one quiet line.</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="topbar"><span class="logo-mark"><svg viewBox="0 0 100 100" fill="none" class="ca-mark"><path d="M58 12 C42 6,16 16,14 34 C12 52,22 62,42 64" stroke="var(--accent)"/><line x1="30" y1="84" x2="70" y2="16" stroke="var(--text-dim)" stroke-width="5" stroke-linecap="round"/><path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="var(--accent)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="logo-name">CertAnvil</span></div>
+      <div class="plan-context">
+        <div class="pc-h"><span>YOUR PASS PLAN</span><span>72% pass probability</span></div>
+        <div class="pc-row"><span>Subnetting</span><span class="pc-bar"><i style="width:40%"></i></span></div>
+        <div class="pc-row"><span>Network security</span><span class="pc-bar"><i style="width:55%"></i></span></div>
+        <div class="pc-row"><span>14 cards seeded to review</span><span>first session: tomorrow</span></div>
+      </div>
+      <div class="conv">
+        <p class="affirm"><svg viewBox="0 0 24 24" fill="none"><path d="M20 6 9 17l-5-5" stroke="var(--green)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>Saved to your account</p>
+        <a href="#" class="affirm-link">View it on your account page</a>
+        <button class="btn btn-primary btn-full">Start today's session</button>
+        <p class="pro-soft">Want unlimited questions and every cert? <a href="#">Get Pro at launch · $9.99/mo</a></p>
+      </div>
+    </div></div>
+  </div>
+
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot"></span>Pro user</div>
+      <div class="why">Nothing to sell. Just the next step, plus a small acknowledgement (peak-end: it ends clean and respectful).</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="topbar"><span class="logo-mark"><svg viewBox="0 0 100 100" fill="none" class="ca-mark"><path d="M58 12 C42 6,16 16,14 34 C12 52,22 62,42 64" stroke="var(--accent)"/><line x1="30" y1="84" x2="70" y2="16" stroke="var(--text-dim)" stroke-width="5" stroke-linecap="round"/><path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="var(--accent)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="logo-name">CertAnvil</span></div>
+      <div class="plan-context">
+        <div class="pc-h"><span>YOUR PASS PLAN</span><span>72% pass probability</span></div>
+        <div class="pc-row"><span>Subnetting</span><span class="pc-bar"><i style="width:40%"></i></span></div>
+        <div class="pc-row"><span>Network security</span><span class="pc-bar"><i style="width:55%"></i></span></div>
+        <div class="pc-row"><span>14 cards seeded to review</span><span>first session: tomorrow</span></div>
+      </div>
+      <div class="conv">
+        <p class="affirm"><svg viewBox="0 0 24 24" fill="none"><path d="M20 6 9 17l-5-5" stroke="var(--green)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>Pro · synced and unlimited</p>
+        <button class="btn btn-primary btn-full">Start today's session</button>
+      </div>
+    </div></div>
+  </div>
+
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot"></span>Alternative: bottom sheet</div>
+      <div class="why">Same content, but it rises on tapping "Start today's session" instead of sitting inline. Catches them at the exit, keeps the page shorter. Converts a touch harder, feels a touch more like a gate.</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="sheet-stage">
+        <div class="dimmed-plan">
+          <div class="pc-h"><span>Your Pass Plan</span><span>72%</span></div>
+          <div class="pc-row"><span>Subnetting</span><span class="pc-bar"><i style="width:40%"></i></span></div>
+          <div class="pc-row"><span>Network security</span><span class="pc-bar"><i style="width:55%"></i></span></div>
+          <div class="pc-row"><span>Routing</span><span class="pc-bar"><i style="width:70%"></i></span></div>
+        </div>
+        <div class="sheet-dim"></div>
+        <div class="sheet">
+          <div class="sheet-grip"></div>
+          <div class="save-panel" style="background:transparent;border:0;padding:4px 0 0">
+            <p class="save-eyebrow">Before you start</p>
+            <h2 class="save-h">Don't lose your Pass Plan</h2>
+            <p class="save-sub">It lives only on this device. Save it free and study from anywhere.</p>
+            <div class="email-row"><input class="email-input" type="email" placeholder="you@email.com" aria-label="Email"><button class="btn btn-primary">Save it free</button></div>
+            <p class="save-micro"><b>Just your email.</b> No password <span class="sep"></span> no card <span class="sep"></span> 15 a day</p>
+          </div>
+          <a href="#" class="escape">Continue without saving</a>
+        </div>
+      </div>
+    </div></div>
+  </div>
+
+</div>
+
+<h2 class="section-h">2 · The account page · Free vs Pro</h2>
+<p class="section-note">The saved plan lives here permanently. Free has one plan (one cert) and the locked certs become the Pro pitch. Pro keeps a plan for every cert. The data already cloud-syncs, so this is a view on top of it. One responsive build (the desktop frame shows the same surface reflowed).</p>
+
+<div class="frames">
+
+  <!-- FREE account (phone) -->
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot"></span>Free account · one plan + upsell</div>
+      <div class="why">Their one plan, with retake (after the 7-day cooldown). The other certs sit right below as a locked Pro pitch, so the limit becomes the upsell at the exact moment they would want more (contrast + aspiration, not a wall).</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="topbar between">
+        <div class="logo-row"><span class="logo-mark"><svg viewBox="0 0 100 100" fill="none" class="ca-mark"><path d="M58 12 C42 6,16 16,14 34 C12 52,22 62,42 64" stroke="var(--accent)"/><line x1="30" y1="84" x2="70" y2="16" stroke="var(--text-dim)" stroke-width="5" stroke-linecap="round"/><path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="var(--accent)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="logo-name">CertAnvil</span></div>
+        <span class="acct-pill"><span class="acct-av">S</span>Free</span>
+      </div>
+      <div style="padding:8px 0 0">
+        <h2 class="acct-title">Account</h2>
+        <div class="sub-label">Your Pass Plan</div>
+        <div class="plan-card">
+          <div class="pcard-eyebrow"><span>Network+ N10-009</span><span>Taken Jun 14</span></div>
+          <div class="pcard-main">
+            <div class="prob-ring"><div class="inner"><span class="pct">72%</span><span class="lbl">pass</span></div></div>
+            <div class="pcard-detail"><p class="meta">15 of 20 correct</p><p class="weak">Weakest: <b>Subnetting</b>, <b>Network security</b></p></div>
+          </div>
+          <div class="pcard-cta"><button class="btn btn-primary btn-sm">View full plan</button><button class="btn btn-ghost btn-sm" style="width:auto">Retake</button></div>
+        </div>
+        <div class="locked-certs">
+          <p class="locked-h">A plan for every cert</p>
+          <p class="locked-sub">Free covers one cert. Pro unlocks a Pass Plan for each of these, plus unlimited questions.</p>
+          <div class="cert-chips">
+            <span class="cert-chip"><svg viewBox="0 0 24 24" fill="none"><rect x="5" y="11" width="14" height="9" rx="2" stroke="var(--text-dim)" stroke-width="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="var(--text-dim)" stroke-width="2"/></svg>Security+</span>
+            <span class="cert-chip"><svg viewBox="0 0 24 24" fill="none"><rect x="5" y="11" width="14" height="9" rx="2" stroke="var(--text-dim)" stroke-width="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="var(--text-dim)" stroke-width="2"/></svg>A+ Core 1</span>
+            <span class="cert-chip"><svg viewBox="0 0 24 24" fill="none"><rect x="5" y="11" width="14" height="9" rx="2" stroke="var(--text-dim)" stroke-width="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="var(--text-dim)" stroke-width="2"/></svg>A+ Core 2</span>
+            <span class="cert-chip"><svg viewBox="0 0 24 24" fill="none"><rect x="5" y="11" width="14" height="9" rx="2" stroke="var(--text-dim)" stroke-width="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="var(--text-dim)" stroke-width="2"/></svg>Azure</span>
+            <span class="cert-chip"><svg viewBox="0 0 24 24" fill="none"><rect x="5" y="11" width="14" height="9" rx="2" stroke="var(--text-dim)" stroke-width="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="var(--text-dim)" stroke-width="2"/></svg>AWS</span>
+          </div>
+          <button class="btn btn-primary btn-full btn-sm" style="height:44px">Get Pro at launch · $9.99/mo</button>
+        </div>
+      </div>
+    </div></div>
+  </div>
+
+  <!-- PRO account (phone) -->
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot pro"></span>Pro account · a plan per cert</div>
+      <div class="why">A list of plans, one per cert they have run, each with its readiness and a way in. "Diagnose another cert" is open because Pro has them all. Goal-gradient: they can see their whole certification path in one place.</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="topbar between">
+        <div class="logo-row"><span class="logo-mark"><svg viewBox="0 0 100 100" fill="none" class="ca-mark"><path d="M58 12 C42 6,16 16,14 34 C12 52,22 62,42 64" stroke="var(--accent)"/><line x1="30" y1="84" x2="70" y2="16" stroke="var(--text-dim)" stroke-width="5" stroke-linecap="round"/><path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="var(--accent)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="logo-name">CertAnvil</span></div>
+        <span class="acct-pill is-pro"><span class="acct-av">S</span>Pro</span>
+      </div>
+      <div style="padding:8px 0 0">
+        <h2 class="acct-title">Account <span class="pro-badge">PRO</span></h2>
+        <div class="sub-label">Your Pass Plans</div>
+        <div class="plan-list">
+          <div class="plan-item"><span class="pi-ring" style="background:var(--accent)">72%</span><span class="pi-body"><span class="pi-cert">Network+ N10-009</span><div class="pi-meta">Taken Jun 14 · weakest: Subnetting</div></span><span class="pi-go">›</span></div>
+          <div class="plan-item"><span class="pi-ring" style="background:oklch(0.55 0.16 40)">64%</span><span class="pi-body"><span class="pi-cert">Security+ SY0-701</span><div class="pi-meta">Taken Jun 10 · weakest: Cryptography</div></span><span class="pi-go">›</span></div>
+          <div class="plan-item"><span class="pi-ring" style="background:var(--green)">81%</span><span class="pi-body"><span class="pi-cert">A+ Core 1</span><div class="pi-meta">Taken Jun 2 · weakest: Networking</div></span><span class="pi-go">›</span></div>
+        </div>
+        <button class="add-cert"><svg viewBox="0 0 24 24" fill="none" width="15" height="15"><path d="M5 12h14M12 5v14" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"/></svg>Diagnose another cert</button>
+        <div class="acct-row" style="margin-top:6px"><span class="k">Plan</span><span class="v" style="color:var(--green)">Pro · unlimited</span></div>
+      </div>
+    </div></div>
+  </div>
+
+  <!-- PRO account (desktop) -->
+  <div class="frame-col wide">
+    <div class="frame-caption">
+      <div class="state"><span class="dot pro"></span>Pro account · desktop / Safari</div>
+      <div class="why">The same list reflows wide. One responsive build, no separate desktop work. (Free reflows the same way.)</div>
+    </div>
+    <div class="desktop">
+      <div class="desktop-bar"><i></i><i></i><i></i></div>
+      <div class="desktop-body">
+        <h2 class="acct-title" style="margin-left:0">Account <span class="pro-badge">PRO</span></h2>
+        <div class="sub-label" style="margin-left:0">Your Pass Plans · 3 certs</div>
+        <div class="plan-list">
+          <div class="plan-item"><span class="pi-ring" style="background:var(--accent)">72%</span><span class="pi-body"><span class="pi-cert">Network+ N10-009</span><div class="pi-meta">Taken Jun 14 · 15 of 20 · weakest: Subnetting, Network security</div></span><button class="btn btn-ghost btn-sm" style="width:auto">View plan</button><span class="pi-go">›</span></div>
+          <div class="plan-item"><span class="pi-ring" style="background:oklch(0.55 0.16 40)">64%</span><span class="pi-body"><span class="pi-cert">Security+ SY0-701</span><div class="pi-meta">Taken Jun 10 · 13 of 20 · weakest: Cryptography, IAM</div></span><button class="btn btn-ghost btn-sm" style="width:auto">View plan</button><span class="pi-go">›</span></div>
+          <div class="plan-item"><span class="pi-ring" style="background:var(--green)">81%</span><span class="pi-body"><span class="pi-cert">A+ Core 1 · 220-1101</span><div class="pi-meta">Taken Jun 2 · 16 of 20 · weakest: Networking, Virtualization</div></span><button class="btn btn-ghost btn-sm" style="width:auto">View plan</button><span class="pi-go">›</span></div>
+        </div>
+        <button class="add-cert" style="max-width:260px"><svg viewBox="0 0 24 24" fill="none" width="15" height="15"><path d="M5 12h14M12 5v14" stroke="var(--accent)" stroke-width="2" stroke-linecap="round"/></svg>Diagnose another cert</button>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<h2 class="section-h">3 · From plan to practice</h2>
+<p class="section-note">Open a saved plan and the weakest topics are tappable. Tap one, or drill them all, and the existing Custom Quiz builder opens pre-loaded with those topics. You confirm count and difficulty, then it builds the quiz on exactly those topics. No new quiz engine. For a free user the builder shows how many of their 15 daily questions are left and caps the count to that (the 5 daily reviews are a separate pool); at zero left it shows a gentle back-tomorrow wall with the Pro nudge instead of starting a quiz that dead-ends. Re-diagnostic uses the section 2 entry points: Retake a cert after its 7-day cooldown, or Diagnose another cert on Pro.</p>
+
+<div class="frames">
+
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot"></span>Full plan · weak topics are tappable</div>
+      <div class="why">The plan you opened from your account. Each weak topic is a tap target; "Drill all weak topics" sends the whole set at once.</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="topbar between">
+        <div class="logo-row"><span class="logo-mark"><svg viewBox="0 0 100 100" fill="none" class="ca-mark"><path d="M58 12 C42 6,16 16,14 34 C12 52,22 62,42 64" stroke="var(--accent)"/><line x1="30" y1="84" x2="70" y2="16" stroke="var(--text-dim)" stroke-width="5" stroke-linecap="round"/><path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="var(--accent)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="logo-name">CertAnvil</span></div>
+        <span class="acct-pill"><span class="acct-av">S</span>Free</span>
+      </div>
+      <div style="padding:6px 0 0">
+        <div class="detail-h"><span>Your Pass Plan</span><span style="font-size:13px;color:var(--accent);font-weight:700">72%</span></div>
+        <p class="detail-sub">Network+ N10-009 · taken Jun 14 · predicted 781 / 900</p>
+        <div class="sub-label" style="margin-left:0">Weakest topics · tap to drill</div>
+        <div class="weak-list">
+          <div class="weak-item"><span class="wbar"><i style="width:40%"></i></span><span class="wname">Subnetting</span><span class="wpct">40%</span><span class="wdrill">Drill</span></div>
+          <div class="weak-item"><span class="wbar"><i style="width:55%"></i></span><span class="wname">Network security</span><span class="wpct">55%</span><span class="wdrill">Drill</span></div>
+          <div class="weak-item"><span class="wbar"><i style="width:48%"></i></span><span class="wname">IPv6 addressing</span><span class="wpct">48%</span><span class="wdrill">Drill</span></div>
+        </div>
+        <button class="btn btn-primary btn-full">Drill all weak topics</button>
+      </div>
+    </div></div>
+  </div>
+
+  <div class="frame-col">
+    <div class="frame-caption">
+      <div class="state"><span class="dot"></span>Custom Quiz builder · pre-loaded</div>
+      <div class="why">The existing builder opens with your weak topics already selected (the work is done), but you stay in control of difficulty and count. Build, and the quiz loads on exactly those topics.</div>
+    </div>
+    <div class="phone"><div class="phone-inner">
+      <div class="topbar between">
+        <div class="logo-row"><span class="logo-mark"><svg viewBox="0 0 100 100" fill="none" class="ca-mark"><path d="M58 12 C42 6,16 16,14 34 C12 52,22 62,42 64" stroke="var(--accent)"/><line x1="30" y1="84" x2="70" y2="16" stroke="var(--text-dim)" stroke-width="5" stroke-linecap="round"/><path d="M46 88 L64 50 L82 88 M53 74 L75 74" stroke="var(--accent)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="logo-name">CertAnvil</span></div>
+        <span class="acct-pill"><span class="acct-av">S</span>Free</span>
+      </div>
+      <div style="padding:6px 0 0">
+        <div class="picker">
+          <p class="picker-h">Build a custom quiz</p>
+          <p class="picker-note">From your Pass Plan. Your weak topics are pre-selected.</p>
+          <div class="quota-note"><span>Free plan</span><b>8 of 15 questions left today</b></div>
+          <p class="pick-label">Topics</p>
+          <div class="chip-wrap">
+            <span class="tchip sel">Subnetting</span>
+            <span class="tchip sel">Network security</span>
+            <span class="tchip sel">IPv6 addressing</span>
+            <span class="tchip">Routing</span>
+            <span class="tchip">VLANs</span>
+            <span class="tchip">Wireless</span>
+          </div>
+          <p class="pick-label">Difficulty</p>
+          <div class="seg"><button>Easy</button><button class="on">Mixed</button><button>Hard</button></div>
+          <p class="pick-label">Questions <span class="cap-hint">capped to your 8 left today</span></p>
+          <div class="seg"><button>5</button><button class="on">8</button><button class="locked">Unlimited · Pro</button></div>
+          <button class="btn btn-primary btn-full">Build quiz · 8 questions</button>
+        </div>
+      </div>
+    </div></div>
+  </div>
+
+</div>
+
+</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.51.1",
+  "version": "7.52.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.51.1
+   Network+ AI Quiz — styles.css  v7.52.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.51.1 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.51.1';
+// Service Worker v7.52.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.52.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -8134,6 +8134,9 @@ test('Pro teaser has no pricing link', !_fnBody(js, '_showProWaitlist').includes
 test('account Pass Plan section', html.includes('id="passplan-section"'));
 test('Pass Plan section tier-aware', _fnBody(js, 'renderPassPlanSection').includes('_renderPassPlanProHtml'));
 test('Pro plan list uses snapshots', _fnBody(js, '_renderPassPlanProHtml').includes('_readReadinessSnapshots'));
+// v7.52.0: weak domains open the Custom Quiz builder pre-loaded (no auto-start) + quota-aware line
+test('weak drill opens builder (no autostart)', _fnBody(js, '_drillWeakDomainToBuilder').includes('prefillDomainTopics') && !_fnBody(js, '_drillWeakDomainToBuilder').includes('startQuiz('));
+test('builder quota line', html.includes('id="cq-quota-line"') && /function _renderBuilderQuotaLine\(/.test(js));
 test('getAvailableCerts exposed', /window\.getAvailableCerts\s*=/.test(authStateJs));
 test('readiness snapshot reader', /function _readReadinessSnapshots\(/.test(js));
 test('v4.81.0 Diagnostic: renderDiagnosticSurface function defined',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -16793,10 +16793,10 @@ test('v4.99.54 D.3: prompt requires original content (no copy from prep banks)',
   /ORIGINAL[\s\S]{0,200}Jason Dion|Professor Messer|CertMaster/i.test(_genEndpointRaw));
 
 // — Quiz UI integration —
-test('v4.99.54 D.3: quiz.html loads Cloudflare Turnstile script',
-  /<script[^>]+turnstile\/v0\/api\.js/.test(_quizD3Raw));
-test('v4.99.54 D.3: quiz.html has invisible Turnstile widget',
-  /class="cf-turnstile"[\s\S]{0,400}data-sitekey/.test(_quizD3Raw));
+test('v7.51.x: quiz.html no longer loads the Cloudflare Turnstile script (gate removed)',
+  !/turnstile\/v0\/api\.js/.test(_quizD3Raw));
+test('v7.51.x: quiz.html no longer renders the Turnstile widget (gate removed)',
+  !/class="cf-turnstile"/.test(_quizD3Raw));
 test('v4.99.54 D.3: quiz.html session envelope now includes full questions array + source field',
   /questions:\s*questions/.test(_quizD3Raw)
   && /source:\s*source/.test(_quizD3Raw)
@@ -16807,8 +16807,9 @@ test('v4.99.54 D.3: quiz.html has AI-first fetch to /api/diagnostic/generate',
 test('v4.99.54 D.3: quiz.html falls back to inline pool on any error path',
   /bootWithFallback\(\s*['"]fallback['"]\s*\)/.test(_quizD3Raw)
   && /shuffleInlinePool/.test(_quizD3Raw));
-test('v4.99.54 D.3: quiz.html has 10s Turnstile timeout (TURNSTILE_TIMEOUT_MS)',
-  /TURNSTILE_TIMEOUT_MS\s*=\s*10000/.test(_quizD3Raw));
+test('v7.51.x: quiz.html boots directly via fetchAIQuestions(null) (Turnstile gate removed)',
+  /fetchAIQuestions\(null\)/.test(_quizD3Raw)
+  && !/TURNSTILE_TIMEOUT_MS/.test(_quizD3Raw));
 test('v4.99.54 D.3: quiz.html has 25s fetch timeout via AbortController',
   /FETCH_TIMEOUT_MS\s*=\s*25000/.test(_quizD3Raw)
   && /AbortController/.test(_quizD3Raw));
@@ -17246,9 +17247,9 @@ test('v4.99.63 dual-theme: diagnostic-system.css has the 4-block cascade, html[d
     // base html:root dark → @media prefers light → html[data-theme=dark] → html[data-theme=light], in that order
     return /html:root\s*\{[\s\S]*?@media\s*\(prefers-color-scheme:\s*light\)[\s\S]*?html\[data-theme="dark"\][\s\S]*?html\[data-theme="light"\]/.test(s)
       && /--dg-bg:\s*oklch\(0\.975/.test(s) && /--dg-bg:\s*oklch\(0\.17 0\.008 275\)/.test(s); })());
-test('v4.99.63 dual-theme: all 4 diagnostic pages cache-bust diagnostic-system.css at v=4.99.96',
+test('v4.99.63 dual-theme: all 4 diagnostic pages cache-bust diagnostic-system.css',
   [_pickerRaw, _intakeRaw, _quizRaw, _resultsD4Raw].every(s =>
-    /diagnostic-system\.css\?v=4\.99\.96/.test(s)));
+    /diagnostic-system\.css\?v=4\.99\.\d+/.test(s)));
 test('v4.99.61 tombstone: dx-* + dq-* systems authored in shared CSS (de-carded, tap targets, decorative emoji hidden)',
   /PICKER \+ INTAKE\s+\(dx-\*/.test(_dgSys) && /QUIZ\s+\(dq-\*/.test(_dgSys) &&
   /\.dx-intensity-btn-emoji\s*\{\s*display:\s*none/.test(_dgSys) &&

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -8126,6 +8126,10 @@ test('v4.81.0 Diagnostic: _seedReviewQueueFromDiagnostic function defined',
   /function\s+_seedReviewQueueFromDiagnostic\b/.test(js));
 test('v4.81.0 Diagnostic: renderDiagnosticResult function defined',
   /function\s+renderDiagnosticResult\b/.test(js));
+// v7.52.0 · state-aware conversion block at the bottom of the Pass Plan.
+test('diagnostic conversion block present', html.includes('id="dq-conversion"'));
+test('conversion renders states', _fnBody(js, '_renderDiagnosticConversion').includes('_certanvilSignedIn'));
+test('Pro teaser has no pricing link', !_fnBody(js, '_showProWaitlist').includes('certanvil.com/pricing'));
 test('v4.81.0 Diagnostic: renderDiagnosticSurface function defined',
   /function\s+renderDiagnosticSurface\b/.test(js));
 test('v4.81.0 Diagnostic: getDiagnosticCooldownDays function defined',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -8130,6 +8130,12 @@ test('v4.81.0 Diagnostic: renderDiagnosticResult function defined',
 test('diagnostic conversion block present', html.includes('id="dq-conversion"'));
 test('conversion renders states', _fnBody(js, '_renderDiagnosticConversion').includes('_certanvilSignedIn'));
 test('Pro teaser has no pricing link', !_fnBody(js, '_showProWaitlist').includes('certanvil.com/pricing'));
+// v7.52.0: account Pass Plan home (Free one-plan+upsell, Pro plan-per-cert)
+test('account Pass Plan section', html.includes('id="passplan-section"'));
+test('Pass Plan section tier-aware', _fnBody(js, 'renderPassPlanSection').includes('_renderPassPlanProHtml'));
+test('Pro plan list uses snapshots', _fnBody(js, '_renderPassPlanProHtml').includes('_readReadinessSnapshots'));
+test('getAvailableCerts exposed', /window\.getAvailableCerts\s*=/.test(authStateJs));
+test('readiness snapshot reader', /function _readReadinessSnapshots\(/.test(js));
 test('v4.81.0 Diagnostic: renderDiagnosticSurface function defined',
   /function\s+renderDiagnosticSurface\b/.test(js));
 test('v4.81.0 Diagnostic: getDiagnosticCooldownDays function defined',


### PR DESCRIPTION
## What this builds

The in-app Baseline Diagnostic now has a complete ending and afterlife (brainstormed + mockup-approved with Simi). Spec: `docs/superpowers/specs/2026-06-14-in-app-diagnostic-conversion-design.md`. Plan: `docs/superpowers/plans/2026-06-14-in-app-diagnostic-conversion.md`. Mockup: `mockups/diagnostic-conversion/index.html`.

### 1. Conversion moment (result page)
A state-aware block below the Pass Plan: **anonymous** sees a "Don't lose your Pass Plan" save-free panel (email sign-in) + an App-Store-safe Pro waitlist teaser + a soft escape; **signed-in free** sees "Saved to your account" + a soft Pro line; **Pro** sees nothing. No `certanvil.com/pricing` link anywhere (StoreKit is Phase G).

### 2. Account Pass Plan home (`#page-settings`)
- **Free:** one plan card (View full plan / Retake) + a locked-certs Pro upsell.
- **Pro:** a plan per cert (read from the `nplus_readiness_snapshots` map) + "Diagnose another cert" (cert switcher). Responsive to desktop.

### 3. Plan → practice
Weak-domain buttons now open the existing Custom Quiz builder **pre-loaded** (no auto-start), with a **quota-aware** line ("N of 15 left today") and a 0-quota guard.

## Decisions baked in
Account/settings surface · all Pro plans in one view · 7-day retake cooldown for all tiers · free = 15 questions/day (+5 reviews, separate pool).

## Reuse / lane
New UI on shipped tier logic (v7.40 limits, v7.46 15-cap, v7.33 cert-lock, v7.43 cross-cert snapshots). One minimal gated export (`window.getAvailableCerts`/`window.buildSignInUrl` in auth-state.js) → this PR is the gated-lane path. No schema/RLS/migration.

## Quality
- UAT **4132/4132** (also corrected 4 stale landing assertions that #458 invalidated — Turnstile removed, cache-bust agnostic).
- tech-debt: functions>80 at 46/50, **0 new dead functions**, no new breaches.
- Brand: forged-bronze, zero emoji, zero em-dashes in visible copy, full tinted hairlines.
- Correctness review (0 critical / 0 high); 2 medium fixes applied (real save-free fallback + 0-quota guard).
- All new functions <80 lines, every one wired.

## Before merge (recommended)
- Run the 4-agent **`review-feature`** pass (touches accounts + Pro path).
- Live-verify the full flow on the Vercel **preview** (gated-lane), per the post-deploy rule: finish diagnostic → 3 conversion states → account Pass Plan (Free + Pro) → weak-topic drill → builder → retake / switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)