### PR TITLE
CertAnvil rename — Phase 1A+1B: one deploy, retargeted smoke URLs

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -110,7 +110,7 @@ If CI didn't start, the GitHub→Vercel webhook missed the push — manual deplo
 
 Confirm prod is serving the new version (and `certanvil.com` landing too, if touched — separate Vercel project):
 ```bash
-curl -sS "https://networkplus-quiz-sable.vercel.app/?nocache=$(date +%s)" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1
+curl -sS "https://networkplus.certanvil.com/?nocache=$(date +%s)" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1
 ```
 If a live endpoint changed (`/api/notify`, AI, Stripe webhook), run a real request against prod — "logged-as-success-but-actually-broken" is the failure this catches.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
             }
 
   # ── JOB 4a: Deploy Network+ to production (main only) ──
-  # Customer-facing cert deploy — networkplus-quiz-sable.vercel.app
+  # Customer-facing deploy — one project serves all 7 cert subdomains on *.certanvil.com (smoke: networkplus.certanvil.com)
   deploy-production:
     name: Deploy to Production (Network+)
     needs: test
@@ -198,38 +198,6 @@ jobs:
         run: npm i -g vercel@latest
 
       - name: Build and deploy to production
-        run: |
-          vercel --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
-
-  # ── JOB 4b: Deploy Security+ to production (main only) ──
-  # v4.87.x: parallel deploy to the private Security+ cert at
-  # secplus-quiz-sable.vercel.app. Same code, different Vercel project.
-  # URL host detection in app.js picks up the 'secplus-' prefix and
-  # loads CERT_PACKS.secplus. Independent of Network+ deploy so a
-  # Security+-only failure doesn't block Network+ shipping.
-  #
-  # Project IDs are not secret (visible in URLs + CLI output) — only
-  # VERCEL_TOKEN is auth, so hardcoding the Security+ project ID
-  # avoids an extra repo-secret config step.
-  deploy-production-secplus:
-    name: Deploy to Production (Security+)
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: prj_CyuAuPobazxHgrHMYWR0em9gKJeU  # secplus-quiz-sable
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Install Vercel CLI
-        run: npm i -g vercel@latest
-
-      - name: Build and deploy to production (Security+)
         run: |
           vercel --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/vercel-incident-recovery.yml
+++ b/.github/workflows/vercel-incident-recovery.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      PROD_URL: https://networkplus-quiz-sable.vercel.app
+      PROD_URL: https://networkplus.certanvil.com
     steps:
       - uses: actions/checkout@v6
 

--- a/SHIP_CHECKLIST.md
+++ b/SHIP_CHECKLIST.md
@@ -236,7 +236,7 @@ npx vercel --prod --yes
 ### 6.2 Vercel deploy landed
 
 ```bash
-curl -sS "https://networkplus-quiz-sable.vercel.app/?nocache=$(date +%s)" \
+curl -sS "https://networkplus.certanvil.com/?nocache=$(date +%s)" \
   | grep -oE 'v4\.99\.[0-9]+' | head -1
 ```
 

--- a/landing/api/diagnostic/signup-magic-link.js
+++ b/landing/api/diagnostic/signup-magic-link.js
@@ -40,7 +40,7 @@ const IP_HASH_SALT = 'certanvil-diagnostic-salt-v1';
 const ALLOWED_CERTS = ['network-plus', 'security-plus'];
 const CERT_TO_CLAIM_HOST = {
   'network-plus': 'https://networkplus.certanvil.com',
-  'security-plus': 'https://secplus-quiz-sable.vercel.app',
+  'security-plus': 'https://secplus.certanvil.com',
 };
 
 function json(body, status = 200) {

--- a/tests/deploy-verify.js
+++ b/tests/deploy-verify.js
@@ -20,7 +20,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 const os = require('os');
 
-const PROD_URL = 'https://networkplus-quiz-sable.vercel.app';
+const PROD_URL = 'https://networkplus.certanvil.com';
 const REPO_ROOT = path.resolve(__dirname, '..');
 const TS = Date.now();
 

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -14047,13 +14047,16 @@ test('v4.87.0 SecplusContent: Messer URLs use SY0-701 query param',
 // · dynamic topic-chip rendering when CURRENT_CERT === 'secplus'.
 // ═══════════════════════════════════════════════════════════════════════
 
-// ── Auto-deploy: GitHub Actions has parallel Security+ deploy job ──
+// ── Auto-deploy: single GitHub Actions production deploy (main project) ──
+// 2026-06-27 CertAnvil consolidation: the redundant Security+ parallel deploy
+// (Job 4b → secplus-quiz-sable) was REMOVED. secplus.certanvil.com is served by
+// the main project via the Network+ deploy. The two tombstones keep it gone.
 test('v4.87.1 AutoDeploy: ci.yml has Network+ deploy-production job',
   /deploy-production:[\s\S]{0,200}Deploy to Production \(Network\+\)/.test(require('fs').readFileSync('.github/workflows/ci.yml', 'utf8')));
-test('v4.87.1 AutoDeploy: ci.yml has Security+ deploy-production-secplus job',
-  /deploy-production-secplus:[\s\S]{0,200}Deploy to Production \(Security\+\)/.test(require('fs').readFileSync('.github/workflows/ci.yml', 'utf8')));
-test('v4.87.1 AutoDeploy: Security+ deploy uses correct project ID',
-  require('fs').readFileSync('.github/workflows/ci.yml', 'utf8').includes('prj_CyuAuPobazxHgrHMYWR0em9gKJeU'));
+test('Consolidation tombstone: ci.yml has NO redundant Security+ deploy job',
+  !/deploy-production-secplus:/.test(require('fs').readFileSync('.github/workflows/ci.yml', 'utf8')));
+test('Consolidation tombstone: ci.yml does NOT hardcode the retired secplus-quiz-sable project ID',
+  !require('fs').readFileSync('.github/workflows/ci.yml', 'utf8').includes('prj_CyuAuPobazxHgrHMYWR0em9gKJeU'));
 
 // ── Carry-over exemplars in Security+ pack ──
 // v4.88.3: total exemplar count grows with each Phase 3 Cycle. Pin the


### PR DESCRIPTION
**Phase 1A + 1B** of the CertAnvil rename + Vercel cleanup ([plan](docs/superpowers/plans/2026-06-27-certanvil-rename-and-vercel-cleanup.md), on the `docs/phase-g-monetization-plans` branch).

This is the **code-prep** half (assistant). The dashboard actions (rename project, delete the 2 projects) come **after** this is green, per the execution split.

## What this does
- **Removes the redundant Security+ deploy (Job 4b)** — CI was double-deploying the same code to `secplus-quiz-sable`. Now: one deploy, one project, all 7 cert subdomains. `secplus.certanvil.com` is served by the main project (Job 4a), unchanged.
- **Retargets smoke/PROD URLs** off the soon-to-change `*-sable.vercel.app` auto-alias → stable `networkplus.certanvil.com` (`tests/deploy-verify.js`, `vercel-incident-recovery.yml`, ship runbook, `SHIP_CHECKLIST.md`).

## Live dependencies execution surfaced (not in the original static plan)
- `tests/uat.js` — the two Security+ deploy assertions are now **stay-gone tombstones** (the removed job/project-id would otherwise fail UAT).
- `landing/api/diagnostic/signup-magic-link.js` — Security+ signup redirect moved from `secplus-quiz-sable.vercel.app` → `secplus.certanvil.com`. **This is a live path** that would break once the project is deleted.

## Safety
- No production behaviour change — the main project already serves all 7 subdomains.
- Local: **UAT 4160/4160 pass**, tech-debt within limits.
- Nothing depends on Job 4b (`needs:` graph checked).

## Next (after this is green)
1. 🖱️ Rename Vercel project `networkplus-quiz` → `certanvil-app`
2. 🖱️ Delete `secplus-quiz-sable` + `network-plus-quiz`
3. Repo rename, in-repo identity, local folder rename (Phases 2–4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)