### PR TITLE
feat(account): Pass Plan IA — per-cert in browser settings, cross-cert section on /account (v7.53.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.53.0 | Pass Plan IA: per-cert in browser settings, all certs in installed app + a cross-cert Your Pass Plans section on /account |
 | v7.52.0 | In-app diagnostic conversion ending + account Pass Plan home (Free/Pro) + plan-to-practice + quota-aware builder |
 | v7.51.1 | En/em-dash cleanup in cert-app visible copy (readiness scale, drills note, exam abandon, quota line, Pro modal) |
 | v7.51.0 | Forged-bronze audit sweep — cert-app brand/emoji/dark-mode fixes + ACL hint-modal close handler |

--- a/app.js
+++ b/app.js
@@ -5702,7 +5702,14 @@ function renderPassPlanSection() {
   if (!host) return;
   var isPro = !!_quotaState && (_quotaState.tier === 'pro' ||
     (typeof _quotaState.daily_limit === 'number' && _quotaState.daily_limit < 0));
-  host.innerHTML = isPro ? _renderPassPlanProHtml() : _renderPassPlanFreeHtml();
+  // Installed app (iOS PWA) shows all certs' plans; a plain browser tab is one
+  // cert per subdomain, so Settings shows only the current cert's plan.
+  var standalone = document.body.classList.contains('is-standalone');
+  if (standalone) {
+    host.innerHTML = isPro ? _renderPassPlanProHtml() : _renderPassPlanFreeHtml();
+  } else {
+    host.innerHTML = isPro ? _renderPassPlanBrowserProHtml() : _renderPassPlanFreeHtml();
+  }
   _wirePassPlanSection(host);
 }
 
@@ -5721,47 +5728,56 @@ function _passPlanLockSvg() {
     '<path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="var(--text-dim)" stroke-width="2"/></svg>';
 }
 
-// Free tier: one plan card from the on-file diagnostic (or an empty state),
-// then the locked-certs Pro upsell. Stays under 80 lines.
-function _renderPassPlanFreeHtml() {
+// Shared: the single current-cert plan card from the on-file diagnostic, or
+// the "take the baseline diagnostic" empty state. Used by both the Free path
+// and the browser-tab Pro path so each cert shows only its own plan. <80 lines.
+function _passPlanCurrentCertCardHtml() {
   var rec = (typeof loadDiagnostic === 'function') ? loadDiagnostic() : null;
   var pp = rec && rec.passPlan;
   var certName = (typeof CERT_PACK !== 'undefined' && CERT_PACK && CERT_PACK.meta && CERT_PACK.meta.name)
     ? CERT_PACK.meta.name : 'CompTIA Network+';
-  var card;
-  if (pp) {
-    var prob = Math.round((pp.passProbability || 0) * 100);
-    var weak = (pp.weakDomains || []).slice(0, 2).map(function (d) {
-      return '<b>' + escHtml(d.label || d.key || '') + '</b>';
-    }).join(', ');
-    var detail = (typeof pp.correctCount === 'number' && typeof pp.questionCount === 'number')
-      ? (pp.correctCount + ' of ' + pp.questionCount + ' correct')
-      : ((typeof pp.accPct === 'number') ? (pp.accPct + '% accuracy') : '');
-    card =
-      '<div class="plan-card">' +
-        '<div class="pcard-eyebrow"><span>' + escHtml(certName) + '</span><span>' + escHtml(_passPlanDate(pp.completedAt)) + '</span></div>' +
-        '<div class="pcard-main">' +
-          '<div class="prob-ring" style="background:conic-gradient(var(--accent) 0 ' + prob + '%, var(--surface3) ' + prob + '% 100%)">' +
-            '<div class="inner"><span class="pct">' + prob + '%</span><span class="lbl">pass</span></div></div>' +
-          '<div class="pcard-detail">' +
-            (detail ? '<p class="meta">' + escHtml(detail) + '</p>' : '') +
-            (weak ? '<p class="weak">Weakest: ' + weak + '</p>' : '') +
-          '</div>' +
-        '</div>' +
-        '<div class="pcard-cta">' +
-          '<button type="button" class="btn btn-primary btn-sm" data-act="pp-view">View full plan</button>' +
-          '<button type="button" class="btn btn-ghost btn-sm" style="width:auto" data-act="pp-retake">Retake</button>' +
-        '</div>' +
-      '</div>';
-  } else {
-    card =
-      '<div class="plan-card pp-empty">' +
+  if (!pp) {
+    return '<div class="plan-card pp-empty">' +
         '<p class="pp-empty-h">Take the baseline diagnostic</p>' +
         '<p class="pp-empty-sub">20 questions across every domain build your Pass Plan, your readiness and the topics to drill first.</p>' +
         '<button type="button" class="btn btn-primary btn-sm" data-act="pp-empty">Start the diagnostic</button>' +
       '</div>';
   }
-  return '<div class="sub-label">Your Pass Plan</div>' + card + _passPlanLockedCertsHtml();
+  var prob = Math.round((pp.passProbability || 0) * 100);
+  var weak = (pp.weakDomains || []).slice(0, 2).map(function (d) {
+    return '<b>' + escHtml(d.label || d.key || '') + '</b>';
+  }).join(', ');
+  var detail = (typeof pp.correctCount === 'number' && typeof pp.questionCount === 'number')
+    ? (pp.correctCount + ' of ' + pp.questionCount + ' correct')
+    : ((typeof pp.accPct === 'number') ? (pp.accPct + '% accuracy') : '');
+  return '<div class="plan-card">' +
+      '<div class="pcard-eyebrow"><span>' + escHtml(certName) + '</span><span>' + escHtml(_passPlanDate(pp.completedAt)) + '</span></div>' +
+      '<div class="pcard-main">' +
+        '<div class="prob-ring" style="background:conic-gradient(var(--accent) 0 ' + prob + '%, var(--surface3) ' + prob + '% 100%)">' +
+          '<div class="inner"><span class="pct">' + prob + '%</span><span class="lbl">pass</span></div></div>' +
+        '<div class="pcard-detail">' +
+          (detail ? '<p class="meta">' + escHtml(detail) + '</p>' : '') +
+          (weak ? '<p class="weak">Weakest: ' + weak + '</p>' : '') +
+        '</div>' +
+      '</div>' +
+      '<div class="pcard-cta">' +
+        '<button type="button" class="btn btn-primary btn-sm" data-act="pp-view">View full plan</button>' +
+        '<button type="button" class="btn btn-ghost btn-sm" style="width:auto" data-act="pp-retake">Retake</button>' +
+      '</div>' +
+    '</div>';
+}
+
+// Free tier: one plan card from the on-file diagnostic (or an empty state),
+// then the locked-certs Pro upsell. Stays under 80 lines.
+function _renderPassPlanFreeHtml() {
+  return '<div class="sub-label">Your Pass Plan</div>' +
+    _passPlanCurrentCertCardHtml() + _passPlanLockedCertsHtml();
+}
+
+// Browser tab, Pro user: just the current cert's single plan card. Each cert is
+// its own subdomain in a browser, so no multi-cert list and no upsell here.
+function _renderPassPlanBrowserProHtml() {
+  return '<div class="sub-label">Your Pass Plan</div>' + _passPlanCurrentCertCardHtml();
 }
 
 // Free upsell: the Pro certs as locked chips + a launch-waitlist button.

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.52.0
+// Network+ AI Quiz — app.js  v7.53.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.52.0';
+const APP_VERSION = '7.53.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/index.html
+++ b/index.html
@@ -767,7 +767,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.52.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.53.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/landing/account.html
+++ b/landing/account.html
@@ -453,11 +453,24 @@
         </div>
       </section>
 
-      <!-- §03 Exam results (v4.93.0) -->
+      <!-- §03 Pass Plans · cross-cert baseline-diagnostic plans -->
+      <section class="acc-section" id="section-passplans">
+        <header class="section-head">
+          <span class="acc-sec-ic" aria-hidden="true"><img src="assets/account/s02-subscription.svg" alt=""></span>
+          <div class="section-eyebrow">§03 Pass Plans</div>
+          <h2 class="section-title">Your Pass Plans</h2>
+          <p class="section-sub">Your baseline diagnostic for each cert, and where it points you next.</p>
+        </header>
+        <div class="ent-list" id="passplans-list">
+          <!-- Populated by account.js renderPassPlans() -->
+        </div>
+      </section>
+
+      <!-- §04 Exam results (v4.93.0) -->
       <section class="acc-section" id="section-exam-results">
         <header class="section-head">
           <span class="acc-sec-ic" aria-hidden="true"><img src="assets/account/s03-exam.svg" alt=""></span>
-          <div class="section-eyebrow">§03 Exam results</div>
+          <div class="section-eyebrow">§04 Exam results</div>
           <h2 class="section-title">Real-world exam attempts</h2>
           <p class="section-sub">Track your attempts at the real CompTIA / vendor exams. Marking a result unlocks the Passed badge on your cert tile. Always editable.</p>
         </header>
@@ -470,7 +483,7 @@
       <section class="acc-section" id="section-security">
         <header class="section-head">
           <span class="acc-sec-ic" aria-hidden="true"><img src="assets/account/s04-security.svg" alt=""></span>
-          <div class="section-eyebrow">§04 Security</div>
+          <div class="section-eyebrow">§05 Security</div>
           <h2 class="section-title">Security</h2>
         </header>
         <div class="acc-field">
@@ -496,7 +509,7 @@
       <section class="acc-section" id="section-notifications">
         <header class="section-head">
           <span class="acc-sec-ic" aria-hidden="true"><img src="assets/account/s05-notify.svg" alt=""></span>
-          <div class="section-eyebrow">§05 Notifications</div>
+          <div class="section-eyebrow">§06 Notifications</div>
           <h2 class="section-title">Email preferences</h2>
           <p class="section-sub">Toggles save to your account immediately. Email cron wires up in a future ship.</p>
         </header>
@@ -534,7 +547,7 @@
       <section class="acc-section" id="section-data">
         <header class="section-head">
           <span class="acc-sec-ic" aria-hidden="true"><img src="assets/account/s06-data.svg" alt=""></span>
-          <div class="section-eyebrow">§06 Data &amp; Privacy</div>
+          <div class="section-eyebrow">§07 Data &amp; Privacy</div>
           <h2 class="section-title">Your data</h2>
           <p class="section-sub">Export everything you've stored on CertAnvil. Account deletion in the danger zone below.</p>
         </header>
@@ -548,7 +561,7 @@
       <!-- §06 Danger zone -->
       <section class="acc-section is-danger" id="section-danger">
         <header class="section-head">
-          <div class="section-eyebrow">§07 Danger zone</div>
+          <div class="section-eyebrow">§08 Danger zone</div>
           <h2 class="section-title">Delete account</h2>
           <p class="section-sub">Marks your account for deletion. After 7 days, your profile + quiz history are permanently purged. You can cancel during the grace window by signing in.</p>
         </header>

--- a/landing/lib/account.js
+++ b/landing/lib/account.js
@@ -60,6 +60,7 @@
   var elSubTierLabel = document.getElementById('sub-tier-label');
   var elBtnUpgrade = document.getElementById('btn-upgrade');
   var elEntList = document.getElementById('ent-list');
+  var elPassPlansList = document.getElementById('passplans-list');  // cross-cert Pass Plans
   var elErList = document.getElementById('er-list');  // v4.93.0 exam results list
 
   var elSecurityEmailMono = document.getElementById('security-email-mono');
@@ -231,6 +232,9 @@
     // Cert entitlements (status now reflects metadata.cert_results when present)
     if (elEntList) elEntList.innerHTML = renderEntitlements(role, profile);
 
+    // Pass Plans: cross-cert baseline-diagnostic plans from readiness snapshots
+    if (elPassPlansList) elPassPlansList.innerHTML = renderPassPlans(role, profile);
+
     // Exam results section (v4.93.0)
     if (elErList) elErList.innerHTML = renderExamResultsList(role, profile);
 
@@ -300,6 +304,77 @@
         +   '<button class="' + btnClass + ' ent-cta-btn" ' + ctaAttrs + '>' + escapeHtml(c.cta.label) + '</button>'
         + '</div>';
     }).join('');
+  }
+
+  // ── Pass Plans (cross-cert baseline diagnostics) ────────────────────────
+  // Reads the per-cert readiness snapshot map
+  // profile.metadata.nplus_readiness_snapshots = { netplus:{score,computed_at,
+  // weak_domain,...}, secplus:{...}, ... } · the same map the analytics page
+  // reads · and lists every cert that has a plan together. Each row mirrors
+  // the entitlements grammar (.ent-row): a glyph chip with the readiness
+  // score%, cert name + code, "Taken <date> · weakest: <domain>", and a
+  // "View plan ›" link into that cert's subdomain app. Empty → short prompt.
+  function renderPassPlans(role, profile) {
+    var snapshots = (profile && profile.metadata && profile.metadata.nplus_readiness_snapshots) || {};
+    // Cert display metadata + subdomain CTA come from the same source the
+    // entitlements list uses, so a plan opens in that cert's app.
+    var certs = getCertEntitlements(role);
+    var rows = certs.map(function (c) {
+      var snap = snapshots[c.id];
+      if (!snap || typeof snap.score !== 'number') return '';
+      return renderPassPlanRow(c, snap);
+    }).filter(Boolean);
+
+    if (!rows.length) {
+      return '<p class="er-empty">Take a baseline diagnostic to start a Pass Plan.</p>';
+    }
+    return rows.join('');
+  }
+
+  function renderPassPlanRow(cert, snap) {
+    var fmt = EXAM_FORMATS[cert.id] || { maxScore: 900 };
+    // Readiness score is a CompTIA-style scaled band, expressed as a percent
+    // of the cert's max for the glyph chip, matching the mockup ("72%").
+    var pct = Math.max(0, Math.min(100, Math.round((snap.score / fmt.maxScore) * 100)));
+    var taken = snap.computed_at ? humanPlanDate(snap.computed_at) : null;
+    var weak = snap.weak_domain || snap.weak_topic || null;
+    var metaPieces = [];
+    if (taken) metaPieces.push('Taken ' + taken);
+    if (weak) metaPieces.push('weakest: ' + weak);
+    var metaLine = metaPieces.length ? metaPieces.join(' · ') : 'Plan ready';
+    // "View plan ›" opens the cert's app on its own subdomain (same href map
+    // the entitlements "Open →" CTA uses). Disabled certs fall back to text.
+    var href = (cert.cta && !cert.cta.disabled && cert.cta.href) || '';
+    var ctaHtml = href
+      ? '<button class="btn-ghost-sm ent-cta-btn" data-href="' + escapeHtml(href) + '">View plan ›</button>'
+      : '<span class="ent-status-pill">Locked</span>';
+    return ''
+      + '<div class="ent-row">'
+      +   '<div class="ent-glyph ' + cert.glyphClass + '">' + pct + '%</div>'
+      +   '<div class="ent-info">'
+      +     '<div class="ent-name-row">'
+      +       '<span class="ent-name">' + escapeHtml(cert.name) + '</span>'
+      +     '</div>'
+      +     '<div class="ent-meta">' + escapeHtml(cert.code) + ' · ' + escapeHtml(metaLine) + '</div>'
+      +   '</div>'
+      +   ctaHtml
+      + '</div>';
+  }
+
+  function humanPlanDate(iso) {
+    // ISO → "12 Jun" / "12 Jun 2025"-style, matching the mockup copy.
+    try {
+      var d = new Date(iso);
+      if (isNaN(d.getTime())) return null;
+      var now = new Date();
+      var sameYear = d.getFullYear() === now.getFullYear();
+      var opts = sameYear
+        ? { day: 'numeric', month: 'short' }
+        : { day: 'numeric', month: 'short', year: 'numeric' };
+      return d.toLocaleDateString('en-GB', opts);
+    } catch (e) {
+      return null;
+    }
   }
 
   // ── Exam results (v4.93.0) ──────────────────────────────────────────────
@@ -725,14 +800,18 @@
   }
 
   // ── Cert entitlement CTAs ──────────────────────────────────────────────
+  // Shared delegation for the entitlements list AND the Pass Plans list:
+  // both emit .ent-cta-btn[data-href] rows that open a cert's subdomain app.
   function wireEntitlementCtas() {
-    if (!elEntList) return;
-    elEntList.addEventListener('click', function (e) {
-      var btn = e.target.closest('.ent-cta-btn[data-href]');
-      if (!btn || btn.hasAttribute('disabled')) return;
-      var href = btn.getAttribute('data-href');
-      if (!href || href === '#') return;
-      window.location.href = href;
+    [elEntList, elPassPlansList].forEach(function (host) {
+      if (!host) return;
+      host.addEventListener('click', function (e) {
+        var btn = e.target.closest('.ent-cta-btn[data-href]');
+        if (!btn || btn.hasAttribute('disabled')) return;
+        var href = btn.getAttribute('data-href');
+        if (!href || href === '#') return;
+        window.location.href = href;
+      });
     });
   }
 

--- a/mockups/diagnostic-conversion/account-ia.html
+++ b/mockups/diagnostic-conversion/account-ia.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pass Plan IA - per-cert vs aggregate</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:oklch(0.975 0.007 85); --surface:oklch(0.945 0.008 85); --surface3:oklch(0.915 0.008 85);
+    --border:oklch(0.85 0.011 85); --accent:oklch(0.50 0.155 55); --accent-dim:color-mix(in oklab, oklch(0.50 0.155 55) 10%, transparent);
+    --tint:color-mix(in oklab, oklch(0.50 0.155 55) 6%, var(--bg));
+    --text:oklch(0.26 0.015 280); --text-mid:oklch(0.42 0.014 280); --text-dim:oklch(0.50 0.013 280);
+    --green:oklch(0.50 0.15 150); --radius:14px; --radius-sm:10px; --lnum:"lnum" 1,"tnum" 1;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;-webkit-font-smoothing:antialiased;padding:40px 22px 80px}
+  .wrap{max-width:1180px;margin:0 auto}
+  .page-head h1{font-family:Fraunces,serif;font-weight:600;font-size:25px;letter-spacing:-0.01em;margin:0 0 6px}
+  .page-head p{color:var(--text-mid);font-size:14px;line-height:1.6;margin:0;max-width:76ch}
+  .legend{display:flex;gap:8px;flex-wrap:wrap;margin:14px 0 30px}
+  .legend span{font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:var(--accent);border:1px solid var(--border);border-radius:999px;padding:5px 11px;background:var(--tint)}
+  .section-h{font-family:Fraunces,serif;font-weight:600;font-size:18px;margin:34px 0 4px}
+  .section-h.first{margin-top:4px}
+  .note{color:var(--text-mid);font-size:13px;margin:0 0 20px;max-width:76ch;line-height:1.55}
+  .frames{display:flex;gap:30px;flex-wrap:wrap;align-items:flex-start}
+  .col{flex:1 1 360px;min-width:320px;max-width:540px}
+  .cap{font-weight:700;font-size:14px;display:flex;align-items:center;gap:8px;margin:0 0 4px}
+  .cap .dot{width:7px;height:7px;border-radius:50%;background:var(--accent)}
+  .cap .dot.ios{background:var(--green)}
+  .why{color:var(--text-mid);font-size:12.5px;line-height:1.55;margin:0 0 12px}
+
+  /* shared bits */
+  .btn{border:0;border-radius:var(--radius-sm);cursor:pointer;font:700 13px Inter,sans-serif;height:40px;padding:0 16px;display:inline-flex;align-items:center;justify-content:center;gap:6px}
+  .btn-primary{background:var(--accent);color:var(--bg)} .btn-ghost{background:transparent;color:var(--accent);border:1px solid color-mix(in oklab,var(--accent) 42%,var(--border))}
+  .prob-ring{width:54px;height:54px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;background:conic-gradient(var(--accent) 0 72%, var(--surface3) 72% 100%)}
+  .prob-ring .in{width:42px;height:42px;border-radius:50%;background:var(--bg);display:flex;flex-direction:column;align-items:center;justify-content:center}
+  .prob-ring .pct{font-family:Fraunces,serif;font-weight:600;font-size:15px;font-feature-settings:var(--lnum);line-height:1}
+  .prob-ring .lbl{font-size:7px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.05em}
+
+  /* Frame A — cert-app settings card (dg-system look) */
+  .app-card{background:var(--surface);border:1px solid var(--border);border-radius:18px;padding:18px 18px 4px;box-shadow:0 14px 40px color-mix(in oklab,var(--text) 7%,transparent)}
+  .app-bar{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+  .app-bar .logo{font-family:Fraunces,serif;font-weight:600;font-size:15px}
+  .app-bar .url{font-size:11px;color:var(--text-dim);background:var(--surface3);border-radius:999px;padding:3px 10px}
+  .sub-label{font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--text-dim);margin:0 0 10px}
+  .plan-card{border:1px solid var(--border);border-radius:var(--radius);background:var(--bg);padding:15px;margin-bottom:14px}
+  .pc-eyebrow{font-size:10.5px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--text-dim);display:flex;justify-content:space-between;margin-bottom:11px}
+  .pc-main{display:flex;gap:13px;align-items:center}
+  .pc-meta{font-size:12.5px;color:var(--text-mid);margin:0 0 6px;font-feature-settings:var(--lnum)}
+  .pc-weak{font-size:12.5px} .pc-weak b{color:var(--accent)}
+  .pc-cta{display:flex;gap:8px;margin-top:13px}
+  .ios-foot{font-size:11.5px;color:var(--text-dim);border-top:1px solid var(--border);padding:11px 2px;margin-top:2px;display:flex;align-items:center;gap:7px}
+  .ios-foot svg{width:13px;height:13px;flex:none}
+
+  /* Frame B — /account editorial section */
+  .acct{background:#fff;border:1px solid var(--border);border-radius:16px;overflow:hidden;box-shadow:0 14px 40px color-mix(in oklab,var(--text) 7%,transparent)}
+  .acct-bar{height:34px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:6px;padding:0 12px}
+  .acct-bar i{width:9px;height:9px;border-radius:50%;background:var(--surface3)}
+  .acct-body{padding:24px 26px}
+  .acc-eyebrow{font-size:10.5px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--accent);margin:0 0 4px}
+  .acc-title{font-family:Fraunces,serif;font-weight:600;font-size:21px;margin:0 0 4px}
+  .acc-sub{font-size:13px;color:var(--text-mid);margin:0 0 18px}
+  .ent{display:flex;align-items:center;gap:14px;padding:13px 2px;border-top:1px solid var(--border)}
+  .ent:first-of-type{border-top:0}
+  .ent .glyph{width:34px;height:34px;border-radius:8px;flex:none;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:var(--bg);font-feature-settings:var(--lnum)}
+  .ent .body{flex:1;min-width:0}
+  .ent .nm{font-weight:700;font-size:13.5px}
+  .ent .mt{font-size:12px;color:var(--text-mid);font-feature-settings:var(--lnum)}
+  .ent .go{color:var(--text-dim);font-weight:600;font-size:13px}
+  .ent a.go{color:var(--accent);text-decoration:none}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<div class="page-head">
+  <h1>Pass Plan placement &middot; per-cert vs aggregate</h1>
+  <p>Fix: the all-certs list should be conditional. In a web browser tab (each cert is its own subdomain), the cert-app Settings shows only THAT cert's plan; the installed app (iOS standalone) keeps all certs in one screen; and the general account page gets the full cross-cert list. Light theme. Forged-bronze, emoji and em-dash free.</p>
+</div>
+<div class="legend"><span>design-taste</span><span>emil-design-eng</span><span>humanizer</span><span>marketing-psychology</span></div>
+
+<h2 class="section-h first">A &middot; Cert-app Settings in a browser tab (web)</h2>
+<p class="note">On the web, networkplus.certanvil.com is the Network+ app. Its Settings should show only the Network+ plan. The installed iOS app keeps the full all-certs list (a one-line branch on the existing is-standalone flag).</p>
+<div class="frames">
+  <div class="col" style="max-width:400px">
+    <div class="cap"><span class="dot"></span>Network+ subdomain Settings &middot; one plan</div>
+    <div class="why">You are in Network+'s settings, so you see Network+'s plan. No Security+, no list. Switching cert switches subdomain (and its settings).</div>
+    <div class="app-card">
+      <div class="app-bar"><span class="logo">CertAnvil</span><span class="url">networkplus.certanvil.com</span></div>
+      <div class="sub-label">Your Pass Plan</div>
+      <div class="plan-card">
+        <div class="pc-eyebrow"><span>Network+ N10-009</span><span>Taken 12 Jun</span></div>
+        <div class="pc-main">
+          <div class="prob-ring"><div class="in"><span class="pct">72%</span><span class="lbl">pass</span></div></div>
+          <div>
+            <p class="pc-meta">15 of 20 correct &middot; predicted 781 / 900</p>
+            <p class="pc-weak">Weakest: <b>Subnetting</b>, <b>Network security</b></p>
+          </div>
+        </div>
+        <div class="pc-cta"><button class="btn btn-primary">View full plan</button><button class="btn btn-ghost">Retake</button></div>
+      </div>
+      <div class="ios-foot"><svg viewBox="0 0 24 24" fill="none"><rect x="4" y="3" width="16" height="18" rx="3" stroke="var(--text-dim)" stroke-width="1.8"/><line x1="10" y1="18" x2="14" y2="18" stroke="var(--text-dim)" stroke-width="1.8"/></svg>Installed app (iOS): this same section shows every cert's plan in one place.</div>
+    </div>
+  </div>
+</div>
+
+<h2 class="section-h">B &middot; General account page (certanvil.com/account)</h2>
+<p class="note">The cross-cert home. A new "Your Pass Plans" section sits alongside your entitlements and exam attempts, listing every cert's plan together. Matches the page's existing editorial sections.</p>
+<div class="frames">
+  <div class="col" style="max-width:560px">
+    <div class="cap"><span class="dot ios"></span>certanvil.com/account &middot; all certs</div>
+    <div class="why">Every cert you have run, in one list, on the page that already aggregates everything else about your account.</div>
+    <div class="acct">
+      <div class="acct-bar"><i></i><i></i><i></i></div>
+      <div class="acct-body">
+        <p class="acc-eyebrow">&sect; 03 &middot; Your Pass Plans</p>
+        <h2 class="acc-title">Your Pass Plans</h2>
+        <p class="acc-sub">Your baseline diagnostic for each cert, and where it points you next.</p>
+        <div class="ent">
+          <span class="glyph" style="background:var(--accent)">72%</span>
+          <span class="body"><div class="nm">Network+ &middot; N10-009</div><div class="mt">Taken 12 Jun &middot; 15 of 20 &middot; weakest: Subnetting</div></span>
+          <a href="#" class="go">View plan &rsaquo;</a>
+        </div>
+        <div class="ent">
+          <span class="glyph" style="background:oklch(0.55 0.16 40)">64%</span>
+          <span class="body"><div class="nm">Security+ &middot; SY0-701</div><div class="mt">Taken 12 May &middot; 13 of 20 &middot; weakest: Cryptography</div></span>
+          <a href="#" class="go">View plan &rsaquo;</a>
+        </div>
+        <div class="ent">
+          <span class="glyph" style="background:var(--green)">81%</span>
+          <span class="body"><div class="nm">CompTIA A+ &middot; 220-1201</div><div class="mt">Taken 2 Jun &middot; 16 of 20 &middot; weakest: Networking</div></span>
+          <a href="#" class="go">View plan &rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.52.0",
+  "version": "7.53.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.52.0
+   Network+ AI Quiz — styles.css  v7.53.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.52.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.52.0';
+// Service Worker v7.53.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.53.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -8134,6 +8134,8 @@ test('Pro teaser has no pricing link', !_fnBody(js, '_showProWaitlist').includes
 test('account Pass Plan section', html.includes('id="passplan-section"'));
 test('Pass Plan section tier-aware', _fnBody(js, 'renderPassPlanSection').includes('_renderPassPlanProHtml'));
 test('Pro plan list uses snapshots', _fnBody(js, '_renderPassPlanProHtml').includes('_readReadinessSnapshots'));
+test('Pass Plan section branches on standalone vs browser', _fnBody(js, 'renderPassPlanSection').includes("classList.contains('is-standalone')"));
+test('browser Pass Plan reuses single current-cert card helper', /_passPlanCurrentCertCardHtml/.test(js));
 // v7.52.0: weak domains open the Custom Quiz builder pre-loaded (no auto-start) + quota-aware line
 test('weak drill opens builder (no autostart)', _fnBody(js, '_drillWeakDomainToBuilder').includes('prefillDomainTopics') && !_fnBody(js, '_drillWeakDomainToBuilder').includes('startQuiz('));
 test('builder quota line', html.includes('id="cq-quota-line"') && /function _renderBuilderQuotaLine\(/.test(js));


### PR DESCRIPTION
## What & why
Follow-up to v7.52.0. The all-certs Pass Plan list was showing inside a single cert's Settings, which is wrong on the web (each cert is its own subdomain). Fix: make placement context-aware.

| Surface | Shows |
|---|---|
| Cert-app Settings, **browser tab** (web subdomain) | **only the current cert's** plan card |
| Cert-app Settings, **installed app** (iOS standalone) | **all certs** in one screen (unchanged) |
| **certanvil.com/account** | new **"Your Pass Plans"** section — all certs aggregated |

## Changes
- **cert-app** (`app.js`): `renderPassPlanSection()` branches on the existing `body.is-standalone` flag. Extracted a shared `_passPlanCurrentCertCardHtml()` (DRY); browser-Pro shows just the current cert's card, browser-Free keeps card+upsell, standalone unchanged.
- **landing** (`account.html` + `lib/account.js`): new `.acc-section` "Your Pass Plans" + `renderPassPlans()`, reusing the readiness-snapshot map and the entitlements' cert metadata / subdomain links. "View plan" opens that cert's app.

## Quality
- UAT **4134/4134**; tech-debt: functions>80 at 46/50, **0 new dead functions**.
- Brand: forged-bronze, zero emoji, zero em-dashes; mockup-approved (`mockups/diagnostic-conversion/account-ia.html`).
- Gated lane (auth-state untouched here, but sw.js bumped + cross-cert read) → this PR.

Deploys both the cert-app and the landing `/account` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)