### PR TITLE
fix(account): Pass Plan settings section squished on desktop (v7.53.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.53.1 | Fix Pass Plan settings section squished on desktop (missing grid-column span) |
 | v7.53.0 | Pass Plan IA: per-cert in browser settings, all certs in installed app + a cross-cert Your Pass Plans section on /account |
 | v7.52.0 | In-app diagnostic conversion ending + account Pass Plan home (Free/Pro) + plan-to-practice + quota-aware builder |
 | v7.51.1 | En/em-dash cleanup in cert-app visible copy (readiness scale, drills note, exam abandon, quota line, Pro modal) |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.53.0
+// Network+ AI Quiz — app.js  v7.53.1
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.53.0';
+const APP_VERSION = '7.53.1';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/dg-system.css
+++ b/dg-system.css
@@ -1787,6 +1787,12 @@ html[data-theme] body #page-settings .ed-pagehead-back:hover{border-color:var(--
 #page-settings [data-group="data-backups"] section.settings-section:nth-of-type(1){grid-column:span 5;}
 #page-settings [data-group="data-backups"] section.settings-section:nth-of-type(2){grid-column:span 7;}
 #page-settings .settings-group-danger .settings-section{grid-column:1 / -1;}
+/* v7.53.1: Pass Plan section spans the full settings grid (was defaulting to span 1 = squished on desktop). */
+#page-settings [data-group="passplan"] section.settings-section{grid-column:1 / -1;}
+/* keep a lone plan card / empty-state / upsell to a tidy column width so the full-width section is not sparse;
+   the multi-plan list (installed app) can use the full width. */
+#page-settings [data-group="passplan"] .plan-card,
+#page-settings [data-group="passplan"] .locked-certs{max-width:560px;}
 @media (max-width:820px){
   #page-settings .settings-group{grid-template-columns:1fr;}
   #page-settings .settings-group .settings-section{grid-column:1 / -1 !important;}

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.50.3">
+<link rel="stylesheet" href="dg-system.css?v=7.53.1">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic
@@ -767,7 +767,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.53.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.53.1</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkplus-quiz",
-  "version": "7.53.0",
+  "version": "7.53.1",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.53.0
+   Network+ AI Quiz — styles.css  v7.53.1
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.53.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.53.0';
+// Service Worker v7.53.1 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.53.1';
 const SHELL_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
The §00 Your Pass Plan section had no `grid-column` rule, so in the settings 12-column grid it defaulted to spanning 1 column (~55px) = squished on desktop. (Mobile collapses the grid to 1 column, so it looked fine there.) Added `grid-column: 1 / -1` like every other settings section, plus a tidy max-width on the lone card/upsell so the full-width section isn't sparse. Verified live on desktop: empty-state and populated card both render full-width and clean. CSS-only + dg-system.css cache-bump. UAT 4134/4134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)