### PR TITLE
feat(gauntlet): free tier gets 1 Reword Gauntlet run/day (bonus, off the 15-q quota)

### DIFF
--- a/app.js
+++ b/app.js
@@ -670,7 +670,7 @@ function _showQuotaExceededUI(detail) {
     '<div class="quota-exceeded-card">' +
       '<div class="quota-exceeded-icon">&#128267;</div>' +
       '<div class="quota-exceeded-title">You&rsquo;ve used today&rsquo;s free questions</div>' +
-      '<div class="quota-exceeded-sub">' + _streakPrefix + 'Free is 15 questions a day, every day, no card required &middot; resets in <strong>' + resetText + '</strong> (midnight UTC).</div>' +
+      '<div class="quota-exceeded-sub">' + _streakPrefix + 'Free is 15 questions a day, plus a separate Reword Gauntlet run, every day, no card required &middot; resets in <strong>' + resetText + '</strong> (midnight UTC).</div>' +
       '<div class="quota-exceeded-actions">' +
         _srBtnHtml +
         '<a class="quota-exceeded-cta" href="https://certanvil.com/pricing" target="_blank" rel="noopener">Upgrade to Pro &middot; $9.99/mo &rarr;</a>' +
@@ -1035,6 +1035,7 @@ const STORAGE = {
   DAILY_GOAL: 'nplus_daily_goal',
   DAILY_CHALLENGE: 'nplus_daily_challenge',
   GAUNTLET_CRACKED: 'nplus_gauntlet_cracked', // v7.48.0 Reword Gauntlet: [{concept, topic, certId, date, attempts}]
+  GAUNTLET_FREE_COUNT: 'nplus_gauntlet_free_count', // v7.54.0 free-tier daily Gauntlet runs ({date, count}) — separate from the 15-question quota
   DEEP_DIVE_USES: 'nplus_deep_dive_uses',
   ERROR_LOG: 'nplus_error_log',
   GH_TOKEN: 'nplus_gh_monitor_token',
@@ -6923,6 +6924,51 @@ function loadGauntletCracked() {
 
 // Entry points (Drills hero card + Home Practice tile). The entry screen is
 // viewable by free users (funnel tease) — the Pro gate fires on Start.
+// v7.54.0 — Reword Gauntlet free daily allowance. The free tier gets ONE run a
+// day as a BONUS that does NOT consume the 15-question quota (the run is fetched
+// non-metered for free users in _fetchGauntletRun). Pro / admin / anonymous are
+// uncapped. Mirrors the GAP-1 SR free-cap helpers (_srFreeReviewedToday etc).
+const GAUNTLET_FREE_DAILY_CAP = 1;
+function _gauntletFreeRunsToday() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORAGE.GAUNTLET_FREE_COUNT) || 'null');
+    if (raw && raw.date === new Date().toISOString().slice(0, 10)) return raw.count || 0;
+  } catch (_) {}
+  return 0;
+}
+function _bumpGauntletFreeRun() {
+  // Only the free tier accrues a count; Pro / admin / anonymous never do.
+  if (!(_quotaState && _quotaState.tier === 'free')) return;
+  try {
+    localStorage.setItem(STORAGE.GAUNTLET_FREE_COUNT, JSON.stringify({
+      date: new Date().toISOString().slice(0, 10),
+      count: _gauntletFreeRunsToday() + 1
+    }));
+  } catch (_) {}
+}
+// Gate for gauntletStart. Returns true to proceed, false (and shows the
+// "today's free run done" modal) when a free user has used today's run.
+function _gateGauntletDaily() {
+  // State still hydrating, or anonymous BYOK (self-pay) → allow. Matches the
+  // optimistic-allow contract in _gateProOnly; anonymous users are uncapped.
+  if (!_quotaState) return true;
+  // Pro / admin / unlimited → always allow.
+  if (_quotaState.tier === 'pro') return true;
+  if (typeof _quotaState.daily_limit === 'number' && _quotaState.daily_limit < 0) return true;
+  // Free tier → one run a day.
+  if (_gauntletFreeRunsToday() >= GAUNTLET_FREE_DAILY_CAP) {
+    if (typeof _showProOnlyUI === 'function') {
+      _showProOnlyUI({
+        feature: 'Reword Gauntlet',
+        title: "That's today's free Gauntlet done",
+        body: 'Free includes one Reword Gauntlet run a day, a bonus on top of your 15 questions. Your next free run unlocks at midnight UTC. Go Pro to run it as often as you like, on every cert.'
+      });
+    }
+    return false;
+  }
+  return true;
+}
+
 function startRewordGauntlet() {
   _gauntletTopic = null;
   // v7.48.1: remember the entry origin — Back must never route a desktop
@@ -7016,8 +7062,10 @@ async function _fetchGauntletRun(topicName, forcedConcept) {
       'anthropic-version': '2023-06-01',
       'anthropic-dangerous-direct-browser-access': 'true'
     },
-    // _metered: true — counts toward quota + the global kill-switch.
-    body: JSON.stringify({ model: CLAUDE_MODEL, max_tokens: MAX_TOKENS_GENERATION, messages: [{ role: 'user', content: prompt }], _metered: true })
+    // v7.54.0: the free-tier daily Gauntlet is a BONUS, separate from the
+    // 15-question quota, so it is sent NON-metered for free users. Pro
+    // (unlimited) and anonymous (BYOK) keep _metered: true exactly as before.
+    body: JSON.stringify({ model: CLAUDE_MODEL, max_tokens: MAX_TOKENS_GENERATION, messages: [{ role: 'user', content: prompt }], _metered: !(_quotaState && _quotaState.tier === 'free') })
   });
   if (!res.ok) throw new Error('gauntlet API error ' + res.status);
   const data = await res.json();
@@ -7044,15 +7092,17 @@ async function _fetchGauntletRun(topicName, forcedConcept) {
 async function gauntletStart(opts) {
   opts = opts || {};
   if (_gauntletBusy) return; // double-tap guard
-  if (typeof _gateProOnly === 'function' && !_gateProOnly('Reword Gauntlet', {
-    title: 'The Reword Gauntlet is a Pro feature',
-    body: 'One concept, asked five ways. Crack all five and you own it in any wording. Go Pro to run the Gauntlet on every cert in the library.'
-  })) return;
+  // v7.54.0: free users get one Gauntlet run a day (was Pro-only). _gateGauntletDaily
+  // allows Pro / anonymous freely and caps the free tier at 1/day with its own modal.
+  if (typeof _gateGauntletDaily === 'function' && !_gateGauntletDaily()) return;
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     showToast('The Gauntlet forges fresh questions, so it needs a connection.', 'info');
     return;
   }
-  if (typeof _canMakeMeteredCall === 'function' && !_canMakeMeteredCall('Reword Gauntlet')) return;
+  // v7.54.0: the free daily Gauntlet is non-metered (a bonus separate from the
+  // 15-question quota), so the metered-quota gate must not block free users.
+  // Pro (unlimited) and anonymous (BYOK) still pass through it unchanged.
+  if (!(_quotaState && _quotaState.tier === 'free') && typeof _canMakeMeteredCall === 'function' && !_canMakeMeteredCall('Reword Gauntlet')) return;
 
   let topicName = opts.topic || _gauntletTopic || null;
   if (!topicName) { const w = getWeakTopic(); topicName = (w && w.topic) || null; }
@@ -7088,6 +7138,9 @@ async function gauntletStart(opts) {
   _gauntletBusy = false;
 
   _gauntletRun = { concept: run.concept, topic: topicName, results: [], attempts: (opts.attempts || 0) + 1 };
+  // v7.54.0: consume the free-tier daily Gauntlet allowance. After a successful
+  // fetch only, so a forge misfire (caught above) never burns the free run.
+  if (typeof _bumpGauntletFreeRun === 'function') _bumpGauntletFreeRun();
   gauntletMode = true;
   wrongDrillMode = false;
   examMode = false;

--- a/docs/FREE-GAUNTLET-RECONCILE-SPEC-2026-06-15.md
+++ b/docs/FREE-GAUNTLET-RECONCILE-SPEC-2026-06-15.md
@@ -1,0 +1,126 @@
+# Free-Gauntlet Reconciliation Spec
+**Date:** 2026-06-15
+**Goal:** Make every surface (landing + app) accurately reflect: **Free gets 1 Reword Gauntlet run per day as a bonus**, separate from the 15-question daily quota. Why-Not stays Pro-only.
+
+> Source: audit + canonical model + code-gating map produced by the `gauntlet-free-taste-reconcile` workflow (113 surfaces audited). Copy-drafting stage was rate-limited; drafting is being completed manually against this canon.
+
+---
+
+## 1. Canonical model (single source of truth — all copy must match)
+
+| Feature | Free (daily, no card) | Pro ($9.99/mo · $89/yr) |
+|---|---|---|
+| AI questions | 15 / day, one cert you pick | Unlimited, every cert |
+| Spaced-review cards | 5 / day | Unlimited |
+| **Reword Gauntlet** | **1 bonus run/day, separate from the 15; you pick the topic on your first run** | Unlimited runs, any cert |
+| **Why-Not drill** | Not included; Pro gate fires on Start | Included |
+| Full Exam Simulator (90q timed) | Not included | Included |
+| Baseline Diagnostic + Pass Plan | Both included (Pass Plan as study map) | Both + Pass Plan coaching |
+| Analytics | Basic | Advanced |
+| Certs | One of your choice | Every cert |
+
+**Free line:** "Free forever, no card: 15 fresh AI-generated questions plus 5 spaced-review cards every day, on one cert you choose, with one bonus Reword Gauntlet run on top. You also get the Baseline Diagnostic, your Pass Plan, the streak tracker, and basic analytics."
+
+**Pro line:** "Pro is $9.99 a month or $89 a year: unlimited questions across every cert, unlimited Reword Gauntlet, the Why-Not drill, the Full Exam Simulator (90 questions, timed), advanced analytics, and Pass Plan coaching. 14-day money-back, cancel anytime."
+
+**Gauntlet free rule:** "Free gets 1 Reword Gauntlet run a day: one concept asked five ways, five rungs to clear. It's a bonus that sits on top of your 15 daily questions, so running it never eats into those 15. New here? You pick the topic for your first run. After your one free run, more runs are a Pro thing."
+
+**Why-Not rule:** Pro-only. Free users can see the entry; the Pro gate fires on Start. (Already matches live code.)
+
+### Approved reusable phrasings
+- "Free forever, no card. Properly free, not a 7-day trial."
+- "15 fresh questions plus 5 review cards every day, on one cert you pick."
+- "1 bonus Reword Gauntlet run a day, separate from your 15 questions."
+- "One concept, asked five ways. Crack all five and you own it in any wording."
+- "Pro is $9.99/mo or $89/yr: unlimited questions across every cert, with 14-day money-back."
+- "Why-Not is a Pro drill. Free users see the door; Pro opens it."
+
+### Forbidden claims (would mislead — never ship)
+1. Implying free users get **Why-Not**.
+2. Implying the daily Gauntlet run **comes out of the 15** ("15 questions including a Gauntlet").
+3. Saying free gets **"unlimited Gauntlet"** / "as many runs as you want". Free is exactly 1/day.
+4. **Claiming the free Gauntlet is live today** — it is NOT until the code gate changes (see §2). Copy and code must ship together.
+5. Implying free covers **more than one cert** / "all certs" / "every cert".
+6. Implying free includes the **Full Exam Simulator, advanced analytics, or Pass Plan coaching**.
+7. Calling the free tier a **trial** or anything time-limited.
+8. Saying free has **"no daily cap" / "unlimited questions"** (those describe Pro only).
+9. Describing the **Diagnostic or Pass Plan as Pro-gated** (both are free; only deeper coaching is Pro).
+
+---
+
+## 2. Code-gate change (REQUIRED — copy is only honest once this ships)
+
+**Today:** the Reword Gauntlet is gated **Pro-only** (`app.js` ~7047 via `_gateProOnly`). Free users cannot run it at all. Why-Not is also Pro-only and stays that way.
+
+### Change points
+
+**a. New STORAGE key (`app.js` ~1037, beside `GAUNTLET_CRACKED`):**
+```js
+GAUNTLET_FREE_COUNT: 'nplus_gauntlet_free_count', // {date, count} — free 1/day, separate from the 15-question quota
+```
+
+**b. Swap the gate (`app.js` ~7047):**
+```js
+// was: if (typeof _gateProOnly === 'function' && !_gateProOnly('Reword Gauntlet', {...})) return;
+if (!_gateGauntletDaily()) return;
+```
+
+**c. New helper (after `_gateProOnly`, ~901):**
+```js
+function _gateGauntletDaily() {
+  // Free: 1 run/day. Pro/admin/anon: always allow.
+  if (_quotaState && _quotaState.tier === 'free') {
+    var today = new Date().toISOString().slice(0, 10);
+    var count = 0;
+    try {
+      var raw = JSON.parse(localStorage.getItem(STORAGE.GAUNTLET_FREE_COUNT) || 'null');
+      if (raw && raw.date === today) count = raw.count || 0;
+    } catch (_) {}
+    if (count >= 1) {
+      if (typeof _showProOnlyUI === 'function') {
+        _showProOnlyUI({
+          title: "That's today's free Gauntlet done",
+          body: "Free includes one Reword Gauntlet run a day. Go Pro for unlimited runs, every day, on every cert."
+        });
+      }
+      return false;
+    }
+  }
+  return true;
+}
+```
+> Note: corrected the apostrophe-in-single-quote bug from the raw spec (used double-quoted strings).
+
+**d. Increment after a completed run** — add `_bumpGauntletFreeCount()` called from `gauntletCompleted()` once the run is saved.
+
+**e. Keep the free run off the 15-question quota.** Two options:
+- **Pattern B (recommended, server-side):** mark the call `{ _metered: true, _category: 'gauntlet' }`; the proxy exempts `'gauntlet'` from `daily_limit` and counts it in a separate `gauntlet_used_today`. The 15-question counter stays clean.
+- **Pattern A (client-side, simpler):** for free tier, strip `_metered` before `_fetchGauntletRun`. Risk: a stale offline tier state could accidentally meter a free run.
+
+**Why-Not:** no change. Stays Pro-only at ~7404.
+
+---
+
+## 3. Surfaces to reconcile (focused set — the ~12 that actually touch the free tier / Gauntlet)
+
+### Landing
+- `pricing.html` — meta description (~10), og:description (~25), twitter:description (~36)
+- `pricing.html` — Free plan-card feature list (~544 "15 questions + 5 review cards a day")
+- `pricing.html` — Free tagline / hero subheader
+- `index.html` — free-tier FAQ answer (~3037-3038)
+- `index.html` — `#gauntlet` marketing section: confirm it doesn't imply free OR add the honest "1 free a day" note
+
+### App
+- `index.html` — settings daily-allowance copy (~1578-1581 "Free is fixed at 15 questions a day")
+- `app.js` — quota chip tooltip, esp. the Pro tooltip (~582 "Drills... are all yours" — now stale/contradictory)
+- `app.js` — quota-exceeded modal (~673)
+- `app.js` — the Pro-only modal that fires for the Gauntlet → becomes the "today's free run done" modal (from §2c)
+- `index.html` — Gauntlet drill entry + card: add the free-state ("1 free today") vs spent-state vs Pro framing
+
+### Out of scope (audit captured them but they're not about the free Gauntlet)
+Exam Simulator entries, Deep Scan, 30/45/60-question marathons, Drill Mistakes, onboarding Pro hints — these are correctly Pro and need no change.
+
+---
+
+## 4. Sequencing (non-negotiable)
+Copy + code-gate change **ship in the same release**. Putting "1 free Gauntlet a day" on the live pricing page while the app still Pro-gates it is a bait-and-switch (forbidden claim #4). Mockup of the app's free-Gauntlet entry (3 states) to follow.

--- a/index.html
+++ b/index.html
@@ -1230,7 +1230,7 @@
 
   <!-- v7.48.0: Reword Gauntlet — flagship drill, hero position -->
   <div class="drills-card gnt-drills-hero" id="drills-gauntlet-card">
-    <div class="drills-card-head"><span class="drills-card-title">Reword Gauntlet <span class="pro-lock-pill tier-free-only"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"></rect><path d="M8 11V8a4 4 0 0 1 8 0v3"></path></svg>Pro</span></span><span class="drills-count-pill" id="drills-gauntlet-pill">Flagship drill</span></div>
+    <div class="drills-card-head"><span class="drills-card-title">Reword Gauntlet</span><span class="drills-count-pill" id="drills-gauntlet-pill">Flagship drill</span></div>
     <p class="drills-card-note">One concept, asked five ways: plain, scenario, best-of, not-trap, twisted. Crack all five and you own it in any wording.</p>
     <button type="button" class="drills-btn" id="drills-gauntlet-btn" data-action="startRewordGauntlet">Run the Gauntlet</button>
   </div>

--- a/landing/index.html
+++ b/landing/index.html
@@ -3034,8 +3034,8 @@
           <span class="fqx-q-tog" aria-hidden="true"></span>
         </summary>
         <div class="fqx-a">
-          <p>Yes, properly free, not a 7-day trial. You get <strong>15 fresh AI-generated questions plus 5 spaced-review cards every day</strong>, plus the diagnostic, your Pass Plan, your streak tracker, and your analytics. Enough to keep a real daily habit going.</p>
-          <p>Unlimited questions, the Full Exam Simulator, and advanced analytics are Pro. When 15 a day stops being enough, or you want to sit full timed mock exams, that's when most people upgrade.</p>
+          <p>Yes, properly free, not a 7-day trial. You get <strong>15 fresh AI-generated questions, 5 spaced-review cards, and 1 Reword Gauntlet run every day</strong> (the Gauntlet sits on top of the 15, it never spends them), plus the diagnostic, your Pass Plan, your streak tracker, and your analytics. Enough to keep a real daily habit going.</p>
+          <p>Unlimited questions, unlimited Reword Gauntlet, the Why-Not drill, the Full Exam Simulator, and advanced analytics are Pro. When 15 a day stops being enough, or you want unlimited drilling and full timed mock exams, that's when most people upgrade.</p>
         </div>
       </details>
 

--- a/landing/pricing.html
+++ b/landing/pricing.html
@@ -7,7 +7,7 @@
 <meta name="theme-color" content="#fafbff">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-title" content="CertAnvil">
-<meta name="description" content="Simple, honest CertAnvil pricing. Free tier with 15 questions + 5 review cards a day, forever. Pro is $89/yr or $9.99/mo for unlimited questions across every cert. Cancel anytime.">
+<meta name="description" content="Free forever, no card: 15 questions, 5 review cards, plus a bonus Gauntlet run a day. Pro is $9.99/mo or $89/yr, unlimited across every cert. Cancel anytime.">
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 <link rel="apple-touch-icon" href="favicon.svg">
 <link rel="stylesheet" href="styles.css">
@@ -22,7 +22,7 @@
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="CertAnvil">
 <meta property="og:title" content="CertAnvil Pricing · Free or $89/yr unlimited">
-<meta property="og:description" content="Free tier with 15 questions + 5 review cards/day. Pro $9.99/mo or $89/yr unlimited across all certs. Cancel anytime, 14-day money-back.">
+<meta property="og:description" content="Free forever: 15 questions, 5 review cards, plus 1 Reword Gauntlet run a day. Pro $9.99/mo or $89/yr, unlimited across every cert. 14-day money-back.">
 <meta property="og:url" content="https://certanvil.com/pricing">
 <meta property="og:image" content="https://certanvil.com/og-image.svg">
 <meta property="og:image:type" content="image/svg+xml">
@@ -33,7 +33,7 @@
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="CertAnvil Pricing · Free or $89/yr unlimited">
-<meta name="twitter:description" content="Free tier with 15 questions + 5 review cards/day. Pro $9.99/mo or $89/yr unlimited across all certs. Cancel anytime, 14-day money-back.">
+<meta name="twitter:description" content="Free forever: 15 questions, 5 review cards, plus 1 Reword Gauntlet run a day. Pro $9.99/mo or $89/yr, unlimited across every cert. 14-day money-back.">
 <meta name="twitter:image" content="https://certanvil.com/og-image.svg">
 
 <link rel="canonical" href="https://certanvil.com/pricing">
@@ -483,7 +483,7 @@
     <div class="pp-hero">
       <span class="pp-eyebrow">Pricing · no hidden tiers</span>
       <h1 class="pp-headline">Free until it's working.<br>Then <span class="pp-amount">$89</span> a year.</h1>
-      <p class="pp-sub">Start on the free diagnostic and pay nothing until CertAnvil is clearly working for you. No per-cert upcharges, no card to begin.</p>
+      <p class="pp-sub">Free forever, no card. Properly free, not a 7-day trial: 15 fresh questions plus 5 review cards every day on one cert you pick, with 1 bonus Reword Gauntlet run a day on top. No per-cert upcharges, no card to begin.</p>
       <p class="pp-anchor">A single exam voucher costs more than <b>a full year of Pro</b>. Fail once and you pay for the voucher twice.</p>
     </div>
 
@@ -542,6 +542,7 @@
           <p class="pp-tagline">Try the engine. Build the habit. No card.</p>
           <ul class="pp-features">
             <li class="pp-feat"><svg viewBox="0 0 24 24" fill="none" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg><span><strong>15 questions + 5 review cards a day</strong>, one cert of your choice</span></li>
+            <li class="pp-feat"><svg viewBox="0 0 24 24" fill="none" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg><span><strong>1 Reword Gauntlet run a day</strong>, a bonus on top of your 15</span></li>
             <li class="pp-feat"><svg viewBox="0 0 24 24" fill="none" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg><span>Full Baseline Diagnostic + Pass Plan</span></li>
             <li class="pp-feat"><svg viewBox="0 0 24 24" fill="none" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg><span>Streak tracker + spaced-repetition review</span></li>
           </ul>

--- a/mockups/free-gauntlet-states.html
+++ b/mockups/free-gauntlet-states.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CertAnvil · Free Gauntlet entry states mockup</title>
+<style>
+  /* Tokens copied verbatim from mockups/reword-gauntlet.html (BRAND.md §3 / dg-system.css) */
+  :root, [data-theme="dark"] {
+    --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+    --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+    --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+    --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+    --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25);
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --page-bg: oklch(0.13 0.008 275); --page-ink: oklch(0.96 0.006 275); --page-dim: oklch(0.66 0.012 275);
+  }
+  [data-theme="light"] {
+    --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+    --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+    --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+    --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+    --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25);
+    --page-bg: oklch(0.94 0.008 85); --page-ink: oklch(0.22 0.015 280); --page-dim: oklch(0.50 0.013 280);
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: var(--page-bg); color: var(--page-ink); font: 400 14px/1.5 Inter, -apple-system, sans-serif; padding: 34px 22px 60px; -webkit-font-smoothing: antialiased; }
+
+  /* Focus-visible: keyboard users get a clear bronze ring; mouse/touch presses stay quiet. */
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+  :focus:not(:focus-visible) { outline: none; }
+
+  .stage-head { max-width: 1180px; margin: 0 auto 26px; }
+  .stage-eyebrow { font: 800 10.5px/1 Inter, sans-serif; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 9px; }
+  .stage-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 25px; letter-spacing: -0.012em; }
+  .stage-sub { color: var(--page-dim); font-size: 13px; margin-top: 8px; max-width: 76ch; line-height: 1.55; }
+  .stage-sub b { color: var(--page-ink); }
+  .theme-toggle { position: fixed; top: 22px; right: 22px; z-index: 50; background: var(--surface); color: var(--ink); border: 1px solid var(--border); border-radius: 999px; padding: 9px 14px; font: 650 12px/1 Inter, sans-serif; cursor: pointer; transition: transform 0.16s var(--ease-out), border-color 0.16s ease; }
+  .theme-toggle:active { transform: scale(0.96); }
+  @media (hover: hover) and (pointer: fine) { .theme-toggle:hover { border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); } }
+
+  .phones { display: flex; flex-wrap: wrap; gap: 30px; justify-content: center; max-width: 1900px; margin: 0 auto; }
+  .unit { width: 390px; }
+  .unit-label { display: inline-flex; align-items: baseline; gap: 8px; font: 700 11px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--page-dim); margin: 0 0 11px 6px; }
+  .unit-label .seq { font-variant-numeric: tabular-nums; color: var(--page-ink); }
+  .unit-note { font-size: 12px; color: var(--page-dim); line-height: 1.5; margin: 13px 6px 0; }
+  .unit-note b { color: var(--page-ink); }
+
+  .phone { width: 390px; border-radius: 46px; padding: 10px; background: #050505; box-shadow: 0 24px 70px -30px rgba(0,0,0,0.7); }
+  .screen { position: relative; border-radius: 38px; background: var(--bg); color: var(--ink); overflow: hidden; min-height: 720px; display: flex; flex-direction: column; }
+  .notch { position: absolute; top: 9px; left: 50%; transform: translateX(-50%); width: 112px; height: 26px; border-radius: 16px; background: #050505; z-index: 5; }
+  .statusbar { display: flex; justify-content: space-between; padding: 16px 26px 4px; font: 650 12.5px/1 Inter, sans-serif; }
+
+  .hdr { display: flex; align-items: center; justify-content: space-between; padding: 12px 18px 8px; }
+  .hdr h1 { font: 650 16px/1 Inter, sans-serif; letter-spacing: -0.01em; }
+  .hdr .back { display: inline-flex; align-items: center; justify-content: center; background: none; border: 0; border-radius: 10px; color: var(--ink-soft); width: 34px; height: 34px; cursor: pointer; transition: color 0.16s ease, background 0.16s ease, transform 0.16s var(--ease-out); }
+  .hdr .back:active { transform: scale(0.92); }
+  @media (hover: hover) and (pointer: fine) { .hdr .back:hover { color: var(--ink); background: var(--surface-2); } }
+  .hdr svg { width: 21px; height: 21px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+
+  .body { flex: 1; padding: 8px 22px 22px; display: flex; flex-direction: column; gap: 14px; }
+  .drills-lede { color: var(--muted); font-size: 12.5px; line-height: 1.5; }
+  .body-foot { margin-top: auto; }
+
+  /* atoms */
+  .pill { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.10em; text-transform: uppercase; color: var(--accent-deep); background: color-mix(in oklab, var(--accent) 14%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 32%, var(--border)); border-radius: 999px; padding: 4px 9px; display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+  .pill svg { width: 11px; height: 11px; stroke: currentColor; fill: none; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+  .pill.is-muted { color: var(--muted); background: var(--surface-2); border-color: var(--border); }
+  /* The payoff badge lands just after the Pro spine sweeps, so "Unlimited" reads as the reward arriving. */
+  .pill.is-pro { color: var(--on-accent); background: var(--accent); border-color: var(--accent); animation: pill-land 0.4s var(--ease-out) 0.46s both; }
+  @keyframes pill-land { from { opacity: 0; transform: scale(0.9); } to { opacity: 1; transform: scale(1); } }
+  .cta { width: 100%; border: 0; border-radius: 12px; padding: 14px; cursor: pointer; background: var(--accent); color: var(--on-accent); font: 700 14.5px/1 Inter, sans-serif; display: inline-flex; align-items: center; justify-content: center; gap: 8px; transition: transform 0.16s var(--ease-out), filter 0.16s ease, border-color 0.16s ease; }
+  .cta svg { width: 17px; height: 17px; stroke: currentColor; fill: none; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; transition: transform 0.18s var(--ease-out); }
+  /* Press feedback: whole button settles, then the arrow nudges forward to echo "go". */
+  .cta:active { transform: scale(0.97); }
+  .cta:active svg { transform: translateX(2px); }
+  .cta.is-pro { background: transparent; color: var(--accent-deep); border: 1px solid color-mix(in oklab, var(--accent) 42%, var(--border)); }
+  @media (hover: hover) and (pointer: fine) {
+    .cta:hover { filter: brightness(1.04); }
+    .cta.is-pro:hover { filter: none; border-color: color-mix(in oklab, var(--accent) 64%, var(--border)); background: color-mix(in oklab, var(--accent) 7%, transparent); }
+  }
+  .ghost { width: 100%; background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 13px; color: var(--ink); font: 600 13px/1 Inter, sans-serif; cursor: pointer; transition: transform 0.16s var(--ease-out), border-color 0.16s ease; }
+  .ghost:active { transform: scale(0.98); }
+
+  /* drills card (mirrors app .drills-card / .gnt-drills-hero) */
+  .drills-card { position: relative; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); padding: 18px; }
+  /* Card settles in on load. Staggered across the three units so they read A then B then C, the way a day unfolds. */
+  @keyframes card-rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+  .drills-card { animation: card-rise 0.5s var(--ease-out) both; }
+  .unit:nth-child(1) .drills-card { animation-delay: 0.04s; }
+  .unit:nth-child(2) .drills-card { animation-delay: 0.13s; }
+  .unit:nth-child(3) .drills-card { animation-delay: 0.22s; }
+  .drills-card.hero { border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); background: color-mix(in oklab, var(--accent) 5%, var(--surface)); }
+  /* State accent spine: a single top edge that colour-codes the state at a glance */
+  .drills-card.hero::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 3px; border-radius: 16px 16px 0 0; background: var(--accent); }
+  .drills-card.is-spent { background: var(--surface); border-color: var(--border-soft); }
+  .drills-card.is-spent::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 3px; border-radius: 16px 16px 0 0; background: var(--border); }
+  .drills-card.is-pro { border-color: color-mix(in oklab, var(--accent) 44%, var(--border)); background: color-mix(in oklab, var(--accent) 8%, var(--surface)); }
+  /* Pro spine sweeps the full width on arrival: the reward landing, not just sitting there. */
+  .drills-card.is-pro::before { background: var(--accent-deep); transform: scaleX(0); transform-origin: left center; animation: spine-sweep 0.55s var(--ease-out) 0.30s forwards; }
+  @keyframes spine-sweep { to { transform: scaleX(1); } }
+
+  .card-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 11px; }
+  .card-title { font: 650 17px/1.2 Inter, sans-serif; display: inline-flex; align-items: center; gap: 9px; }
+  .card-note { color: var(--ink-soft); font-size: 13px; line-height: 1.5; }
+  .card-foot { margin-top: 16px; }
+
+  /* rungs: makes "one concept, asked five ways" legible instead of a buried comma list */
+  .rungs { display: flex; gap: 6px; margin: 13px 0 2px; }
+  .rung { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 6px; }
+  .rung .dot { position: relative; width: 100%; height: 5px; border-radius: 999px; background: color-mix(in oklab, var(--accent) 38%, var(--surface-2)); overflow: hidden; }
+  /* The five rungs fill left-to-right on entry: it shows "one concept, asked five ways" as a ladder. */
+  .rung .dot::after { content: ""; position: absolute; inset: 0; border-radius: inherit; background: var(--accent); transform: scaleX(0); transform-origin: left center; }
+  .rung .lbl { font: 700 8.5px/1 Inter, sans-serif; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); }
+  .is-spent .rung .dot { background: var(--border); }
+  .is-spent .rung .lbl { color: color-mix(in oklab, var(--muted) 70%, var(--surface)); }
+  .is-pro .rung .dot { background: color-mix(in oklab, var(--accent) 55%, var(--surface-2)); }
+
+  /* Rung fill choreography. Available + Pro light up; spent stays quiet (no reward to replay). */
+  @keyframes rung-fill { to { transform: scaleX(1); } }
+  .drills-card.hero .rung .dot::after { background: var(--accent); }
+  .drills-card.is-pro .rung .dot::after { background: var(--accent-deep); }
+  .drills-card.hero .rung .dot::after,
+  .drills-card.is-pro .rung .dot::after { animation: rung-fill 0.42s var(--ease-out) forwards; }
+  .drills-card.hero .rung:nth-child(1) .dot::after, .drills-card.is-pro .rung:nth-child(1) .dot::after { animation-delay: 0.34s; }
+  .drills-card.hero .rung:nth-child(2) .dot::after, .drills-card.is-pro .rung:nth-child(2) .dot::after { animation-delay: 0.40s; }
+  .drills-card.hero .rung:nth-child(3) .dot::after, .drills-card.is-pro .rung:nth-child(3) .dot::after { animation-delay: 0.46s; }
+  .drills-card.hero .rung:nth-child(4) .dot::after, .drills-card.is-pro .rung:nth-child(4) .dot::after { animation-delay: 0.52s; }
+  .drills-card.hero .rung:nth-child(5) .dot::after, .drills-card.is-pro .rung:nth-child(5) .dot::after { animation-delay: 0.58s; }
+
+  /* the load-bearing product-truth line, promoted to a framed claim instead of a muted footnote */
+  .truth { display: flex; align-items: flex-start; gap: 9px; margin-top: 14px; padding: 11px 13px; border-radius: 11px; background: var(--surface-2); border: 1px solid var(--border-soft); }
+  /* The product-truth line settles in after the rungs finish filling, so it reads as the takeaway. */
+  .truth { animation: chip-settle 0.45s var(--ease-out) 0.62s both; }
+  .truth svg { width: 16px; height: 16px; stroke: var(--accent); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; flex: none; margin-top: 1px; }
+  .truth p { font: 600 12px/1.4 Inter, sans-serif; color: var(--ink-soft); }
+  .truth p b { color: var(--ink); font-weight: 700; }
+
+  .reset-chip { display: inline-flex; align-items: center; gap: 7px; font: 650 12px/1 Inter, sans-serif; color: var(--ink-soft); border: 1px solid var(--border-soft); border-radius: 999px; padding: 8px 13px; background: var(--surface-2); margin-top: 14px; }
+  .reset-chip svg { width: 13px; height: 13px; stroke: var(--muted); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  /* The reset chip settles in calmly, no pulse: it is information, not a countdown to act on. */
+  .reset-chip { animation: chip-settle 0.45s var(--ease-out) 0.30s both; }
+  @keyframes chip-settle { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+
+  /* upsell as a "locked door": Pro is the thing on the other side, not fake urgency */
+  .upsell { margin-top: 16px; border: 1px solid color-mix(in oklab, var(--accent) 26%, var(--border)); border-radius: 13px; background: color-mix(in oklab, var(--accent) 7%, var(--surface)); padding: 14px; }
+  /* The ask arrives last, once the run is felt as spent: it follows the chip, never races it. */
+  .body-foot { animation: card-rise 0.5s var(--ease-out) 0.5s both; }
+  .upsell-head { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
+  .upsell-head svg { width: 14px; height: 14px; stroke: var(--accent-deep); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; flex: none; }
+  .upsell-k { font: 800 10px/1 Inter, sans-serif; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); }
+  .upsell p { font-size: 12.5px; line-height: 1.5; color: var(--ink-soft); }
+
+  /* Reduced motion: drop every movement and the staged reveals. Keep gentle fades so nothing
+     pops in jarringly, and keep the press scale (it is feedback the finger expects, not decoration). */
+  @media (prefers-reduced-motion: reduce) {
+    .drills-card, .body-foot, .reset-chip, .truth {
+      animation: rm-fade 0.2s ease both;
+    }
+    .unit:nth-child(1) .drills-card, .unit:nth-child(2) .drills-card, .unit:nth-child(3) .drills-card,
+    .body-foot, .reset-chip, .truth { animation-delay: 0s; }
+    @keyframes rm-fade { from { opacity: 0; } to { opacity: 1; } }
+    /* Rungs and Pro spine simply rest in their filled state, no sweep. */
+    .drills-card.hero .rung .dot::after, .drills-card.is-pro .rung .dot::after,
+    .drills-card.is-pro::before { animation: none; transform: scaleX(1); }
+    .pill.is-pro { animation: rm-fade 0.2s ease both; }
+    .cta svg { transition: none; }
+    .cta:active svg { transform: none; }
+  }
+</style>
+</head>
+<body>
+  <button class="theme-toggle" onclick="document.documentElement.setAttribute('data-theme', document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark')">Toggle theme</button>
+
+  <div class="stage-head">
+    <p class="stage-eyebrow">Reword Gauntlet · Free tier</p>
+    <h1 class="stage-title">Your run, every day</h1>
+    <p class="stage-sub">The drills entry as a free user sees it across one day, and what a Pro sees. Your daily Gauntlet run is a <b>bonus on top of the 15 daily questions</b>, so running it never spends them. New users pick their own topic on the first run.</p>
+  </div>
+
+  <div class="phones">
+
+    <!-- STATE A: free, available today -->
+    <div class="unit">
+      <p class="unit-label"><span class="seq">A</span> Free · available today</p>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span>CertAnvil</span></div>
+        <div class="hdr"><button class="back"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg></button><h1>Drills</h1><span style="width:34px"></span></div>
+        <div class="body">
+          <p class="drills-lede">Quick passes that check whether a concept really stuck. Pick one and go.</p>
+          <div class="drills-card hero">
+            <div class="card-head">
+              <span class="card-title">Reword Gauntlet</span>
+              <span class="pill"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg>Yours today</span>
+            </div>
+            <p class="card-note">Today's run is yours. One concept, asked five ways. Crack all five and you own it in any wording.</p>
+            <div class="rungs">
+              <span class="rung"><span class="dot"></span><span class="lbl">Plain</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Scene</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Best</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Not</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Twist</span></span>
+            </div>
+            <div class="truth">
+              <svg viewBox="0 0 24 24"><path d="M12 2v20M2 12h20"/></svg>
+              <p>A <b>bonus</b> run, separate from your 15 daily questions. Running it never spends them.</p>
+            </div>
+            <div class="card-foot"><button class="cta"><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>Claim today's run</button></div>
+          </div>
+        </div>
+      </div></div>
+      <p class="unit-note"><b>Yours.</b> No Pro lock. "Yours today" and "claim" tell the user the run already belongs to them. They are picking up something they have, not earning their way past a paywall.</p>
+    </div>
+
+    <!-- STATE B: free, used today -->
+    <div class="unit">
+      <p class="unit-label"><span class="seq">B</span> Free · used today</p>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span>CertAnvil</span></div>
+        <div class="hdr"><button class="back"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg></button><h1>Drills</h1><span style="width:34px"></span></div>
+        <div class="body">
+          <p class="drills-lede">Quick passes that check whether a concept really stuck. Pick one and go.</p>
+          <div class="drills-card is-spent">
+            <div class="card-head">
+              <span class="card-title">Reword Gauntlet</span>
+              <span class="pill is-muted"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg>Done today</span>
+            </div>
+            <p class="card-note">Nice work, you cleared today's run. The next one is already lined up for you.</p>
+            <div class="rungs">
+              <span class="rung"><span class="dot"></span><span class="lbl">Plain</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Scene</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Best</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Not</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Twist</span></span>
+            </div>
+            <div class="reset-chip"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>Your next free run lands at midnight</div>
+          </div>
+          <div class="body-foot">
+            <div class="upsell">
+              <div class="upsell-head">
+                <svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+                <span class="upsell-k">On a roll?</span>
+              </div>
+              <p>Free is <b>1 run a day</b>. Pro makes it <b>unlimited</b> on every cert, so you can start the next one now instead of tomorrow.</p>
+            </div>
+            <div class="card-foot"><button class="cta is-pro">See Pro and skip the wait</button></div>
+          </div>
+        </div>
+      </div></div>
+      <p class="unit-note"><b>Spent.</b> A fixed midnight return, no ticking timer. The ask puts "1 a day" next to "unlimited" so Pro reads as relief from the wait. It only shows up after the run is done.</p>
+    </div>
+
+    <!-- STATE C: pro, unlimited -->
+    <div class="unit">
+      <p class="unit-label"><span class="seq">C</span> Pro · unlimited</p>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span>CertAnvil</span></div>
+        <div class="hdr"><button class="back"><svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg></button><h1>Drills</h1><span style="width:34px"></span></div>
+        <div class="body">
+          <p class="drills-lede">Quick passes that check whether a concept really stuck. Pick one and go.</p>
+          <div class="drills-card is-pro">
+            <div class="card-head">
+              <span class="card-title">Reword Gauntlet</span>
+              <span class="pill is-pro">Unlimited</span>
+            </div>
+            <p class="card-note">One concept, asked five ways. Crack all five and you own it in any wording.</p>
+            <div class="rungs">
+              <span class="rung"><span class="dot"></span><span class="lbl">Plain</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Scene</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Best</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Not</span></span>
+              <span class="rung"><span class="dot"></span><span class="lbl">Twist</span></span>
+            </div>
+            <div class="truth">
+              <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+              <p>Run it <b>as often as you like</b>, on any cert. Nothing counts down and nothing waits for midnight.</p>
+            </div>
+            <div class="card-foot"><button class="cta"><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>Run the Gauntlet</button></div>
+          </div>
+        </div>
+      </div></div>
+      <p class="unit-note"><b>Pro.</b> Same card, no counter. "Nothing waits for midnight" answers the exact wait the spent state complained about, so unlimited feels like the wait is over rather than a list of perks.</p>
+    </div>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## What & why

Reconciles the **"1 free Reword Gauntlet run a day"** model across the app and the landing site. Today the Gauntlet is **Pro-only** in code, so the free-tier promise didn't exist yet. This makes it real: the free tier gets **one Gauntlet run a day as a bonus that sits on top of the 15 daily questions** (it never spends them). Why-Not stays Pro-only.

Source of truth + full change spec: `docs/FREE-GAUNTLET-RECONCILE-SPEC-2026-06-15.md`.

## Changes

**App (`app.js`)**
- New `_gateGauntletDaily()` — free tier capped at 1 run/day, Pro/admin/anonymous uncapped. Mirrors the existing GAP-1 SR free-cap pattern (new `STORAGE.GAUNTLET_FREE_COUNT` `{date,count}` cell, `_gauntletFreeRunsToday()` / `_bumpGauntletFreeRun()`).
- `gauntletStart()` now gates via `_gateGauntletDaily()` (was the `_gateProOnly` Pro-gate). The free run is fetched **non-metered**, so it does not consume the 15-question quota, and the metered-quota gate is skipped for free tier.
- "That's today's free Gauntlet done" modal via `_showProOnlyUI`.
- Drills card: removed the now-incorrect **"Pro"** lock pill on the Gauntlet (Why-Not keeps its Pro pill).

**Landing**
- `pricing.html`: meta/og/twitter descriptions + free plan-card bullet now state the daily Gauntlet bonus.
- `index.html` FAQ: free includes 1 Gauntlet/day (separate from the 15); Why-Not + unlimited Gauntlet are Pro.

**Docs / mockup**
- `docs/FREE-GAUNTLET-RECONCILE-SPEC-2026-06-15.md` — canon + change spec.
- `mockups/free-gauntlet-states.html` — 3-state entry mockup (available / used today / Pro), built via design-taste → emil → marketing-psychology → humanizer passes.

## ⚠️ Review decisions (made a call on each — please confirm)

1. **Anonymous (BYOK) users can now run the Gauntlet uncapped.** Previously Pro-only blocked them; this allows them, consistent with how the SR cap treats anonymous self-payers. Confirm, or we gate anonymous too.
2. **Metering is client-side (Pattern A):** free runs are sent non-metered. The spec's Pattern B (server-side `_category:'gauntlet'` exemption in the AI proxy) is more robust and keeps the **global cost kill-switch** in play. Pattern A bypasses that kill-switch for the free run (bounded by the 1/day cap). Decide before ship — Pattern B touches `landing/api/ai/*` (also gated lane).
3. **Live drills-card badge not wired** — only the misleading Pro pill was removed. The dynamic "1 free today / done today / Pro" badge (per the mockup) is a recommended UI follow-up.
4. **Retry consumes the run** — a free near-miss retry the same day hits the "done today" modal. Cost-safe and defensible; soften-able if you'd rather allow same-concept retries.

## Test plan
- `node tests/uat.js` → **4134/4134 pass**.
- `node tests/tech-debt.js` → within limits.
- Landing pricing page renders the new free-tier bullet + consistent hero copy (verified in preview).
- **Gated-lane smoke test (do on the Vercel preview before merge):** sign in as a free user → run the Gauntlet once (works, no quota decrement) → run again same day (blocked by the "done today" modal) → confirm the 15-question quota is untouched → confirm Pro is still unlimited and Why-Not still Pro-gated.

## Notes
- **Gated lane** (tier/quota logic): merge after the preview smoke-test + green CI.
- **Version bump happens at ship** (`scripts/bump-version.js`), not in this branch.
- Copy + code ship together in this PR (the free messaging must not go live before the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
