### PR TITLE
Sim Lab PBQ archetypes: Diagram, Incident Response, Defense in Depth (v7.61.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,9 +115,9 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.60.4 | Sim Lab: layered defense-in-depth reference renderer (nested-frames SVG + CSS; Task 8) |
 | v7.60.3 | Sim Lab: attack-timeline reference renderer (data-driven vertical timeline + CSS; Task 7) |
 | v7.60.2 | Sim Lab: network PBQ reference renderer (data-driven SVG diagram + incident overlay; Task 6) |
-| v7.60.1 | Sim Lab configure step: forged-bronze dropdown styling (dg-system.css Task 4) |
 
 _Older releases (v7.55.0 and back) live in [CHANGELOG.md](./CHANGELOG.md) — v7.55.0 + v7.54.1 + v7.54.0 ported during the 2026-06-25 v7.56.0 night-end consolidation (Sim Lab session-mode marathon)._
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ Dark theme in `:root`, light theme in `[data-theme="light"]`. Key variables: `--
 - `hasAnswer` checks must include `Object.keys(a.topoState || {}).length > 0`
 - `setQuestionText(el, raw)` order is **escape-THEN-highlight** (`escHtml` → `highlightExamKeywords` → `innerHTML`). Reversing it is an XSS hole since question text is AI-generated.
 - The `_fnBody(src, name)` helper used by UAT extracts function bodies via brace-depth walking. **Prefix-match trap**: `tbShowCoach` will match `tbShowCoachModalLoading`. When writing UAT for a function, pick a name that's either unique or specify the exact suffix.
+- Sim Lab `layered` references support an optional `layout: 'nested' | 'stacked'` field (default `'nested'`); `_slRenderReference` dispatches on it — Sec+ Defense in Depth uses `'stacked'` (perimeter + interior bands + exposed core), Net+ keeps `'nested'` (concentric frames).
 
 **Testing**
 - Don't tune `validateQuestions()` without running `node tests/validation-audit.js` first — the `MIN_CATCH_RATE = 60` / `MAX_FP_RATE = 0` floor is CI-enforced inside UAT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Dark theme in `:root`, light theme in `[data-theme="light"]`. Key variables: `--
 - `setQuestionText(el, raw)` order is **escape-THEN-highlight** (`escHtml` → `highlightExamKeywords` → `innerHTML`). Reversing it is an XSS hole since question text is AI-generated.
 - The `_fnBody(src, name)` helper used by UAT extracts function bodies via brace-depth walking. **Prefix-match trap**: `tbShowCoach` will match `tbShowCoachModalLoading`. When writing UAT for a function, pick a name that's either unique or specify the exact suffix.
 - Sim Lab `layered` references support an optional `layout: 'nested' | 'stacked'` field (default `'nested'`); `_slRenderReference` dispatches on it — Sec+ Defense in Depth uses `'stacked'` (perimeter + interior bands + exposed core), Net+ keeps `'nested'` (concentric frames).
+- The stacked layout's perimeter layer (`layers[0]`) supports an optional `device: { label }` field (e.g. `'FW-1'`, `'WAF-1'`) rendered as a decorative device box (`.sl-fw`) top-right inside the perimeter frame; absent = no extra markup, fully backward-compatible.
 
 **Testing**
 - Don't tune `validateQuestions()` without running `node tests/validation-audit.js` first — the `MIN_CATCH_RATE = 60` / `MAX_FP_RATE = 0` floor is CI-enforced inside UAT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,9 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.60.3 | Sim Lab: attack-timeline reference renderer (data-driven vertical timeline + CSS; Task 7) |
 | v7.60.2 | Sim Lab: network PBQ reference renderer (data-driven SVG diagram + incident overlay; Task 6) |
 | v7.60.1 | Sim Lab configure step: forged-bronze dropdown styling (dg-system.css Task 4) |
-| v7.60.0 | Per-cert milestones + 12 drill milestones (Sim Lab/Decision Lab/Why-Not/Gauntlet) + orphan cleanup + bronze celebration toast |
-| v7.59.0 | Decision Lab: cloud-cert scenario decision drill (engine + 4 seed banks) |
 
 _Older releases (v7.55.0 and back) live in [CHANGELOG.md](./CHANGELOG.md) — v7.55.0 + v7.54.1 + v7.54.0 ported during the 2026-06-25 v7.56.0 night-end consolidation (Sim Lab session-mode marathon)._
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,12 +115,11 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
-| v7.60.5 | Sim Lab: fix undefined --fail token → --red in reference renderers (live-verify Task 18) |
-| v7.60.4 | Sim Lab: layered defense-in-depth reference renderer (nested-frames SVG + CSS; Task 8) |
-| v7.60.3 | Sim Lab: attack-timeline reference renderer (data-driven vertical timeline + CSS; Task 7) |
-| v7.60.2 | Sim Lab: network PBQ reference renderer (data-driven SVG diagram + incident overlay; Task 6) |
+| v7.61.0 | Sim Lab PBQ archetypes: Diagram, Incident Response, Defense in Depth |
+| v7.60.0 | Per-cert milestones + 12 drill milestones (Sim Lab/Decision Lab/Why-Not/Gauntlet) + orphan cleanup + bronze celebration toast |
+| v7.59.0 | Decision Lab: cloud-cert scenario decision drill (engine + 4 seed banks) |
 
-_Older releases (v7.55.0 and back) live in [CHANGELOG.md](./CHANGELOG.md) — v7.55.0 + v7.54.1 + v7.54.0 ported during the 2026-06-25 v7.56.0 night-end consolidation (Sim Lab session-mode marathon)._
+_Older releases (v7.58.0 and back) live in [CHANGELOG.md](./CHANGELOG.md). The v7.60.1–v7.60.5 CSS `?v=` cache-bump stubs from the PBQ-archetypes build were collapsed into this single v7.61.0 ship at consolidation._
 
 ## CSS Theme System
 Dark theme in `:root`, light theme in `[data-theme="light"]`. Key variables: `--bg`, `--surface`, `--accent`, `--text`, `--green`, `--red`, `--yellow`. Toggle via `toggleTheme()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.60.5 | Sim Lab: fix undefined --fail token → --red in reference renderers (live-verify Task 18) |
 | v7.60.4 | Sim Lab: layered defense-in-depth reference renderer (nested-frames SVG + CSS; Task 8) |
 | v7.60.3 | Sim Lab: attack-timeline reference renderer (data-driven vertical timeline + CSS; Task 7) |
 | v7.60.2 | Sim Lab: network PBQ reference renderer (data-driven SVG diagram + incident overlay; Task 6) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,10 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.60.2 | Sim Lab: network PBQ reference renderer (data-driven SVG diagram + incident overlay; Task 6) |
 | v7.60.1 | Sim Lab configure step: forged-bronze dropdown styling (dg-system.css Task 4) |
 | v7.60.0 | Per-cert milestones + 12 drill milestones (Sim Lab/Decision Lab/Why-Not/Gauntlet) + orphan cleanup + bronze celebration toast |
 | v7.59.0 | Decision Lab: cloud-cert scenario decision drill (engine + 4 seed banks) |
-| v7.58.0 | Sim Lab: A+ Core 1 (220-1201) + Core 2 (220-1202) PBQ seed banks live (cert rollout) |
 
 _Older releases (v7.55.0 and back) live in [CHANGELOG.md](./CHANGELOG.md) — v7.55.0 + v7.54.1 + v7.54.0 ported during the 2026-06-25 v7.56.0 night-end consolidation (Sim Lab session-mode marathon)._
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.60.1 | Sim Lab configure step: forged-bronze dropdown styling (dg-system.css Task 4) |
 | v7.60.0 | Per-cert milestones + 12 drill milestones (Sim Lab/Decision Lab/Why-Not/Gauntlet) + orphan cleanup + bronze celebration toast |
 | v7.59.0 | Decision Lab: cloud-cert scenario decision drill (engine + 4 seed banks) |
 | v7.58.0 | Sim Lab: A+ Core 1 (220-1201) + Core 2 (220-1202) PBQ seed banks live (cert rollout) |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,48 @@
+# CertAnvil — Domain Glossary
+
+Canonical language for the CertAnvil cert-study app. This file is a glossary only — no implementation detail. Add terms as they are resolved in design discussions.
+
+## Drills & PBQs
+
+**Sim Lab**:
+The PBQ (Performance-Based Question) drill — an engine of AI-generated multi-step "scenarios" covering several interaction types, in Practice and Exam modes. The home for all PBQ practice.
+_Avoid_: "the sim", "PBQ drill" (use Sim Lab)
+
+**Decision Lab**:
+The cloud-cert scenario decision drill. Still live in prod.
+
+**Diagram PBQ** _(provisional name — concept under design 2026-06-30)_:
+A Sim Lab PBQ where the candidate reads a **static, given** network diagram and answers **entirely by selection** (dropdowns) — never by dragging devices, drawing cables, or typing CLI. Has two answer phases: a **Diagnose** phase (identify the misconfiguration) and a **Reconfigure** phase (choose the correct configuration per device). The CLI / Network ID / subnet mask shown are read-only reference, not a live terminal.
+_Avoid_: "topology builder" (removed drill), "network sim", "CLI sim"
+
+**Diagnose phase**:
+The step of a Diagram PBQ where the candidate identifies what is *wrong* with the shown network by selecting from option(s).
+
+**Reconfigure phase**:
+The step of a Diagram PBQ where the candidate selects the *correct* configuration for each relevant device from per-device options.
+
+**Network model**:
+The structured JSON description of a Diagram PBQ's network (devices, VLAN/zone assignments, given IPs/masks/gateways, links). The visual diagram is **rendered from** this model, so the diagram cannot disagree with the data.
+
+**Fidelity validator**:
+Deterministic code (subnetting/CIDR/VLAN math + best-practice rules) that checks a Network model is logically sound — the flagged misconfiguration is real, and the "correct" answer actually fixes it — *before* a scenario reaches a candidate. The safeguard that makes AI-drafted scenarios trustworthy.
+
+**Configure step**:
+A Sim Lab step type of N labelled slots, each with its own dropdown of options and its own correct answer. One slot = the Diagnose phase ("what's wrong?"); N slots = the Reconfigure phase (one dropdown per device). The shared new interaction type for both Diagram and Incident Response PBQs.
+
+**Incident Response PBQ** _(Security+ application of the same engine — concept under design 2026-06-30)_:
+A Sim Lab PBQ for IR/recovery. Reference is **visual**: an **Attack timeline** and/or the **Network model rendered "under attack"** (compromised/affected device states + attacker-path arrows — same renderer as Diagram PBQ, different state). Answered with the existing `order` step (sequence the response) + `configure` step (correct action per phase) + optional `analyze` (spot the clue). No new interaction type.
+
+**Attack timeline**:
+The signature visual IR reference — a rendered horizontal strip of attack stages (icon + label + severity), e.g. phishing → malware → lateral movement → exfiltration. The IR analog of the network diagram.
+
+**Defense in Depth PBQ** _(third archetype on the same engine — Net+ AND Sec+, concept approved 2026-06-30)_:
+A Sim Lab PBQ where the candidate reads a **layered-defense diagram** (the `layered` reference: nested frames = layers around the core, with missing/weak layers flagged), then **diagnoses** the gap and **adds the correct control at each layer** by dropdown. Reuses `diagnose` + `configure` (no new interaction type). Net+ = network-layer focused (DMZ, segmentation, IDS/IPS); Sec+ = deeper (endpoint/data/identity layers + a control-type classification). Doctrine-curated like the IR PBQ.
+
+**Network model (shared visual)**:
+The structured network is used by BOTH certs — Net+ renders it to *fix a misconfig*; Sec+ renders it *mid-attack* (incident overlay) to *respond*. One renderer, different state.
+
+## Removed (tombstones — do not reintroduce as live without explicit decision)
+
+**Topology Builder** · **Subnet Trainer** · **ACL PBQ**:
+Former standalone drills, removed from prod. Some orphaned code/markup may remain (e.g. `page-acl-pbq`, `submitTopology()`); these are dead, not live features.

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.60.0
+// Network+ AI Quiz — app.js  v7.61.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.60.0';
+const APP_VERSION = '7.61.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/dg-system.css
+++ b/dg-system.css
@@ -4333,3 +4333,24 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 #page-sim-lab .sl-net-row .k,#page-decision-lab .sl-net-row .k{color:var(--text-dim);font-weight:700;min-width:86px}
 #page-sim-lab .sl-net-row .v,#page-decision-lab .sl-net-row .v{font-family:ui-monospace,Menlo,monospace;color:var(--text);font-size:12px}
 #page-sim-lab .sl-net-cli,#page-decision-lab .sl-net-cli{margin:0 8px 8px;background:color-mix(in oklab,var(--text) 5%,var(--surface));border:1px solid var(--border);border-radius:11px;padding:11px 13px;font-family:ui-monospace,Menlo,monospace;font-size:11.5px;line-height:1.6;color:var(--text-mid);white-space:pre-wrap;word-break:break-word}
+
+/* ── Sim Lab: attack-timeline reference renderer (Task 7) ──────────────────
+   Vertical timeline: each .sl-stage row = left rail (.sl-dot + .sl-line) +
+   right body (.sl-when / .sl-what / .sl-sevtag). severity drives --sev token.
+   .sev-med uses --yellow (same precedent as .sl-clock .is-low, Task 6).
+   Scoped to #page-sim-lab + #page-decision-lab; 0 hardcoded hex. */
+#page-sim-lab .sl-timeline,#page-decision-lab .sl-timeline{display:grid;gap:0;padding:16px 16px 6px}
+#page-sim-lab .sl-stage,#page-decision-lab .sl-stage{display:grid;grid-template-columns:22px 1fr;gap:12px}
+#page-sim-lab .sl-rail,#page-decision-lab .sl-rail{display:flex;flex-direction:column;align-items:center}
+#page-sim-lab .sl-dot,#page-decision-lab .sl-dot{width:13px;height:13px;border-radius:999px;margin-top:3px;flex-shrink:0;background:var(--sev,var(--muted));box-shadow:0 0 0 3px color-mix(in oklab,var(--sev,var(--muted)) 22%,transparent)}
+#page-sim-lab .sl-line,#page-decision-lab .sl-line{flex:1;width:2px;background:color-mix(in oklab,var(--sev,var(--muted)) 28%,var(--border));min-height:18px;margin:3px 0}
+#page-sim-lab .sl-body,#page-decision-lab .sl-body{padding-bottom:18px;min-width:0}
+#page-sim-lab .sl-when,#page-decision-lab .sl-when{font:700 11px ui-monospace,Menlo,monospace;color:var(--text-dim);margin-bottom:3px}
+#page-sim-lab .sl-what,#page-decision-lab .sl-what{font-size:13px;line-height:1.45;color:var(--text);margin-bottom:6px}
+#page-sim-lab .sl-sevtag,#page-decision-lab .sl-sevtag{display:inline-block;font-size:10px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:var(--sev,var(--muted));background:color-mix(in oklab,var(--sev,var(--muted)) 12%,transparent);border:1px solid color-mix(in oklab,var(--sev,var(--muted)) 30%,var(--border));border-radius:999px;padding:2px 8px}
+
+/* severity → --sev token (--yellow for med: no --warn in dg-system.css) */
+#page-sim-lab .sev-low,#page-decision-lab .sev-low{--sev:var(--muted)}
+#page-sim-lab .sev-med,#page-decision-lab .sev-med{--sev:var(--yellow)}
+#page-sim-lab .sev-high,#page-decision-lab .sev-high{--sev:color-mix(in oklab,var(--fail) 80%,var(--yellow))}
+#page-sim-lab .sev-crit,#page-decision-lab .sev-crit{--sev:var(--fail)}

--- a/dg-system.css
+++ b/dg-system.css
@@ -4393,3 +4393,33 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 /* device node labels */
 #page-sim-lab .sl-dev-nm,#page-decision-lab .sl-dev-nm{font:700 10.5px Inter,sans-serif;fill:var(--text);text-anchor:middle}
 #page-sim-lab .sl-dev-nm-exp,#page-decision-lab .sl-dev-nm-exp{fill:var(--red)}
+
+/* ── Sim Lab: layered defense-in-depth "stacked-bands" reference renderer ──
+   Faithful lift of mockups/defense-in-depth-secplus-concept.html (~lines
+   63-85 CSS / 188-209 SVG). Layout: a strong PERIMETER frame + a vertical
+   stack of horizontal interior BANDS + an exposed/safe CORE band with
+   device boxes. Reuses .sl-core/.sl-core-exposed/.sl-dev-box*/.sl-dev-nm*
+   from the nested renderer above (same core semantics). Present = accent
+   solid; missing/exposed = --red dashed/solid. Tokens only, 0 hardcoded
+   hex. Scoped to #page-sim-lab + #page-decision-lab. */
+#page-sim-lab .sl-stacked,#page-decision-lab .sl-stacked{padding:8px}
+
+/* perimeter frame: present */
+#page-sim-lab .sl-perim,#page-decision-lab .sl-perim{fill:color-mix(in oklab,var(--accent) 5%,transparent);stroke:color-mix(in oklab,var(--accent) 55%,var(--border));stroke-width:1.4}
+/* perimeter frame: missing */
+#page-sim-lab .sl-perim-missing,#page-decision-lab .sl-perim-missing{fill:color-mix(in oklab,var(--red) 5%,transparent);stroke:var(--red);stroke-width:1.5;stroke-dasharray:6 5}
+
+/* perimeter labels */
+#page-sim-lab .sl-perim-lbl,#page-decision-lab .sl-perim-lbl{font:800 10.5px Inter,sans-serif;letter-spacing:.1em;text-transform:uppercase;fill:var(--accent)}
+#page-sim-lab .sl-perim-lbl-miss,#page-decision-lab .sl-perim-lbl-miss{fill:var(--red)}
+#page-sim-lab .sl-perim-sub,#page-decision-lab .sl-perim-sub{font:600 10.5px ui-monospace,Menlo,monospace;fill:var(--text-mid)}
+
+/* interior band: present */
+#page-sim-lab .sl-band,#page-decision-lab .sl-band{fill:color-mix(in oklab,var(--accent) 6%,transparent);stroke:color-mix(in oklab,var(--accent) 50%,var(--border));stroke-width:1.4}
+/* interior band: missing */
+#page-sim-lab .sl-band-missing,#page-decision-lab .sl-band-missing{fill:color-mix(in oklab,var(--red) 5%,transparent);stroke:var(--red);stroke-width:1.5;stroke-dasharray:6 5}
+
+/* band labels */
+#page-sim-lab .sl-band-lbl,#page-decision-lab .sl-band-lbl{font:800 10.5px Inter,sans-serif;letter-spacing:.06em;text-transform:uppercase;fill:var(--text)}
+#page-sim-lab .sl-band-lbl-miss,#page-decision-lab .sl-band-lbl-miss{fill:var(--red)}
+#page-sim-lab .sl-band-sub,#page-decision-lab .sl-band-sub{font:600 9.5px ui-monospace,Menlo,monospace;fill:var(--text-dim)}

--- a/dg-system.css
+++ b/dg-system.css
@@ -4423,3 +4423,11 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 #page-sim-lab .sl-band-lbl,#page-decision-lab .sl-band-lbl{font:800 10.5px Inter,sans-serif;letter-spacing:.06em;text-transform:uppercase;fill:var(--text)}
 #page-sim-lab .sl-band-lbl-miss,#page-decision-lab .sl-band-lbl-miss{fill:var(--red)}
 #page-sim-lab .sl-band-sub,#page-decision-lab .sl-band-sub{font:600 9.5px ui-monospace,Menlo,monospace;fill:var(--text-dim)}
+
+/* perimeter device box (FW-1, WAF-1, ...) — faithful lift of the mockup's
+   .fw device box (~lines 79-81, 194): surface box, border stroke, accent
+   glyph, text label. Optional — only rendered when layers[0].device.label
+   is present on a stacked-layout scenario. Tokens only, 0 hardcoded hex. */
+#page-sim-lab .sl-fw-box,#page-decision-lab .sl-fw-box{fill:var(--surface);stroke:var(--border);stroke-width:1.2}
+#page-sim-lab .sl-fw-nm,#page-decision-lab .sl-fw-nm{font:700 11px Inter,sans-serif;fill:var(--text);text-anchor:middle}
+#page-sim-lab .sl-fw-glyph,#page-decision-lab .sl-fw-glyph{stroke:var(--accent);stroke-width:1.7;fill:none}

--- a/dg-system.css
+++ b/dg-system.css
@@ -4354,3 +4354,42 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 #page-sim-lab .sev-med,#page-decision-lab .sev-med{--sev:var(--yellow)}
 #page-sim-lab .sev-high,#page-decision-lab .sev-high{--sev:color-mix(in oklab,var(--fail) 80%,var(--yellow))}
 #page-sim-lab .sev-crit,#page-decision-lab .sev-crit{--sev:var(--fail)}
+
+/* ── Sim Lab: layered defense-in-depth reference renderer (Task 8) ────────
+   Nested-frames SVG layout. Layers ordered outer→inner; each frame is either
+   present (.sl-layer, accent stroke) or missing (.sl-misslayer, red dashed).
+   Core is .sl-core (safe) or .sl-core-exposed (any asset exposed = red fill).
+   Device nodes inside core: .sl-dev (normal) or .sl-dev.exposed (red).
+   Lifted from mockups/defense-in-depth-{netplus,secplus}-concept.html; tokens
+   only, 0 hardcoded hex. --fail = red/missing/exposed; --accent = present. */
+#page-sim-lab .sl-layered,#page-decision-lab .sl-layered{padding:8px}
+#page-sim-lab .sl-layered-svg,#page-decision-lab .sl-layered-svg{width:100%;height:auto;display:block;touch-action:pan-x pan-y pinch-zoom}
+
+/* present layer frame */
+#page-sim-lab .sl-layer,#page-decision-lab .sl-layer{fill:color-mix(in oklab,var(--accent) 6%,transparent);stroke:color-mix(in oklab,var(--accent) 50%,var(--border));stroke-width:1.4}
+
+/* missing layer frame — red dashed */
+#page-sim-lab .sl-misslayer,#page-decision-lab .sl-misslayer{fill:color-mix(in oklab,var(--fail) 5%,transparent);stroke:var(--fail);stroke-width:1.5;stroke-dasharray:6 5}
+
+/* layer labels */
+#page-sim-lab .sl-layer-lbl,#page-decision-lab .sl-layer-lbl{font:700 11px Inter,sans-serif;fill:var(--text-mid)}
+#page-sim-lab .sl-layer-lbl-miss,#page-decision-lab .sl-layer-lbl-miss{fill:var(--fail)}
+#page-sim-lab .sl-misslayer-tag,#page-decision-lab .sl-misslayer-tag{font-weight:400;font-size:10px;opacity:.85}
+
+/* core: safe */
+#page-sim-lab .sl-core,#page-decision-lab .sl-core{fill:color-mix(in oklab,var(--accent) 10%,transparent);stroke:color-mix(in oklab,var(--accent) 40%,var(--border));stroke-width:1.4}
+/* core: exposed (one or more assets are exposed) */
+#page-sim-lab .sl-core-exposed,#page-decision-lab .sl-core-exposed{fill:color-mix(in oklab,var(--fail) 9%,transparent);stroke:var(--fail);stroke-width:1.7}
+
+/* core labels */
+#page-sim-lab .sl-core-lbl,#page-decision-lab .sl-core-lbl{font:700 11px Inter,sans-serif;fill:var(--text-mid)}
+#page-sim-lab .sl-core-lbl-exp,#page-decision-lab .sl-core-lbl-exp{fill:var(--fail)}
+
+/* device node box (safe) */
+#page-sim-lab .sl-dev-box,#page-decision-lab .sl-dev-box{fill:var(--surface);stroke:var(--border);stroke-width:1.2}
+/* device node box (exposed) */
+#page-sim-lab .sl-dev-box-exp,#page-decision-lab .sl-dev-box-exp{stroke:var(--fail);stroke-width:1.8}
+
+/* device node labels */
+#page-sim-lab .sl-dev-nm,#page-decision-lab .sl-dev-nm{font:700 10.5px Inter,sans-serif;fill:var(--text);text-anchor:middle}
+#page-sim-lab .sl-dev-nm-exp,#page-decision-lab .sl-dev-nm-exp{fill:var(--fail)}

--- a/dg-system.css
+++ b/dg-system.css
@@ -4092,6 +4092,16 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 #page-sim-lab-result .slp-pr-val.over{color:var(--yellow,var(--warn))}
 #page-sim-lab-result .slp-pr-val.under{color:var(--green,var(--pass))}
 @media (prefers-reduced-motion:reduce){#page-sim-lab-result .slp-par-fill,#page-sim-lab-result .slp-pr-bar i{transition:none;transform:scaleX(1)}}
+/* Sim Lab session: configure step dropdowns (Task 4) - grading task toggles .is-correct/.is-wrong on .sl-cfg-select */
+#page-sim-lab .sl-cfg{display:grid;gap:13px}
+#page-sim-lab .sl-cfg-slot{display:grid;gap:6px}
+#page-sim-lab .sl-cfg-label{font:700 12px/1 Inter,sans-serif;color:var(--text-dim)}
+#page-sim-lab .sl-cfg-select{width:100%;appearance:none;-webkit-appearance:none;font:inherit;font-size:13.5px;font-weight:600;color:var(--text);background:var(--surface2);border:1px solid var(--border);border-radius:10px;padding:11px 38px 11px 13px;cursor:pointer;transition:border-color .18s var(--ease),box-shadow .18s var(--ease);background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpolyline points='2,3 5,7 8,3' fill='none' stroke='%23888' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 13px center}
+#page-sim-lab .sl-cfg-select:focus{outline:none;border-color:color-mix(in oklab,var(--accent) 55%,var(--border));box-shadow:0 0 0 3px color-mix(in oklab,var(--accent) 18%,transparent)}
+#page-sim-lab .sl-cfg-select.is-correct{border-color:color-mix(in oklab,var(--pass) 60%,var(--border));box-shadow:0 0 0 3px color-mix(in oklab,var(--pass) 15%,transparent)}
+#page-sim-lab .sl-cfg-select.is-wrong{border-color:color-mix(in oklab,var(--fail) 60%,var(--border));box-shadow:0 0 0 3px color-mix(in oklab,var(--fail) 14%,transparent)}
+@media (hover:hover) and (pointer:fine){#page-sim-lab .sl-cfg-select:hover{border-color:color-mix(in oklab,var(--accent) 30%,var(--border))}}
+@media (prefers-reduced-motion:reduce){#page-sim-lab .sl-cfg-select{transition:none}}
 /* Decision Lab: per-option why reveal + teach block (Task 2) — v7.59.0 */
 #page-decision-lab .dl-opt .dl-why{font:500 12.5px/1.45 Inter,sans-serif;color:var(--text-dim);margin-top:4px;display:grid;grid-template-rows:0fr;opacity:0;overflow:hidden;transition:grid-template-rows .16s var(--ease,cubic-bezier(.16,1,.3,1)),opacity .16s,transform .16s;transform:translateY(2px)}
 #page-decision-lab .dl-graded .dl-opt .dl-why{grid-template-rows:1fr;opacity:1;transform:none}

--- a/dg-system.css
+++ b/dg-system.css
@@ -3984,7 +3984,7 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 #page-sim-lab-result .sls-r{display:flex;align-items:center;gap:12px;padding:13px 2px;border-bottom:1px solid var(--border-soft,var(--border))}
 #page-sim-lab-result .sls-r-ic{width:22px;height:22px;border-radius:50%;display:grid;place-items:center;font:800 12px/1 Inter,sans-serif;flex:none}
 #page-sim-lab-result .sls-r-ic.ok{color:var(--green,var(--pass));background:color-mix(in oklab,var(--green,var(--pass)) 14%,transparent)}
-#page-sim-lab-result .sls-r-ic.no{color:var(--red,var(--fail));background:color-mix(in oklab,var(--red,var(--fail)) 14%,transparent)}
+#page-sim-lab-result .sls-r-ic.no{color:var(--red,var(--red));background:color-mix(in oklab,var(--red,var(--red)) 14%,transparent)}
 #page-sim-lab-result .sls-r-body{flex:1;min-width:0}
 #page-sim-lab-result .sls-r-title{font:600 14px/1.3 Inter,sans-serif;color:var(--text)}
 #page-sim-lab-result .sls-r-why{font:400 12.5px/1.4 Inter,sans-serif;color:var(--text-dim);margin-top:2px}
@@ -4099,7 +4099,7 @@ mark.gnt-hinge{background:color-mix(in oklab,var(--red) 26%,transparent);color:i
 #page-sim-lab .sl-cfg-select{width:100%;appearance:none;-webkit-appearance:none;font:inherit;font-size:13.5px;font-weight:600;color:var(--text);background:var(--surface2);border:1px solid var(--border);border-radius:10px;padding:11px 38px 11px 13px;cursor:pointer;transition:border-color .18s var(--ease),box-shadow .18s var(--ease);background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpolyline points='2,3 5,7 8,3' fill='none' stroke='%23888' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 13px center}
 #page-sim-lab .sl-cfg-select:focus{outline:none;border-color:color-mix(in oklab,var(--accent) 55%,var(--border));box-shadow:0 0 0 3px color-mix(in oklab,var(--accent) 18%,transparent)}
 #page-sim-lab .sl-cfg-select.is-correct{border-color:color-mix(in oklab,var(--pass) 60%,var(--border));box-shadow:0 0 0 3px color-mix(in oklab,var(--pass) 15%,transparent)}
-#page-sim-lab .sl-cfg-select.is-wrong{border-color:color-mix(in oklab,var(--fail) 60%,var(--border));box-shadow:0 0 0 3px color-mix(in oklab,var(--fail) 14%,transparent)}
+#page-sim-lab .sl-cfg-select.is-wrong{border-color:color-mix(in oklab,var(--red) 60%,var(--border));box-shadow:0 0 0 3px color-mix(in oklab,var(--red) 14%,transparent)}
 @media (hover:hover) and (pointer:fine){#page-sim-lab .sl-cfg-select:hover{border-color:color-mix(in oklab,var(--accent) 30%,var(--border))}}
 @media (prefers-reduced-motion:reduce){#page-sim-lab .sl-cfg-select{transition:none}}
 /* Decision Lab: per-option why reveal + teach block (Task 2) — v7.59.0 */
@@ -4352,8 +4352,8 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 /* severity → --sev token (--yellow for med: no --warn in dg-system.css) */
 #page-sim-lab .sev-low,#page-decision-lab .sev-low{--sev:var(--muted)}
 #page-sim-lab .sev-med,#page-decision-lab .sev-med{--sev:var(--yellow)}
-#page-sim-lab .sev-high,#page-decision-lab .sev-high{--sev:color-mix(in oklab,var(--fail) 80%,var(--yellow))}
-#page-sim-lab .sev-crit,#page-decision-lab .sev-crit{--sev:var(--fail)}
+#page-sim-lab .sev-high,#page-decision-lab .sev-high{--sev:color-mix(in oklab,var(--red) 80%,var(--yellow))}
+#page-sim-lab .sev-crit,#page-decision-lab .sev-crit{--sev:var(--red)}
 
 /* ── Sim Lab: layered defense-in-depth reference renderer (Task 8) ────────
    Nested-frames SVG layout. Layers ordered outer→inner; each frame is either
@@ -4361,7 +4361,7 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
    Core is .sl-core (safe) or .sl-core-exposed (any asset exposed = red fill).
    Device nodes inside core: .sl-dev (normal) or .sl-dev.exposed (red).
    Lifted from mockups/defense-in-depth-{netplus,secplus}-concept.html; tokens
-   only, 0 hardcoded hex. --fail = red/missing/exposed; --accent = present. */
+   only, 0 hardcoded hex. --red = red/missing/exposed; --accent = present. */
 #page-sim-lab .sl-layered,#page-decision-lab .sl-layered{padding:8px}
 #page-sim-lab .sl-layered-svg,#page-decision-lab .sl-layered-svg{width:100%;height:auto;display:block;touch-action:pan-x pan-y pinch-zoom}
 
@@ -4369,27 +4369,27 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 #page-sim-lab .sl-layer,#page-decision-lab .sl-layer{fill:color-mix(in oklab,var(--accent) 6%,transparent);stroke:color-mix(in oklab,var(--accent) 50%,var(--border));stroke-width:1.4}
 
 /* missing layer frame — red dashed */
-#page-sim-lab .sl-misslayer,#page-decision-lab .sl-misslayer{fill:color-mix(in oklab,var(--fail) 5%,transparent);stroke:var(--fail);stroke-width:1.5;stroke-dasharray:6 5}
+#page-sim-lab .sl-misslayer,#page-decision-lab .sl-misslayer{fill:color-mix(in oklab,var(--red) 5%,transparent);stroke:var(--red);stroke-width:1.5;stroke-dasharray:6 5}
 
 /* layer labels */
 #page-sim-lab .sl-layer-lbl,#page-decision-lab .sl-layer-lbl{font:700 11px Inter,sans-serif;fill:var(--text-mid)}
-#page-sim-lab .sl-layer-lbl-miss,#page-decision-lab .sl-layer-lbl-miss{fill:var(--fail)}
+#page-sim-lab .sl-layer-lbl-miss,#page-decision-lab .sl-layer-lbl-miss{fill:var(--red)}
 #page-sim-lab .sl-misslayer-tag,#page-decision-lab .sl-misslayer-tag{font-weight:400;font-size:10px;opacity:.85}
 
 /* core: safe */
 #page-sim-lab .sl-core,#page-decision-lab .sl-core{fill:color-mix(in oklab,var(--accent) 10%,transparent);stroke:color-mix(in oklab,var(--accent) 40%,var(--border));stroke-width:1.4}
 /* core: exposed (one or more assets are exposed) */
-#page-sim-lab .sl-core-exposed,#page-decision-lab .sl-core-exposed{fill:color-mix(in oklab,var(--fail) 9%,transparent);stroke:var(--fail);stroke-width:1.7}
+#page-sim-lab .sl-core-exposed,#page-decision-lab .sl-core-exposed{fill:color-mix(in oklab,var(--red) 9%,transparent);stroke:var(--red);stroke-width:1.7}
 
 /* core labels */
 #page-sim-lab .sl-core-lbl,#page-decision-lab .sl-core-lbl{font:700 11px Inter,sans-serif;fill:var(--text-mid)}
-#page-sim-lab .sl-core-lbl-exp,#page-decision-lab .sl-core-lbl-exp{fill:var(--fail)}
+#page-sim-lab .sl-core-lbl-exp,#page-decision-lab .sl-core-lbl-exp{fill:var(--red)}
 
 /* device node box (safe) */
 #page-sim-lab .sl-dev-box,#page-decision-lab .sl-dev-box{fill:var(--surface);stroke:var(--border);stroke-width:1.2}
 /* device node box (exposed) */
-#page-sim-lab .sl-dev-box-exp,#page-decision-lab .sl-dev-box-exp{stroke:var(--fail);stroke-width:1.8}
+#page-sim-lab .sl-dev-box-exp,#page-decision-lab .sl-dev-box-exp{stroke:var(--red);stroke-width:1.8}
 
 /* device node labels */
 #page-sim-lab .sl-dev-nm,#page-decision-lab .sl-dev-nm{font:700 10.5px Inter,sans-serif;fill:var(--text);text-anchor:middle}
-#page-sim-lab .sl-dev-nm-exp,#page-decision-lab .sl-dev-nm-exp{fill:var(--fail)}
+#page-sim-lab .sl-dev-nm-exp,#page-decision-lab .sl-dev-nm-exp{fill:var(--red)}

--- a/dg-system.css
+++ b/dg-system.css
@@ -4284,3 +4284,52 @@ html[data-theme="light"] body .celebration-toast{
 }
 html[data-theme] body .celebration-toast-title{color:var(--text)}
 html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,255,.75));opacity:1}
+
+/* ════════════════════════════════════════════════════════════════════════
+   SIM LAB · network reference renderer (Task 6) — diagram + incident overlay
+   ────────────────────────────────────────────────────────────────────────
+   Faithful STYLE lift of mockups/diagram-pbq-concept.html (.vlan-zone /
+   centered-stack .node / .link / given+CLI) + the incident overlay states
+   from mockups/incident-response-pbq-concept.html (.compromised / .affected
+   / .link.attack animated dashes + marker#arrow). Layout is computed in JS
+   (data-driven); these are presentation only. Mockup tokens mapped to the
+   app's dg tokens: --ink→--text, --ink-soft→--text-mid, --muted→--text-dim,
+   --surface-2→--surface2, --fail→--red. The mockups' affected-state used
+   --warn, which is NOT defined in this stylesheet — the app's defined amber
+   is --yellow, so affected uses --yellow (matches the existing .sl-clock
+   .is-low precedent at line ~4168). Scoped to both labs that mount a
+   reference panel (#page-sim-lab + #page-decision-lab). 0 hardcoded hex. */
+#page-sim-lab .sl-net,#page-decision-lab .sl-net{padding:8px}
+#page-sim-lab .sl-net-svg,#page-decision-lab .sl-net-svg{width:100%;height:auto;display:block;touch-action:pan-x pan-y pinch-zoom}
+
+/* zones */
+#page-sim-lab .sl-vlan-zone,#page-decision-lab .sl-vlan-zone{fill:color-mix(in oklab,var(--accent) 7%,transparent);stroke:color-mix(in oklab,var(--accent) 26%,var(--border));stroke-width:1}
+#page-sim-lab .sl-zone-lbl,#page-decision-lab .sl-zone-lbl{font:800 10.5px Inter,sans-serif;letter-spacing:.1em;text-transform:uppercase;fill:var(--text-dim)}
+
+/* links */
+#page-sim-lab .sl-link,#page-decision-lab .sl-link{stroke:color-mix(in oklab,var(--text) 34%,transparent);stroke-width:1.6;fill:none}
+#page-sim-lab .sl-link.attack,#page-decision-lab .sl-link.attack{stroke:var(--red);stroke-width:2.2;fill:none;stroke-dasharray:5 6}
+#page-sim-lab .sl-net-arrowhead,#page-decision-lab .sl-net-arrowhead{fill:var(--red)}
+@media (prefers-reduced-motion:no-preference){#page-sim-lab .sl-link.attack,#page-decision-lab .sl-link.attack{animation:sl-net-flow 1s linear infinite}}
+@keyframes sl-net-flow{to{stroke-dashoffset:-22}}
+
+/* nodes — centered stack (rect + glyph-on-top + name/ip centered) */
+#page-sim-lab .sl-node-box,#page-decision-lab .sl-node-box{fill:var(--surface2);stroke:var(--border);stroke-width:1.2}
+#page-sim-lab .sl-node-name,#page-decision-lab .sl-node-name{font:700 13px Inter,sans-serif;fill:var(--text);text-anchor:middle}
+#page-sim-lab .sl-node-ip,#page-decision-lab .sl-node-ip{font:600 11px ui-monospace,Menlo,monospace;fill:var(--text-mid);text-anchor:middle}
+#page-sim-lab .sl-glyph,#page-decision-lab .sl-glyph{stroke:var(--accent);stroke-width:1.8;fill:none}
+
+/* incident overlay states */
+#page-sim-lab .sl-node.compromised .sl-node-box,#page-decision-lab .sl-node.compromised .sl-node-box{stroke:var(--red);stroke-width:2}
+#page-sim-lab .sl-node.compromised .sl-node-name,#page-decision-lab .sl-node.compromised .sl-node-name{fill:var(--red)}
+#page-sim-lab .sl-node.compromised .sl-glyph,#page-decision-lab .sl-node.compromised .sl-glyph{stroke:var(--red)}
+#page-sim-lab .sl-node.affected .sl-node-box,#page-decision-lab .sl-node.affected .sl-node-box{stroke:var(--yellow);stroke-width:1.8}
+#page-sim-lab .sl-node.affected .sl-node-name,#page-decision-lab .sl-node.affected .sl-node-name{fill:var(--yellow)}
+#page-sim-lab .sl-node.affected .sl-glyph,#page-decision-lab .sl-node.affected .sl-glyph{stroke:var(--yellow)}
+
+/* read-only given reference + CLI block */
+#page-sim-lab .sl-net-given,#page-decision-lab .sl-net-given{margin:2px 8px 10px;border-top:1px solid var(--border);padding-top:11px;display:grid;gap:9px}
+#page-sim-lab .sl-net-row,#page-decision-lab .sl-net-row{display:flex;align-items:baseline;gap:10px;font-size:12.5px}
+#page-sim-lab .sl-net-row .k,#page-decision-lab .sl-net-row .k{color:var(--text-dim);font-weight:700;min-width:86px}
+#page-sim-lab .sl-net-row .v,#page-decision-lab .sl-net-row .v{font-family:ui-monospace,Menlo,monospace;color:var(--text);font-size:12px}
+#page-sim-lab .sl-net-cli,#page-decision-lab .sl-net-cli{margin:0 8px 8px;background:color-mix(in oklab,var(--text) 5%,var(--surface));border:1px solid var(--border);border-radius:11px;padding:11px 13px;font-family:ui-monospace,Menlo,monospace;font-size:11.5px;line-height:1.6;color:var(--text-mid);white-space:pre-wrap;word-break:break-word}

--- a/docs/decisions/ADR-003-pbq-structured-model-and-per-cert-validation.md
+++ b/docs/decisions/ADR-003-pbq-structured-model-and-per-cert-validation.md
@@ -1,0 +1,55 @@
+---
+up: "[[Decisions MOC]]"
+type: decision
+status: active
+cert: netplus, secplus
+updated: 2026-06-30
+tags: [decision]
+---
+# ADR-003 — Diagram/IR PBQs: structured model + per-cert validation strategy
+
+- **Status:** Accepted
+- **Date:** 2026-06-30
+- **Decider:** Founder (grilled via grill-with-docs)
+- **Design ref:** [[2026-06-30-diagram-and-incident-response-pbq-design]]
+- **Extends:** [[2026-06-23-sim-lab-pbq-drill-design]]
+
+## Context
+
+A real Net+ exam PBQ (diagram → diagnose → reconfigure) was identified as the missing PBQ archetype, with a Sec+ Incident Response analog wanted alongside it. The core risk (Sim Lab spec §11) is a scenario with a wrong/ambiguous answer punishing the student for the *generator's* error. The design had to choose how the diagram is represented and how answers are guaranteed correct — across two certs with very different validatability.
+
+## Decision
+
+**1. The visual is rendered from a structured model, never hand-drawn.**
+A `network` (and `timeline`) **model** is the source of truth; the engine renders the diagram from it. The diagram therefore *cannot* disagree with the data — fidelity collapses to "is the model sound?"
+
+**2. Validation strategy is per-cert, because the two certs differ in kind:**
+- **Net+ = math.** A deterministic **fidelity validator** (subnetting/CIDR/VLAN) auto-rejects any logically-wrong scenario and verifies the "correct" answer actually fixes the flagged fault. This unlocks **parametric, infinitely-scalable** generation later.
+- **Sec+ IR = doctrine.** No math validator is possible. Correctness rests on a **curated, human/expert-authored bank** gated by **two agents that must agree** — a *network engineer* (technical correctness) and a *CompTIA examiner* (exam fidelity). This two-agent consensus gate also runs on Net+, on top of the math validator.
+
+**3. Ship on a curated bank; architect for parametric.**
+Net+ launches with ~15–20 validated seeds then auto-scales; IR launches with ≥20 coverage-matrixed scenarios growing to ~30–40 and stays curated.
+
+**4. One shared engine, two archetypes.**
+Both certs are new **Sim Lab** scenario types sharing a `configure` step (per-slot scored dropdowns) and a pluggable visual reference; the network diagram is a **shared** visual (Net+ fixes it; Sec+ shows it under attack).
+
+## Consequences
+
+- The data model + validator are a foundational, **hard-to-reverse** commitment — everything (rendering, dropdown binding, parametric generation, scoring) depends on the network being structured data.
+- Content production **diverges by cert**: Net+ is cheap and scalable; IR is deliberately handcrafted and capped by authoring throughput. Roadmap and effort estimates must reflect this asymmetry.
+- The two-agent consensus gate becomes a **standing authoring requirement** (see memory rule; mirrors the `review-feature` multi-agent pattern).
+- Per-slot partial credit for `configure` is a scoped deviation from the Sim Lab spec's all-or-nothing scoring.
+
+## Rejected alternatives
+
+- **Pre-drawn static images** — not AI-generatable, can't bind dropdowns to regions, doesn't scale or reflow on mobile.
+- **Live runtime AI generation for both certs** — too high a blast radius; for IR, uncheckable.
+- **Net+ first, IR as a later fast-follow** — rejected in favour of co-designing the shared engine so IR drops in without a rebuild.
+- **All-or-nothing scoring on `configure`** — punishing and less instructive for multi-device steps.
+
+## Revisit trigger
+
+Revisit if (a) a math-like validator for some IR sub-domain becomes feasible (allowing IR parametric scaling), or (b) the parametric Net+ generator proves so reliable that the per-scenario two-agent gate can be sampled rather than exhaustive.
+
+## Related
+[[2026-06-30-diagram-and-incident-response-pbq-design]] · [[ADR-001-m5-supabase-session-cookies]] · [[ADR-002-rbac-admin-surface]] · [[Decisions MOC]]

--- a/docs/superpowers/plans/2026-06-30-sim-lab-pbq-implementation.md
+++ b/docs/superpowers/plans/2026-06-30-sim-lab-pbq-implementation.md
@@ -1,0 +1,511 @@
+---
+up: "[[Drills MOC]]"
+type: plan
+status: active
+cert: netplus, secplus
+updated: 2026-06-30
+tags: [plan, drill, pbq]
+---
+# Sim Lab PBQ Archetypes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three new Sim Lab scenario archetypes — Diagram PBQ (Net+), Incident Response (Sec+), and Defense in Depth (Net+ & Sec+) — to the live Sim Lab engine, by extending it with one new step type (`configure`) and pluggable visual `reference` assets, then authoring validated seed banks.
+
+**Architecture:** The Sim Lab engine already exists and is live in `features/sim-lab.js` (scenario model, 5 step renderers via `simLabRenderStep`, `simLabValidateScenario`, `simLabScoreScenario`, `_slMountScenario`, seed-bank picking). This feature ADDS: (1) a `configure` step type (per-slot dropdowns, per-slot partial credit), (2) three SVG `reference` renderers (`network`, `timeline`, `layered`) rendered decoupled above the steps, (3) a deterministic Net+ fidelity validator (subnetting math), and (4) seed-bank content authored through a two-agent consensus gate. The four approved concept mockups in `mockups/` are the faithful-lift source of truth for all visuals/CSS.
+
+**Tech Stack:** Vanilla ES5-style JS (no build step, IIFE module), native `<select>` for cross-platform (Desktop/Safari/iOS Capacitor), `tests/uat.js` (behavioral UAT, ~4252 checks), forged-bronze design tokens in `dg-system.css`.
+
+**Lane:** Fast lane (JS + content; no schema/auth/sw/money). Build on branch `feat/sim-lab-pbq-archetypes` (already created; design docs committed at 97ec573).
+
+---
+
+## Reference contracts (used across tasks — keep names identical)
+
+**`configure` step:**
+```js
+{
+  id: 'string', type: 'configure', prompt: 'string', explanation: 'string', points: 1,
+  payload: { slots: [ { id: 'string', label: 'string', options: [ { id: 'string', text: 'string' } ] } ] }, // each slot: options.length >= 2
+  answer:  { slots: { /* slotId: correctOptionId */ } }  // one correct option id per slot; must exist in that slot's options
+}
+```
+Renderer reports response via `onChange({ slots: { slotId: selectedOptionId } })`.
+Scoring: **per-slot** — slot correct iff `response.slots[slotId] === answer.slots[slotId]`.
+
+**`reference` asset (optional, on `scenario.assets.reference`):**
+```js
+// network (Net+ Diagram; also Sec+ IR "under attack" via device.state + link.kind)
+{ kind:'network', devices:[{ id,label,type,zone,ip?,mask?,gateway?,x,y,state? /* 'clean'|'affected'|'compromised' */ }],
+  links:[{ from,to,kind? /* 'normal'|'attack' */ }], given?:{ networkId?, mask?, cli?:[ 'string' ] } }
+// timeline (Sec+ IR attack timeline)
+{ kind:'timeline', stages:[{ id, icon, label, time?, severity /* 'low'|'med'|'high'|'crit' */ }] }
+// layered (Defense in Depth)
+{ kind:'layered', layers:[{ id, label, control?, state /* 'present'|'missing' */ }],
+  core:{ label, assets:[{ id, label, exposed? }] } }
+```
+
+**Dev-fixture rule (HARD):** Phases 1-4 use the scenarios embedded in the mockups ONLY as labeled dev fixtures for rendering/tests. NO scenario reaches a real user until it clears the Phase 5 two-agent consensus gate.
+
+---
+
+## Phase 1 — The `configure` step type
+
+### Task 1: `configure` payload validation
+
+**Files:**
+- Modify: `features/sim-lab.js` (`STEP_TYPES` ~L5; `_validateStepPayload` ~L11)
+- Test: `tests/uat.js` (Sim Lab validation section — locate by grep `simLabValidateScenario`)
+
+- [ ] **Step 1: Write failing tests** — add to the Sim Lab UAT block:
+```js
+// configure: valid scenario passes
+var _cfgStep = { id:'s1', type:'configure', prompt:'p', explanation:'e', points:1,
+  payload:{ slots:[ {id:'ip', label:'IP', options:[{id:'a',text:'A'},{id:'b',text:'B'}]} ] },
+  answer:{ slots:{ ip:'a' } } };
+var _cfgScn = { id:'c1', cert:'netplus', scenario:'prose', estMinutes:3, steps:[_cfgStep] };
+assert(simLabValidateScenario(_cfgScn).ok === true, 'configure valid scenario passes');
+// configure: bad answer (option id not in slot) fails
+var _bad = JSON.parse(JSON.stringify(_cfgScn)); _bad.steps[0].answer.slots.ip = 'zzz';
+assert(simLabValidateScenario(_bad).ok === false, 'configure rejects unknown option id');
+// configure: slot with <2 options fails
+var _bad2 = JSON.parse(JSON.stringify(_cfgScn)); _bad2.steps[0].payload.slots[0].options.pop();
+assert(simLabValidateScenario(_bad2).ok === false, 'configure rejects slot with <2 options');
+```
+
+- [ ] **Step 2: Run UAT, verify the new assertions FAIL**
+Run: `export PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" && node tests/uat.js`
+Expected: FAIL on `configure valid scenario passes` (type rejected by `STEP_TYPES`).
+
+- [ ] **Step 3: Add `'configure'` to `STEP_TYPES`** (~L5):
+```js
+var STEP_TYPES = ['order', 'categorize', 'match', 'analyze', 'fillin', 'configure'];
+```
+
+- [ ] **Step 4: Add the `configure` case to `_validateStepPayload`** (in the `switch (step.type)`):
+```js
+case 'configure':
+  return Array.isArray(p.slots) && p.slots.length >= 1 &&
+         a.slots && typeof a.slots === 'object' && !Array.isArray(a.slots) &&
+         p.slots.every(function (sl) {
+           return _isNonEmptyStr(sl.id) && _isNonEmptyStr(sl.label) &&
+                  Array.isArray(sl.options) && sl.options.length >= 2 &&
+                  sl.options.every(function (o) { return _isNonEmptyStr(o.id) && _isNonEmptyStr(o.text); }) &&
+                  _isNonEmptyStr(a.slots[sl.id]) &&
+                  sl.options.some(function (o) { return o.id === a.slots[sl.id]; });
+         });
+```
+
+- [ ] **Step 5: Run UAT, verify the 3 new assertions PASS and total is green**
+Run: `node tests/uat.js`  Expected: `NNNN/NNNN ALL PASS ✓` (count increased by 3).
+
+- [ ] **Step 6: Commit**
+```bash
+git add features/sim-lab.js tests/uat.js
+git commit -m "feat(sim-lab): add configure step type validation"
+```
+
+### Task 2: `configure` per-slot scoring (the spec deviation)
+
+**Files:**
+- Modify: `features/sim-lab.js` (`_scoreStep` ~L85; `simLabScoreScenario` ~L110)
+- Test: `tests/uat.js`
+
+- [ ] **Step 1: Write failing tests** — per-slot partial credit:
+```js
+// 2 of 3 slots correct -> scenario score 2/3 (slot-granular), not 0/1
+var _scn3 = { id:'c2', cert:'netplus', scenario:'p', estMinutes:3, steps:[{
+  id:'s', type:'configure', prompt:'p', explanation:'e', points:1,
+  payload:{ slots:[
+    {id:'a',label:'A',options:[{id:'x',text:'x'},{id:'y',text:'y'}]},
+    {id:'b',label:'B',options:[{id:'x',text:'x'},{id:'y',text:'y'}]},
+    {id:'c',label:'C',options:[{id:'x',text:'x'},{id:'y',text:'y'}]} ]},
+  answer:{ slots:{ a:'x', b:'x', c:'x' } } }] };
+var _r = simLabScoreScenario(_scn3, { s: { slots:{ a:'x', b:'x', c:'y' } } });
+assert(_r.correct === 2 && _r.total === 3, 'configure scores per-slot (2/3)');
+// non-configure scenarios unchanged: 1 point per step
+var _ord = { id:'c3', cert:'netplus', scenario:'p', estMinutes:3, steps:[{
+  id:'o', type:'order', prompt:'p', explanation:'e', points:1,
+  payload:{ items:[{id:'1',label:'1'},{id:'2',label:'2'}] }, answer:{ correctOrder:['1','2'] } }] };
+var _ro = simLabScoreScenario(_ord, { o:{ order:['1','2'] } });
+assert(_ro.correct === 1 && _ro.total === 1, 'non-configure unchanged (1 per step)');
+```
+
+- [ ] **Step 2: Run UAT, verify new assertions FAIL**
+Run: `node tests/uat.js`  Expected: FAIL on `configure scores per-slot (2/3)`.
+
+- [ ] **Step 3: Add a slot-scorer and a `configure` case to `_scoreStep`** (above `simLabScoreScenario`):
+```js
+function _scoreConfigureSlots(step, resp) {
+  var ans = step.answer.slots, total = 0, correct = 0;
+  Object.keys(ans).forEach(function (slotId) {
+    total++;
+    if (resp && resp.slots && resp.slots[slotId] === ans[slotId]) correct++;
+  });
+  return { total: total, correct: correct };
+}
+```
+And in `_scoreStep`'s switch, add (so callers treating it as boolean see "fully correct"):
+```js
+case 'configure':
+  var _sc = _scoreConfigureSlots(step, resp);
+  return _sc.total > 0 && _sc.correct === _sc.total;
+```
+
+- [ ] **Step 4: Make `simLabScoreScenario` slot-aware** — replace its body:
+```js
+function simLabScoreScenario(scn, responses) {
+  var perStep = {}, correct = 0, total = 0;
+  scn.steps.forEach(function (st) {
+    var resp = responses ? responses[st.id] : null;
+    if (st.type === 'configure') {
+      var sc = _scoreConfigureSlots(st, resp);
+      perStep[st.id] = sc;            // { total, correct } breakdown for configure
+      correct += sc.correct; total += sc.total;
+    } else {
+      var ok = _scoreStep(st, resp);
+      perStep[st.id] = ok;            // boolean for existing types
+      if (ok) correct++; total++;
+    }
+  });
+  return { perStep: perStep, correct: correct, total: total, fraction: total ? correct / total : 0 };
+}
+```
+
+- [ ] **Step 5: Run UAT, verify PASS (new + all existing Sim Lab scoring tests still green)**
+Run: `node tests/uat.js`  Expected: `ALL PASS ✓`. If any existing Sim Lab scoring test asserts `perStep[id]` is a boolean for a non-configure step, it still holds (unchanged).
+
+- [ ] **Step 6: Commit**
+```bash
+git add features/sim-lab.js tests/uat.js
+git commit -m "feat(sim-lab): per-slot partial credit for configure steps"
+```
+
+### Task 3: `_slRenderConfigure` renderer + dispatch
+
+**Files:**
+- Modify: `features/sim-lab.js` (add `_slRenderConfigure` near other renderers ~L412; register in `simLabRenderStep` ~L448)
+- Test: `tests/uat.js`
+
+- [ ] **Step 1: Write failing test** (render + state reporting, jsdom-free DOM is available in UAT via the existing renderer tests — mirror how `_slRenderAnalyze` is tested; locate that test by grep `_slRenderAnalyze`):
+```js
+// renders one <select> per slot and reports selection through onChange
+var _cap = null;
+var _node = simLabRenderStep(_cfgStep, function (r) { _cap = r; });
+assert(_node.querySelectorAll('select').length === 1, 'configure renders one select per slot');
+var _sel = _node.querySelector('select'); _sel.value = 'b';
+_sel.dispatchEvent(new Event('change'));
+assert(_cap && _cap.slots && _cap.slots.ip === 'b', 'configure reports selection via onChange');
+```
+(Reuse `_cfgStep` from Task 1 if in scope; otherwise redefine it in this test.)
+
+- [ ] **Step 2: Run UAT, verify FAIL** (`simLabRenderStep` has no `configure` branch → returns nothing/throws).
+
+- [ ] **Step 3: Implement `_slRenderConfigure`** following the existing renderer contract (`_el`, `_esc`, `onChange`, `initial` re-hydration). Match the markup/classes used by the approved mockups (`.sl-cfg`, `.sl-cfg-slot`, native `<select>`):
+```js
+function _slRenderConfigure(step, onChange, initial) {
+  var resp = (initial && initial.slots && typeof initial.slots === 'object') ? Object.assign({}, initial.slots) : {};
+  var root = _el('div', 'sl-cfg');
+  root.appendChild(_el('p', 'sl-prompt', _esc(step.prompt)));
+  step.payload.slots.forEach(function (sl) {
+    var wrap = _el('div', 'sl-cfg-slot');
+    wrap.appendChild(_el('label', 'sl-cfg-label', _esc(sl.label)));
+    var sel = document.createElement('select');
+    sel.className = 'sl-cfg-select';
+    sel.setAttribute('data-slot', sl.id);
+    var ph = document.createElement('option'); ph.value = ''; ph.textContent = 'Choose…'; sel.appendChild(ph);
+    sl.options.forEach(function (o) {
+      var op = document.createElement('option'); op.value = o.id; op.textContent = o.text;
+      if (resp[sl.id] === o.id) op.selected = true;
+      sel.appendChild(op);
+    });
+    sel.addEventListener('change', function () {
+      if (sel.value) resp[sl.id] = sel.value; else delete resp[sl.id];
+      onChange({ slots: Object.assign({}, resp) });
+    });
+    wrap.appendChild(sel);
+    root.appendChild(wrap);
+  });
+  onChange({ slots: Object.assign({}, resp) }); // report initial
+  return root;
+}
+```
+
+- [ ] **Step 4: Register in `simLabRenderStep`** — add a branch alongside the other `_slRenderX` dispatches:
+```js
+case 'configure': return _slRenderConfigure(step, onChange, initial);
+```
+(If `simLabRenderStep` uses an if/else or map rather than switch, match that exact structure — read ~L448 first.)
+
+- [ ] **Step 5: Run UAT, verify PASS**  Run: `node tests/uat.js`  Expected: `ALL PASS ✓`.
+
+- [ ] **Step 6: Commit**
+```bash
+git add features/sim-lab.js tests/uat.js
+git commit -m "feat(sim-lab): configure step renderer (per-slot native selects)"
+```
+
+### Task 4: `configure` styling (forged-bronze, native select)
+
+**Files:**
+- Modify: `dg-system.css` (locate the Sim Lab block by grep `.sl-prompt` or `.sl-order`; add adjacent). Bump the `dg-system.css?v=` cache-bust query in `index.html` (BRAND.md §Versioning).
+- Test: manual (Phase 6 live-verify); no UAT assertion for pure CSS.
+
+- [ ] **Step 1: Add `.sl-cfg` styles** — lift the dropdown styling verbatim from `mockups/diagram-pbq-concept.html` (the `.sel`/`.sel select`/`.sel::after`/`.sel.correct`/`.sel.wrong` rules), renamed to `.sl-cfg-*`, using existing dg-system tokens (`--accent`, `--surface-2`, `--border`, `color-mix`). Native `<select>` + custom chevron; focus ring; correct/wrong graded states.
+
+- [ ] **Step 2: Bump cache-bust** — in `index.html`, find `dg-system.css?v=X.Y.Z` and increment the patch.
+
+- [ ] **Step 3: Run UAT** (CSS guard tests) Run: `node tests/uat.js`  Expected: `ALL PASS ✓` (no css-guard regressions).
+
+- [ ] **Step 4: Commit**
+```bash
+git add dg-system.css index.html
+git commit -m "style(sim-lab): forged-bronze configure dropdown styling"
+```
+
+---
+
+## Phase 2 — Visual `reference` assets
+
+### Task 5: `reference` asset model + validation + mount wiring
+
+**Files:**
+- Modify: `features/sim-lab.js` (`simLabValidateScenario` ~L35 to validate optional `assets.reference`; `_slMountScenario` ~L465 to render the reference panel above steps)
+- Test: `tests/uat.js`
+
+- [ ] **Step 1: Write failing tests** — reference validation + mount renders a panel:
+```js
+var _net = { kind:'network', devices:[{id:'d1',label:'PC',type:'pc',zone:'v10',x:10,y:10}], links:[] };
+var _scnRef = JSON.parse(JSON.stringify(_cfgScn)); _scnRef.assets = { reference: _net };
+assert(simLabValidateScenario(_scnRef).ok === true, 'valid network reference passes');
+var _badRef = JSON.parse(JSON.stringify(_cfgScn)); _badRef.assets = { reference: { kind:'nope' } };
+assert(simLabValidateScenario(_badRef).ok === false, 'unknown reference kind rejected');
+```
+
+- [ ] **Step 2: Run UAT, verify FAIL.**
+
+- [ ] **Step 3: Add reference validation** to `simLabValidateScenario` (after the steps loop, before `return`):
+```js
+if (s.assets && s.assets.reference) {
+  var ref = s.assets.reference, kinds = ['network', 'timeline', 'layered'];
+  if (kinds.indexOf(ref.kind) === -1) errs.push('reference: bad kind');
+  else if (ref.kind === 'network' && !Array.isArray(ref.devices)) errs.push('reference network: devices[] required');
+  else if (ref.kind === 'timeline' && !Array.isArray(ref.stages)) errs.push('reference timeline: stages[] required');
+  else if (ref.kind === 'layered' && !Array.isArray(ref.layers)) errs.push('reference layered: layers[] required');
+}
+```
+
+- [ ] **Step 4: Add a reference dispatcher** `_slRenderReference(ref)` that returns a panel `<div class="sl-ref">` or null (renderers added in Tasks 6-8; stub them to return an empty `.sl-ref` for now so mount wiring is testable):
+```js
+function _slRenderReference(ref) {
+  if (!ref || !ref.kind) return null;
+  var panel = _el('div', 'sl-ref');
+  if (ref.kind === 'network') panel.appendChild(_slRenderRefNetwork(ref));
+  else if (ref.kind === 'timeline') panel.appendChild(_slRenderRefTimeline(ref));
+  else if (ref.kind === 'layered') panel.appendChild(_slRenderRefLayered(ref));
+  return panel;
+}
+```
+
+- [ ] **Step 5: Wire into `_slMountScenario`** — read ~L465 first; before the steps render, if `scn.assets && scn.assets.reference`, prepend `_slRenderReference(scn.assets.reference)` to the mount root (decoupled: reference panel, then steps).
+
+- [ ] **Step 6: Add temporary stubs** for `_slRenderRefNetwork/Timeline/Layered` returning `_el('div','sl-ref-stub')` so the build runs; Tasks 6-8 replace them.
+
+- [ ] **Step 7: Test mount** — assert `_slMountScenario(_scnRef, …)` output contains `.sl-ref`. Run UAT → PASS.
+
+- [ ] **Step 8: Commit**
+```bash
+git add features/sim-lab.js tests/uat.js
+git commit -m "feat(sim-lab): pluggable reference asset model + mount wiring"
+```
+
+### Task 6: `network` reference renderer (Net+ Diagram + IR overlay)
+
+**Files:**
+- Modify: `features/sim-lab.js` (replace `_slRenderRefNetwork` stub)
+- Modify: `dg-system.css` (diagram styles) + `index.html` (cache-bust)
+- Test: `tests/uat.js` (renders an `<svg>` with one node per device; flagged/compromised state applies a class)
+
+- [ ] **Step 1: Failing test:**
+```js
+var _net2 = { kind:'network', devices:[
+  {id:'a',label:'PC-2',type:'pc',zone:'v10',ip:'192.168.20.45',x:0,y:0,state:'compromised'},
+  {id:'b',label:'FS-1',type:'server',zone:'v10',x:1,y:0} ], links:[{from:'a',to:'b',kind:'attack'}] };
+var _svg = _slRenderRefNetwork(_net2);
+assert(_svg.querySelectorAll('.sl-node').length === 2, 'network renders one node per device');
+assert(_svg.querySelector('.sl-node.compromised'), 'compromised state applies class');
+```
+
+- [ ] **Step 2: Run UAT → FAIL.**
+
+- [ ] **Step 3: Implement `_slRenderRefNetwork(ref)`** — build the themed SVG by **faithful lift from `mockups/diagram-pbq-concept.html`** (the `<svg viewBox="0 0 800 500">` block: zones, links, centered-stack nodes) and the IR overlay states from `mockups/incident-response-pbq-concept.html` (`.node.compromised/.affected`, `.link.attack` animated dashes, `marker#arrow`). Drive node positions from `device.x/y` (grid units → px), zones from `device.zone`, states from `device.state`, attack links from `link.kind==='attack'`. Use `_el` + `innerHTML` for the SVG string; escape labels with `_esc`. Read-only (no interaction).
+
+- [ ] **Step 4: Add diagram CSS** to `dg-system.css` — lift the `.vlan-zone`, `.node`, `.link`, `.link.attack`, `.glyph`, state classes verbatim from the two mockups, prefixed `.sl-` to avoid collisions; bump `dg-system.css?v=`.
+
+- [ ] **Step 5: Run UAT → PASS.**
+
+- [ ] **Step 6: Commit**
+```bash
+git add features/sim-lab.js dg-system.css index.html tests/uat.js
+git commit -m "feat(sim-lab): network reference renderer (diagram + incident overlay)"
+```
+
+### Task 7: `timeline` reference renderer (Sec+ IR)
+
+**Files:** `features/sim-lab.js` (replace stub), `dg-system.css` + `index.html`, `tests/uat.js`
+
+- [ ] **Step 1: Failing test** — `_slRenderRefTimeline({kind:'timeline',stages:[...4...]})` produces 4 `.sl-stage` rows, each with a severity class.
+- [ ] **Step 2: Run UAT → FAIL.**
+- [ ] **Step 3: Implement** by faithful lift of the `.timeline`/`.stage`/`.sev-*` block from `mockups/incident-response-pbq-concept.html`; severity → class `sev-low|med|high|crit`; escape `label`.
+- [ ] **Step 4: CSS** lift `.timeline .stage .dot/.line/.what/.sevtag` + `.sev-*` tokens; bump cache-bust.
+- [ ] **Step 5: Run UAT → PASS.**
+- [ ] **Step 6: Commit** `feat(sim-lab): attack-timeline reference renderer`
+
+### Task 8: `layered` reference renderer (Defense in Depth)
+
+**Files:** `features/sim-lab.js` (replace stub), `dg-system.css` + `index.html`, `tests/uat.js`
+
+- [ ] **Step 1: Failing test** — `_slRenderRefLayered` with N layers (some `state:'missing'`) renders N layer elements and flags missing ones with a class; exposed core assets get a class.
+- [ ] **Step 2: Run UAT → FAIL.**
+- [ ] **Step 3: Implement** by faithful lift of the nested-frames SVG from `mockups/defense-in-depth-netplus-concept.html` (present layer + gap marker) and the multi-missing-layer + exposed-core variant from `mockups/defense-in-depth-secplus-concept.html`. Drive frames from `layers[]` (present → solid frame with `control`; missing → red dashed `.sl-misslayer`), core from `core.assets[]` (`exposed` → flagged).
+- [ ] **Step 4: CSS** lift `.layer`, `.misslayer`, `.core-exposed`, `.dev` from both DID mockups; bump cache-bust.
+- [ ] **Step 5: Run UAT → PASS.**
+- [ ] **Step 6: Commit** `feat(sim-lab): layered defense-in-depth reference renderer`
+
+---
+
+## Phase 3 — Net+ deterministic fidelity validator
+
+### Task 9: subnetting/CIDR fidelity validator
+
+**Files:** `features/sim-lab.js` (add `simLabValidateNetworkFidelity` + CIDR helpers), `tests/uat.js`
+
+- [ ] **Step 1: Failing tests** — given a `network` reference + the configure answer, the validator confirms the flagged device is OUT of its VLAN subnet and the correct answer puts it IN; and it rejects a scenario whose "correct" answer is itself out-of-subnet:
+```js
+// helpers
+assert(_ipToInt('192.168.10.1') === ((192<<24)|(168<<16)|(10<<8)|1) >>> 0, 'ipToInt');
+assert(_inSubnet('192.168.10.45','192.168.10.0','255.255.255.0') === true, 'inSubnet true');
+assert(_inSubnet('192.168.20.45','192.168.10.0','255.255.255.0') === false, 'inSubnet false');
+// fidelity: the diagram fixture from the Net+ mockup must pass (correct answer re-homes PC-2 into .10.x)
+var _fx = /* the Net+ diagram fixture: network ref + configure step with correct IP/mask/gw */;
+assert(simLabValidateNetworkFidelity(_fx.ref, _fx.step).ok === true, 'Net+ fixture is fidelity-sound');
+```
+
+- [ ] **Step 2: Run UAT → FAIL.**
+
+- [ ] **Step 3: Implement** `_ipToInt`, `_maskToInt`, `_inSubnet(ip,netId,mask)`, and `simLabValidateNetworkFidelity(networkModel, configureStep)`:
+  - For each device with `ip`+`mask`+`zone`: compute its VLAN subnet (from the zone's intended network) and check membership; gateway ∈ subnet; no duplicate IPs.
+  - Apply the configure step's correct answers symbolically (the option that sets the corrected IP/mask/gw) and assert the corrected device IS in-subnet with an in-subnet gateway. Return `{ ok, errors }`.
+
+- [ ] **Step 4: Run UAT → PASS.**
+
+- [ ] **Step 5: Commit** `feat(sim-lab): deterministic Net+ subnetting fidelity validator`
+
+---
+
+## Phase 4 — Archetype wiring + Sim Lab surface entry
+
+### Task 10: scenario `archetype` tag + cert-aware availability
+
+**Files:** `features/sim-lab.js` (allow `scenario.archetype` ∈ `['diagram','incident','defense']`; thread through validation only — no behavior change to picking yet), `tests/uat.js`
+
+- [ ] **Step 1: Failing test** — `simLabValidateScenario` accepts a known `archetype` and rejects an unknown one (when present).
+- [ ] **Step 2: Run UAT → FAIL.**
+- [ ] **Step 3: Implement** an optional `archetype` field validation (`['diagram','incident','defense']`).
+- [ ] **Step 4: Run UAT → PASS.**
+- [ ] **Step 5: Commit** `feat(sim-lab): scenario archetype tag`
+
+### Task 11: render the full archetype scenario end-to-end (Net+ vertical slice)
+
+**Files:** `features/sim-lab.js` (ensure `_slMountScenario` renders reference + configure steps + scores via the existing Practice flow), `tests/uat.js`
+
+- [ ] **Step 1: Failing test** — mount the Net+ diagram fixture (network ref + diagnose `configure×1` + reconfigure `configure×N`), simulate selecting the correct options, and assert `simLabScoreScenario` returns `correct === total` and the mounted DOM contains `.sl-ref` + the selects.
+- [ ] **Step 2: Run UAT → FAIL (if any wiring gap).**
+- [ ] **Step 3: Fix wiring** so a configure-based, reference-bearing scenario renders and scores through the existing Practice path (no new mode code — reuse `_slMountScenario`/`_slRenderPracticePage`).
+- [ ] **Step 4: Run UAT → PASS.**
+- [ ] **Step 5: Commit** `feat(sim-lab): end-to-end diagram PBQ vertical slice (fixture)`
+
+---
+
+## Phase 5 — 🔒 Content authoring + TWO-AGENT CONSENSUS GATE (HARD RULE)
+
+> **No scenario authored in this phase enters a seed bank until BOTH agents approve.** This is the project hard rule (memory: 2-agent consensus). Run per scenario. Mirrors the `review-feature` multi-agent pattern.
+
+### Task 12: author + gate the Net+ Diagram seed bank (target ~15-20 scenarios)
+
+**Files:** Create/extend the seed-bank source the engine reads (locate via `_slPickSeed`/`_slPickSeedFresh` — likely a per-cert bank file e.g. `certs/netplus.js` or a dedicated `certs/pbq/netplus-diagram.js`). `tests/uat.js` (bank loads + every scenario passes `simLabValidateScenario` AND `simLabValidateNetworkFidelity`).
+
+- [ ] **Step 1:** Draft each scenario as a `configure`-based scenario with a `network` reference (use the deterministic fidelity validator as a first automatic filter — reject any draft that fails the math).
+- [ ] **Step 2: TWO-AGENT GATE per scenario** — dispatch two subagents:
+  - **Agent A (network engineer):** verify technical correctness (misconfig real, fix correct, addressing/VLAN sound).
+  - **Agent B (CompTIA examiner):** verify exam fidelity (maps to N10-009 objective, exam-realistic, marked-correct answer is what CompTIA accepts, plausible distractors, right difficulty).
+  - Reconcile: if either flags an issue, revise and re-review until **both approve**. Only consensus-approved scenarios are added to the bank.
+- [ ] **Step 3:** Add approved scenarios to the bank; add a UAT test asserting every Net+ diagram scenario passes BOTH validators.
+- [ ] **Step 4: Run UAT → PASS.**
+- [ ] **Step 5: Commit** `content(sim-lab): Net+ Diagram seed bank (2-agent gated)`
+
+### Task 13: author + gate the Sec+ Incident Response seed bank (≥20, coverage-matrixed)
+
+**Files:** seed-bank source for Sec+; `tests/uat.js`.
+
+- [ ] **Step 1:** Draft ≥20 IR scenarios across the coverage matrix (≈6-8 attack archetypes × IR lifecycle emphasis), each with a `timeline` and/or `network`-under-attack reference + `configure` (triage) + `order` (response sequence) steps.
+- [ ] **Step 2: TWO-AGENT GATE per scenario** (Agent A: incident-response/security professional; Agent B: CompTIA examiner for SY0-701 Domain 4). Consensus required. (No math validator — the gate is the primary correctness check.)
+- [ ] **Step 3:** Add approved scenarios; UAT asserts each passes `simLabValidateScenario`.
+- [ ] **Step 4: Run UAT → PASS.**
+- [ ] **Step 5: Commit** `content(sim-lab): Sec+ Incident Response seed bank (2-agent gated)`
+
+### Task 14: author + gate the Defense-in-Depth seed banks (Net+ and Sec+)
+
+**Files:** seed-bank source for both certs; `tests/uat.js`.
+
+- [ ] **Step 1:** Draft DID scenarios with a `layered` reference + `diagnose` + `configure` (Net+: ~3 layer slots; Sec+: 4 slots + control-type classification slot).
+- [ ] **Step 2: TWO-AGENT GATE per scenario** (Agent A: network/security architect; Agent B: CompTIA examiner — N10-009 Domain 4 for Net+, SY0-701 Domain 3 for Sec+). Consensus required.
+- [ ] **Step 3:** Add approved scenarios; UAT asserts each passes `simLabValidateScenario`.
+- [ ] **Step 4: Run UAT → PASS.**
+- [ ] **Step 5: Commit** `content(sim-lab): Defense in Depth seed banks, Net+ & Sec+ (2-agent gated)`
+
+---
+
+## Phase 6 — Gating, entry point, modes, cross-platform, ship
+
+### Task 15: free 1/day + Pro gating reuse
+
+**Files:** `features/sim-lab.js` (confirm new archetypes ride the existing `STORAGE.PBQ_FREE_COUNT` / `_canMakeMeteredCall('Sim Lab')` / `_gateProOnly` path — no new metering), `tests/uat.js`.
+
+- [ ] **Step 1:** Verify (test) that an archetype scenario in Practice consumes the existing free-count and that Pro gating applies; reuse, do not add new gating.
+- [ ] **Step 2: Run UAT → PASS.** Commit `feat(sim-lab): archetypes ride existing free/Pro gating`.
+
+### Task 16: cert-aware entry on the Sim Lab surface
+
+**Files:** `features/sim-lab.js` (surface the archetypes within Sim Lab for `netplus`/`secplus`; absent for Microsoft/AWS certs), `index.html` if a page hook is needed, `tests/uat.js`.
+
+- [ ] **Step 1:** Test that Sim Lab offers the archetypes for Net+/Sec+ and not for non-PBQ certs.
+- [ ] **Step 2: Implement** cert-aware availability. Run UAT → PASS. Commit `feat(sim-lab): cert-aware PBQ archetype entry`.
+
+### Task 17: Exam mode + pacing (reuse)
+
+**Files:** `features/sim-lab.js` (confirm archetype scenarios work inside the existing Exam-mode block + flag-and-return), `tests/uat.js`.
+
+- [ ] **Step 1:** Test an archetype scenario inside an Exam block scores correctly. Run UAT → PASS. Commit `feat(sim-lab): archetypes in Exam mode`.
+
+### Task 18: cross-platform live-verify (Desktop · Safari/WebKit · iOS)
+
+**Files:** none (verification). Per CLAUDE.md post-deploy + SHIP_CHECKLIST Phase 3.
+
+- [ ] **Step 1:** `python3 -m http.server 3131`; drive a Net+ diagram, a Sec+ IR, and a DID scenario on `localhost` via Chrome MCP — confirm native `<select>` works, no console errors, `100dvh` stable, reflow under `md`, reduced-motion collapses the attack-path dashes. NEVER write localStorage on prod (hard rule).
+- [ ] **Step 2:** `npm run test:ios` (or the documented iOS smoke). Note results.
+- [ ] **Step 3:** Commit any fixes. No commit if clean.
+
+### Task 19: final review + ship
+
+- [ ] **Step 1:** Run full gates: `node tests/uat.js`, `node tests/tech-debt.js`, `npx playwright test`.
+- [ ] **Step 2:** `node scripts/bump-version.js <next> "Sim Lab PBQ archetypes: Diagram, Incident Response, Defense in Depth"`; update UAT version pins; re-read CLAUDE.md.
+- [ ] **Step 3:** Use **superpowers:finishing-a-development-branch** → open PR from `feat/sim-lab-pbq-archetypes`. Fast lane, but PR for review given size. Capture a `#decision` note at ship (Step 7 of /ship).
+
+---
+
+## Notes
+- **Dev fixtures vs. real content:** Phases 1-4 use mockup scenarios as labeled fixtures only. Real banks come from Phase 5 (2-agent gated).
+- **Mockups are the source of truth** for all SVG/CSS (faithful lift): `diagram-pbq`, `incident-response-pbq`, `defense-in-depth-netplus`, `defense-in-depth-secplus`.
+- **Check overlap** with pre-existing `secplus-control-type-sorter`, `secplus-ir-war-room`, `secplus-phishing-triage` mockups before authoring Sec+ banks (Task 13).
+- **CSS rule:** never edit `styles.css` for reskins — add to `dg-system.css` and bump `?v=` (BRAND.md).

--- a/docs/superpowers/specs/2026-06-30-diagram-and-incident-response-pbq-design.md
+++ b/docs/superpowers/specs/2026-06-30-diagram-and-incident-response-pbq-design.md
@@ -1,0 +1,178 @@
+---
+up: "[[Drills MOC]]"
+type: spec
+status: active
+cert: netplus, secplus
+updated: 2026-06-30
+tags: [spec, drill, pbq]
+---
+# Diagram + Incident Response + Defense in Depth — Sim Lab PBQ Design Spec
+
+**Date:** 2026-06-30
+**Status:** Approved design (grilled via grill-with-docs), pre-implementation
+**Builds on:** [[2026-06-23-sim-lab-pbq-drill-design]] (the Sim Lab PBQ engine this extends)
+**Platforms:** Desktop web · Safari/WebKit · iOS Capacitor — every requirement applies to all three.
+**Origin:** A real Network+ exam PBQ the founder sat — a drawn office network (devices, VLAN placements, given Network ID + subnet mask + CLI) where you (1) diagnose what's wrong via MCQ dropdowns, then (2) reconfigure each device via dropdowns. Identified as the missing PBQ archetype.
+
+---
+
+## 1. Summary
+
+Three new **Sim Lab scenario archetypes** built on **one shared engine**:
+
+- **Diagram PBQ (Net+):** read a *given* network diagram, **diagnose** the misconfiguration and **reconfigure** the devices — all by **selecting from dropdowns** (no freeform canvas, no live CLI).
+- **Incident Response PBQ (Sec+):** read a **visual** incident (attack timeline and/or the network "under attack"), then **sequence the response** and **pick the correct action per phase**.
+- **Defense in Depth PBQ (Net+ AND Sec+):** read a **layered-defense diagram** (nested frames = layers around the core, gap layers flagged), **diagnose** the missing/weak layer and **add the correct control at each layer** by dropdown. Cross-cert: Net+ is network-layer focused (DMZ, segmentation, IDS/IPS); Sec+ is deeper (endpoint, data, identity layers + a control-type classification).
+
+The engine is identical; only the **reference asset** (the thing you look at) and the **content** differ. This is a *co-designed* set — none is a fast-follow afterthought; the engine is built generic from day one.
+
+**Explicitly NOT this build** (still deferred per the Sim Lab spec §10): a live CLI terminal, a clickable router GUI, or a freeform drag-canvas topology builder. The candidate **reads** a rendered diagram and **answers by selection**.
+
+---
+
+## 2. The shared engine (what's genuinely new)
+
+A Diagram/IR PBQ = one Sim Lab **Scenario** (reuses scenario/modes/gating/session chrome) with exactly three new pieces of surface area:
+
+1. **A pluggable visual `reference` asset** — rendered from structured data, not hand-drawn:
+   - `network` — the network diagram (devices, VLAN/zone placement, given IPs/masks/gateways, links). **Shared by both certs.**
+   - `network` + **incident overlay** — same renderer, plus per-device `state: clean | affected | compromised` and attacker-path arrows (Sec+).
+   - `timeline` — a visual **attack timeline**: a horizontal strip of stages (icon + label + severity), e.g. phishing → malware → lateral movement → exfiltration (Sec+).
+   - `layered` — a **defense-in-depth diagram**: nested frames (perimeter → inner layers → core/data) rendered from a layer list; each layer carries its control or is flagged as a missing/weak layer (Net+ and Sec+).
+2. **One new step type — `configure`** — N labelled slots, each with its own dropdown of options and its own correct answer.
+   - **1 slot** = the **Diagnose** phase ("What's wrong?").
+   - **N slots** = the **Reconfigure** phase (one dropdown per device) / IR "correct action per phase."
+3. **The fidelity validator + two-agent authoring gate** (§6).
+
+Reused unchanged from Sim Lab: Practice/Exam modes, free 1/day + Pro gating & metering, session UI, the `order` step (sequence the IR response) and the `analyze` step (spot the clue in logs).
+
+---
+
+## 3. Data model
+
+```
+Scenario {
+  ...existing Sim Lab Scenario fields...
+  assets: {
+    reference: NetworkModel | TimelineModel      // NEW — the visual the candidate reads
+    logs?, table?, config?                        // existing supporting evidence
+  }
+  steps: Step[]                                   // diagnose (configure×1) + reconfigure (configure×N)
+                                                  // IR may use order + configure + analyze
+}
+
+NetworkModel {                                    // rendered to a themed SVG diagram
+  devices: { id, label, type, zone/vlan, ip?, mask?, gateway?, x, y,
+             state?: 'clean'|'affected'|'compromised' }[]   // state = IR overlay
+  links:   { from, to, kind?: 'normal'|'attack-path' }[]
+  given:   { networkId?, mask?, cli?: string[] }            // READ-ONLY reference
+}
+
+TimelineModel {                                   // rendered to a visual attack strip
+  stages: { id, icon, label, time?, severity }[]
+}
+
+ConfigureStep {
+  type: 'configure'
+  slots: { id, deviceId?, label, options[], answer }[]      // each slot scored independently
+}
+```
+
+The **diagram is rendered from the model** — there is no separate hand-drawn image that could disagree with the data (this is what makes fidelity tractable, §6).
+
+---
+
+## 4. Interaction & scoring
+
+- **Diagnose** = `configure` with one slot. **Reconfigure** = `configure` with N slots.
+- **Per-slot partial credit** (deliberate, scoped deviation from the Sim Lab spec's all-or-nothing rule): for the `configure` type the natural scored unit is the **slot**, so each slot scores independently and the step score is the slot average. This matches real CompTIA partial credit and is far more instructive. Diagnose (1 slot) is all-or-nothing by definition. (Other Sim Lab step types keep their existing all-or-nothing scoring.)
+- **IR** additionally reuses `order` (sequence the response: contain → eradicate → recover) and optionally `analyze` (tap the suspicious log line).
+
+---
+
+## 5. Visuals & cross-platform (the biggest feasibility risk — resolved)
+
+**Decouple the picture from the answer surface.**
+- The **reference visual is read-only** — a zoomable/pannable themed SVG. The candidate never operates controls *on* it.
+- **Answers live in a separate list** — each row labelled by its device ("Switch SW1 → [▾]"), with a "locate on diagram" affordance that highlights that device.
+- **Desktop:** diagram + dropdown list **side-by-side**. **Mobile:** **stacked** (diagram on top, collapsible/zoomable; list below).
+
+Two things this buys us:
+1. **Native `<select>` dropdowns** → the iOS native wheel picker → accessible, and it **dodges the WebKit touch-drag bug class** the drag-based types had to fight.
+2. The diagram is **non-interactive**, so there is no "drag tiny things on a phone" problem.
+
+**Accepted trade-off:** the diagram is a **clean logical layout** (clear, themed, reflowable) — **not** a pixel-faithful reproduction of CompTIA's exact drawing. Good enough to diagnose from.
+
+Inherit the Sim Lab cross-platform rules: `min-h-[100dvh]`, no layout shift on keyboard open, single-column reflow under `md`, `prefers-reduced-motion`, iOS Pro gate via IAP.
+
+---
+
+## 5b. Defense in Depth archetype (Net+ + Sec+)
+
+Defense in depth is a cross-cert objective (Net+ N10-009 Domain 4 · Sec+ SY0-701 Domain 3) and rides the engine with **no new interaction type** — it reuses `diagnose` + `configure` over the new `layered` reference asset.
+
+- **Visual (`layered`):** nested rounded frames = layers around the core (perimeter → … → data). Present layers carry their control; a missing/weak layer is flagged with a red dashed marker; exposed assets are flagged red. Reads on mobile; the gap is obvious.
+- **Net+ version:** network-layer focused — one missing layer (e.g. a public server on a flat LAN with no DMZ); ~3 configure slots (DMZ placement, VLAN segmentation, IDS/IPS).
+- **Sec+ version (deeper):** the "hard shell, soft center" failure — a strong perimeter around a hollow interior; 4 configure slots (endpoint EDR/hardening, data encryption+DLP, identity MFA+least-privilege) **plus a control-type classification slot** (technical/managerial/operational/physical · preventive/detective/compensating).
+- **Validation:** doctrine, not math (like IR) — a few deterministic checks (is every layer covered?), but correctness rests on the **two-agent authoring gate** + curated bank.
+- **Concept mockups (approved):** `mockups/defense-in-depth-netplus-concept.html` · `mockups/defense-in-depth-secplus-concept.html`.
+
+---
+
+## 6. Fidelity & validation — the trust model
+
+A PBQ with a wrong/ambiguous answer is worse than no PBQ (Sim Lab spec §11). The two certs sit at **different points on the auto-validatable spectrum**, so the engine is shared but the **content pipelines diverge**:
+
+### Layer 1 — Deterministic fidelity validator (Net+ only; math)
+Network correctness is computable. Code checks, *before* any scenario reaches a candidate, that: IP ∈ its VLAN's subnet for the mask, gateway ∈ subnet, no duplicate IPs, no overlapping subnets, mask large enough for host count, VLAN membership consistent, and that the **"correct" reconfigure answer actually fixes the flagged problem** (re-run the checker on the fixed state). Any logically-wrong scenario is auto-rejected. **IR is doctrine, not math** — this layer mostly does not apply (except the fixed IR lifecycle order, which *is* checkable).
+
+### Layer 2 — Two-agent authoring consensus gate (BOTH certs — HARD RULE)
+Every authored scenario (Net+ and Sec+) must be validated by **two agents that must AGREE**:
+- **Agent A — Network Engineer / network professional:** technical correctness (network realistic, misconfig real, fix correct, IR response technically sound).
+- **Agent B — CompTIA Examiner:** exam fidelity (maps to the CompTIA objective/blueprint, exam-realistic, the marked-correct answer is what CompTIA would accept, plausible distractors, appropriate difficulty).
+
+They must agree on the **authoring** and on any **edits/fixes** when a scenario is wrong. A scenario only enters the bank after **both agree**. This is the primary correctness gate for IR (where there is no math validator) and an extra gate on top of Layer 1 for Net+.
+
+### Layer 3 — Human spot-check
+Founder review of the seed banks before launch (first impression must be correct).
+
+---
+
+## 7. Generation strategy & bank sizes
+
+**Ship on a curated bank; architect for parametric** (Net+ only).
+
+- **Net+:** launch with **~15–20 hand-checked seed scenarios** (Layer 1 + Layer 2 validated). Then scale via **parametric templates** — hand-authored skeletons with constraints, instantiated to concrete IPs/VLANs at runtime, where the deterministic validator **guarantees every instance is correct** → infinite variety, zero fidelity risk. Build the data model + validator so this is a drop-in upgrade.
+- **Sec+ IR:** **≥ 20 hand-checked scenarios at launch**, authored as a **coverage matrix** (≈6–8 attack archetypes — phishing→malware, ransomware, insider, exfiltration, lateral movement, DDoS, web-app, compromised creds — × IR lifecycle emphasis), **growing to ~30–40**. IR does **not** auto-scale (doctrine, not math); the bank grows by authoring through the two-agent gate. Do not live-generate IR.
+
+---
+
+## 8. Build hard rules (non-negotiable for this build)
+
+1. **Mockups ARE the build.** Every visual surface (the diagram, the timeline, the dropdown list, the result screen) is built as a **faithful lift** of an approved `mockups/*-concept.html`. Mockups come first and are the build target.
+2. **4-stage visual pass — load and run all four, in order**, for every end-user visual: **(1) /design-taste-frontend → (2) /emil-design-eng → (3) /humanizer → (4) /marketing-psychology.**
+3. **Two-agent authoring consensus** (§6 Layer 2) — network-engineer + CompTIA-examiner must agree on every scenario and every edit.
+4. **Cross-platform parity** — Desktop, Safari/WebKit, iOS Capacitor, identical (§5).
+
+---
+
+## 9. Placement, gating, rollout
+
+- **Placement:** new scenario archetypes **inside Sim Lab** — not a new top-level drill. Entry via the existing Sim Lab card on the Drills page.
+- **Gating:** reuse Sim Lab's free 1/day + Pro-unlimited model and metering as-is.
+- **Cert rollout:** Net+ Diagram PBQ first (concrete, math-validatable). Sec+ IR PBQ co-designed and built on the same engine. A+ later (no VOC yet). Microsoft/AWS certs: not rendered (no PBQs).
+
+---
+
+## 10. Open implementation items
+
+- The exact `NetworkModel` device-type set + SVG rendering (reuse/extend the still-live `renderTopology()` where useful).
+- Exam-mode timer budget for diagram scenarios (they read slower than text PBQs).
+- Icon set for `timeline` stages (reuse `design/svg-icons/`).
+- Parametric-template constraint language (Net+ phase 2).
+- The two-agent gate's operational form (parallel agents → consensus, mirroring the `review-feature` pattern) and where the authored banks live per cert.
+
+---
+
+## 11. Related
+[[2026-06-23-sim-lab-pbq-drill-design]] · [[2026-06-25-decision-lab-seed-authoring-contract]] · [[Drills MOC]] · [[CONTEXT|Domain glossary]]

--- a/features/sim-lab-seed-netplus.js
+++ b/features/sim-lab-seed-netplus.js
@@ -1122,5 +1122,491 @@ window.SIM_LAB_SEED_NETPLUS = [
         payload: { fields: [{ id: 'hosts', label: 'Usable hosts', inputmode: 'numeric' }] },
         answer: { hosts: ['510'] } }
     ]
+  },
+
+  // 1 — wrong-subnet host IP, 192.168.x, VLAN framing
+  {
+    id: 'np-diag-branch-vlan10-hostip',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Fix the stranded Staff PC',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'The Mercer & Hale branch office runs two VLANs: Staff (VLAN 10, 192.168.10.0/24) and Guest (VLAN 20, 192.168.20.0/24). A Staff user cannot reach the internal file server or the internet, while everyone else is fine. Inspect the diagram and fix the misconfigured host.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '192.168.10.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'core', ip: '192.168.10.1', mask: '255.255.255.0', x: 3, y: 0 },
+        { id: 'swa', label: 'SW-A', type: 'switch', zone: 'staff', ip: '192.168.10.2', mask: '255.255.255.0', x: 1, y: 1 },
+        { id: 'fs1', label: 'FS-1', type: 'server', zone: 'staff', ip: '192.168.10.20', mask: '255.255.255.0', gateway: '192.168.10.1', x: 0, y: 2 },
+        { id: 'pc2', label: 'PC-2', type: 'pc', zone: 'staff', ip: '192.168.20.45', mask: '255.255.255.0', gateway: '192.168.20.1', x: 1, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'swa' }, { from: 'swa', to: 'fs1' }, { from: 'swa', to: 'pc2' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'pc2',
+        prompt: 'Fix PC-2’s IP configuration so it can reach FS-1 and the internet.',
+        explanation: 'PC-2 sits in VLAN 10 but was assigned a Guest-subnet address. It needs a 192.168.10.x address and the VLAN 10 gateway to rejoin its own subnet.',
+        payload: { slots: [
+          { id: 'ip', label: 'PC-2 IP address', options: [
+            { id: 'a', text: '192.168.10.45' }, { id: 'b', text: '192.168.20.45' }, { id: 'c', text: '10.0.10.45' } ] },
+          { id: 'gateway', label: 'PC-2 default gateway', options: [
+            { id: 'a', text: '192.168.10.1' }, { id: 'b', text: '192.168.20.1' }, { id: 'c', text: '192.168.1.1' } ] }
+        ] },
+        answer: { slots: { ip: 'a', gateway: 'a' } } }
+    ]
+  },
+
+  // 2 — wrong subnet mask, /25 vs /24 boundary
+  {
+    id: 'np-diag-mask-boundary-25',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Correct the /25 mask mismatch',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A small office subnet 192.168.30.0/24 hosts a router, a switch, and three PCs. One PC was imaged from a template used for a smaller /25 segment elsewhere and cannot see the rest of the LAN even though its IP looks fine at a glance.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '192.168.30.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'lan', ip: '192.168.30.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'lan', ip: '192.168.30.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'pc1', label: 'PC-1', type: 'pc', zone: 'lan', ip: '192.168.30.10', mask: '255.255.255.0', gateway: '192.168.30.1', x: 1, y: 2 },
+        { id: 'pc3', label: 'PC-3', type: 'pc', zone: 'lan', ip: '192.168.30.140', mask: '255.255.255.128', gateway: '192.168.30.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'pc1' }, { from: 'sw1', to: 'pc3' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'pc3',
+        prompt: 'PC-3’s IP is correct but it still can’t reach the rest of the LAN. Fix its subnet mask.',
+        explanation: 'PC-3 holds a /25 mask (255.255.255.128) while the documented LAN is a /24 (255.255.255.0). With that /25 mask, PC-3’s address .140 falls in the upper half (.128–.255) while RTR-1, SW-1, and PC-1 sit in the lower half (.0–.127), so PC-3 sees them as a different network even though its IP itself is fine. Restoring the /24 mask puts PC-3 back in the single 192.168.30.0/24 block with everyone else.',
+        payload: { slots: [
+          { id: 'mask', label: 'PC-3 subnet mask', options: [
+            { id: 'a', text: '255.255.255.0' }, { id: 'b', text: '255.255.255.128' }, { id: 'c', text: '255.255.255.192' } ] }
+        ] },
+        answer: { slots: { mask: 'a' } } }
+    ]
+  },
+
+  // 3 — wrong default gateway, 10.x base
+  {
+    id: 'np-diag-datacenter-wrong-gw',
+    cert: 'netplus', objective: '1.4', topic: 'Default gateways',
+    title: 'Point the app server at the right gateway',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A small data-center segment 10.20.30.0/24 hosts a router, a switch, a database server, and an application server. The app server can reach other hosts on the segment but cannot reach anything off-segment.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '10.20.30.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'dc', ip: '10.20.30.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'dc', ip: '10.20.30.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'db1', label: 'DB-1', type: 'server', zone: 'dc', ip: '10.20.30.10', mask: '255.255.255.0', gateway: '10.20.30.1', x: 1, y: 2 },
+        { id: 'app1', label: 'APP-1', type: 'server', zone: 'dc', ip: '10.20.30.15', mask: '255.255.255.0', gateway: '10.20.31.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'db1' }, { from: 'sw1', to: 'app1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'app1',
+        prompt: 'APP-1 has a correct IP but no off-segment reachability. Fix its default gateway.',
+        explanation: 'APP-1 was pointed at 10.20.31.1, an address on a different /24. The router’s actual interface on this segment is 10.20.30.1, so all off-segment traffic was silently dropped at the host.',
+        payload: { slots: [
+          { id: 'gateway', label: 'APP-1 default gateway', options: [
+            { id: 'a', text: '10.20.30.1' }, { id: 'b', text: '10.20.31.1' }, { id: 'c', text: '10.30.30.1' } ] }
+        ] },
+        answer: { slots: { gateway: 'a' } } }
+    ]
+  },
+
+  // 4 — off-by-one octet into wrong subnet, 172.16-31 range
+  {
+    id: 'np-diag-offbyone-172',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Catch the off-by-one subnet',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'Warehouse network 172.20.5.0/24 connects a router, a switch, a scanner terminal, and a workstation. The workstation was recently swapped and now can’t print to the scanner terminal’s shared queue even though its address "looks close enough."',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '172.20.5.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'wh', ip: '172.20.5.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'wh', ip: '172.20.5.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'scan1', label: 'SCAN-1', type: 'pc', zone: 'wh', ip: '172.20.5.30', mask: '255.255.255.0', gateway: '172.20.5.1', x: 1, y: 2 },
+        { id: 'wks5', label: 'WKS-5', type: 'pc', zone: 'wh', ip: '172.20.6.31', mask: '255.255.255.0', gateway: '172.20.5.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'scan1' }, { from: 'sw1', to: 'wks5' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'wks5',
+        prompt: 'WKS-5’s address is one octet off from the documented subnet. Fix its IP.',
+        explanation: '172.20.6.31 falls in the 172.20.6.0/24 network, not 172.20.5.0/24 — a single-octet slip that fully isolates the host from the local segment despite an otherwise plausible-looking address.',
+        payload: { slots: [
+          { id: 'ip', label: 'WKS-5 IP address', options: [
+            { id: 'a', text: '172.20.5.31' }, { id: 'b', text: '172.20.6.31' }, { id: 'c', text: '172.30.5.31' } ] }
+        ] },
+        answer: { slots: { ip: 'a' } } }
+    ]
+  },
+
+  // 5 — wrong host IP, small office, 192.168.x
+  {
+    id: 'np-diag-printer-wrong-net',
+    cert: 'netplus', objective: '1.4', topic: 'IPv4 addressing',
+    title: 'Bring the network printer back on-subnet',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A dentist office LAN 192.168.5.0/24 has a router, a switch, a front-desk PC, and a networked printer. Nobody in the office can print, though the printer powers on and shows a link light.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '192.168.5.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'office', ip: '192.168.5.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'office', ip: '192.168.5.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'pc1', label: 'FRONT-PC', type: 'pc', zone: 'office', ip: '192.168.5.10', mask: '255.255.255.0', gateway: '192.168.5.1', x: 1, y: 2 },
+        { id: 'prn1', label: 'PRN-1', type: 'printer', zone: 'office', ip: '192.168.4.50', mask: '255.255.255.0', gateway: '192.168.5.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'pc1' }, { from: 'sw1', to: 'prn1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'prn1',
+        prompt: 'PRN-1 was configured on the wrong network. Fix its IP address.',
+        explanation: 'PRN-1 holds 192.168.4.50, which belongs to a different /24 than the office LAN (192.168.5.0/24). Correcting the third octet returns it to the documented subnet.',
+        payload: { slots: [
+          { id: 'ip', label: 'PRN-1 IP address', options: [
+            { id: 'a', text: '192.168.5.50' }, { id: 'b', text: '192.168.4.50' }, { id: 'c', text: '192.168.50.5' } ] }
+        ] },
+        answer: { slots: { ip: 'a' } } }
+    ]
+  },
+
+  // 6 — wrong gateway, 172.16-31 range
+  {
+    id: 'np-diag-lab-wrong-gw-172',
+    cert: 'netplus', objective: '1.4', topic: 'Default gateways',
+    title: 'Repair the lab workstation gateway',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A university lab segment 172.24.8.0/24 has a router, a switch, a lab server, and a student workstation. The workstation can reach the lab server but no internet resources.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '172.24.8.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'lab', ip: '172.24.8.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'lab', ip: '172.24.8.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'srv1', label: 'LAB-SRV', type: 'server', zone: 'lab', ip: '172.24.8.5', mask: '255.255.255.0', gateway: '172.24.8.1', x: 1, y: 2 },
+        { id: 'wks9', label: 'WKS-9', type: 'pc', zone: 'lab', ip: '172.24.8.90', mask: '255.255.255.0', gateway: '172.24.9.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'srv1' }, { from: 'sw1', to: 'wks9' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'wks9',
+        prompt: 'WKS-9 reaches local hosts but not the internet. Fix its default gateway.',
+        explanation: 'WKS-9 points to 172.24.9.1, an address outside the 172.24.8.0/24 lab subnet, so off-subnet packets are never forwarded. The correct gateway is the router’s interface on this segment, 172.24.8.1.',
+        payload: { slots: [
+          { id: 'gateway', label: 'WKS-9 default gateway', options: [
+            { id: 'a', text: '172.24.8.1' }, { id: 'b', text: '172.24.9.1' }, { id: 'c', text: '172.16.8.1' } ] }
+        ] },
+        answer: { slots: { gateway: 'a' } } }
+    ]
+  },
+
+  // 7 — diagnose + reconfigure, 10.x, wrong host IP
+  {
+    id: 'np-diag-hq-diagnose-ip',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Diagnose then fix the HQ finance PC',
+    estMinutes: 5, archetype: 'diagram',
+    scenario: 'HQ finance segment 10.10.40.0/24 has a router, a switch, a file server, and a finance PC. The finance user reports the shared drive times out and pings to the file server fail.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '10.10.40.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'finance', ip: '10.10.40.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'finance', ip: '10.10.40.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'fs2', label: 'FS-2', type: 'server', zone: 'finance', ip: '10.10.40.20', mask: '255.255.255.0', gateway: '10.10.40.1', x: 1, y: 2 },
+        { id: 'pcf1', label: 'PC-F1', type: 'pc', zone: 'finance', ip: '10.10.41.77', mask: '255.255.255.0', gateway: '10.10.40.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'fs2' }, { from: 'sw1', to: 'pcf1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1,
+        prompt: 'Which device is misconfigured?',
+        explanation: 'PC-F1 holds 10.10.41.77, a different /24 than the documented finance subnet 10.10.40.0/24, stranding it from FS-2.',
+        payload: { slots: [
+          { id: 'device', label: 'Misconfigured device', options: [
+            { id: 'a', text: 'FS-2' }, { id: 'b', text: 'PC-F1' }, { id: 'c', text: 'RTR-1' } ] }
+        ] },
+        answer: { slots: { device: 'b' } } },
+      { id: 's2', type: 'configure', points: 1, deviceId: 'pcf1',
+        prompt: 'Fix PC-F1’s IP address so it can reach FS-2.',
+        explanation: 'Changing the third octet from 41 to 40 places PC-F1 back inside the documented 10.10.40.0/24 subnet.',
+        payload: { slots: [
+          { id: 'ip', label: 'PC-F1 IP address', options: [
+            { id: 'a', text: '10.10.40.77' }, { id: 'b', text: '10.10.41.77' }, { id: 'c', text: '10.40.10.77' } ] }
+        ] },
+        answer: { slots: { ip: 'a' } } }
+    ]
+  },
+
+  // 8 — wrong mask, /26 vs /24, 192.168.x
+  {
+    id: 'np-diag-mask-26-retail',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Widen the retail POS mask',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A retail store LAN 192.168.60.0/24 hosts a router, a switch, a POS terminal, and a back-office PC. The POS terminal cannot process card transactions that route through the back-office PC’s validation service.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '192.168.60.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'store', ip: '192.168.60.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'store', ip: '192.168.60.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'office1', label: 'OFFICE-PC', type: 'pc', zone: 'store', ip: '192.168.60.15', mask: '255.255.255.0', gateway: '192.168.60.1', x: 1, y: 2 },
+        { id: 'pos1', label: 'POS-1', type: 'pc', zone: 'store', ip: '192.168.60.80', mask: '255.255.255.192', gateway: '192.168.60.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'office1' }, { from: 'sw1', to: 'pos1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'pos1',
+        prompt: 'POS-1’s mask is too narrow for the LAN. Fix it.',
+        explanation: 'POS-1 carries a /26 mask (255.255.255.192), which only spans 192.168.60.64–.127. OFFICE-PC at .15 falls outside that range from POS-1’s point of view, so POS-1 treats it as remote. The documented LAN mask is /24.',
+        payload: { slots: [
+          { id: 'mask', label: 'POS-1 subnet mask', options: [
+            { id: 'a', text: '255.255.255.0' }, { id: 'b', text: '255.255.255.192' }, { id: 'c', text: '255.255.255.224' } ] }
+        ] },
+        answer: { slots: { mask: 'a' } } }
+    ]
+  },
+
+  // 9 — wrong host IP, 10.x, server
+  {
+    id: 'np-diag-backup-server-wrongnet',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Recover the backup server’s address',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A backup segment 10.5.5.0/24 has a router, a switch, a primary server, and a backup server. Scheduled backups have been failing to connect all week.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '10.5.5.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'backup', ip: '10.5.5.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'backup', ip: '10.5.5.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'prim1', label: 'PRIMARY-1', type: 'server', zone: 'backup', ip: '10.5.5.10', mask: '255.255.255.0', gateway: '10.5.5.1', x: 1, y: 2 },
+        { id: 'bkp1', label: 'BACKUP-1', type: 'server', zone: 'backup', ip: '10.6.5.10', mask: '255.255.255.0', gateway: '10.5.5.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'prim1' }, { from: 'sw1', to: 'bkp1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'bkp1',
+        prompt: 'BACKUP-1 sits on the wrong network. Fix its IP address.',
+        explanation: 'BACKUP-1 was assigned 10.6.5.10 instead of an address in 10.5.5.0/24, isolating it from PRIMARY-1 despite both being cabled to the same switch.',
+        payload: { slots: [
+          { id: 'ip', label: 'BACKUP-1 IP address', options: [
+            { id: 'a', text: '10.5.5.10' }, { id: 'b', text: '10.6.5.10' }, { id: 'c', text: '10.5.6.10' } ] }
+        ] },
+        answer: { slots: { ip: 'a' } },
+      }
+    ]
+  },
+
+  // 10 — wrong gateway, VLAN framing, 192.168.x
+  {
+    id: 'np-diag-vlan20-wrong-gw',
+    cert: 'netplus', objective: '1.4', topic: 'VLANs',
+    title: 'Fix the Guest VLAN gateway',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'Guest Wi-Fi VLAN 20 (192.168.20.0/24) serves visitor devices behind an access switch. A guest laptop connects and gets an in-range IP but reports "no internet" while other guests are fine.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '192.168.20.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'guest', ip: '192.168.20.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'swb', label: 'SW-B', type: 'switch', zone: 'guest', ip: '192.168.20.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'pc7', label: 'PC-7', type: 'pc', zone: 'guest', ip: '192.168.20.31', mask: '255.255.255.0', gateway: '192.168.20.1', x: 1, y: 2 },
+        { id: 'lap3', label: 'LAP-3', type: 'pc', zone: 'guest', ip: '192.168.20.62', mask: '255.255.255.0', gateway: '192.168.10.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'swb' }, { from: 'swb', to: 'pc7' }, { from: 'swb', to: 'lap3' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'lap3',
+        prompt: 'LAP-3 has a valid Guest VLAN address but no internet. Fix its default gateway.',
+        explanation: 'LAP-3 was pointed at 192.168.10.1, the Staff VLAN’s gateway, which cannot route Guest-subnet traffic. The correct gateway for VLAN 20 hosts is 192.168.20.1.',
+        payload: { slots: [
+          { id: 'gateway', label: 'LAP-3 default gateway', options: [
+            { id: 'a', text: '192.168.20.1' }, { id: 'b', text: '192.168.10.1' }, { id: 'c', text: '192.168.2.1' } ] }
+        ] },
+        answer: { slots: { gateway: 'a' } } }
+    ]
+  },
+
+  // 11 — off-by-one, 10.x
+  {
+    id: 'np-diag-offbyone-10',
+    cert: 'netplus', objective: '1.4', topic: 'IPv4 addressing',
+    title: 'Spot the near-miss subnet',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'Engineering LAN 10.15.20.0/24 has a router, a switch, a build server, and an engineer’s workstation. The workstation can browse the internet fine but cannot reach the build server for code deploys.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '10.15.20.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'eng', ip: '10.15.20.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'eng', ip: '10.15.20.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'build1', label: 'BUILD-1', type: 'server', zone: 'eng', ip: '10.15.20.40', mask: '255.255.255.0', gateway: '10.15.20.1', x: 1, y: 2 },
+        { id: 'eng1', label: 'ENG-1', type: 'pc', zone: 'eng', ip: '10.15.21.40', mask: '255.255.255.0', gateway: '10.15.20.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'build1' }, { from: 'sw1', to: 'eng1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'eng1',
+        prompt: 'ENG-1 can reach the internet through the gateway but not local hosts. Fix its IP address.',
+        explanation: 'ENG-1 holds 10.15.21.40 — the third octet is off by one from the documented 10.15.20.0/24 segment, so its local subnet mask excludes BUILD-1 even though the gateway still routes its internet-bound traffic.',
+        payload: { slots: [
+          { id: 'ip', label: 'ENG-1 IP address', options: [
+            { id: 'a', text: '10.15.20.40' }, { id: 'b', text: '10.15.21.40' }, { id: 'c', text: '10.16.20.40' } ] }
+        ] },
+        answer: { slots: { ip: 'a' } } }
+    ]
+  },
+
+  // 12 — wrong gateway, small 172 office
+  {
+    id: 'np-diag-clinic-wrong-gw',
+    cert: 'netplus', objective: '1.4', topic: 'Default gateways',
+    title: 'Restore the clinic kiosk’s gateway',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A clinic check-in network 172.18.2.0/24 has a router, a switch, a records server, and a check-in kiosk. The kiosk can reach the records server on the LAN but its cloud scheduling sync has been failing.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '172.18.2.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'clinic', ip: '172.18.2.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'clinic', ip: '172.18.2.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'rec1', label: 'RECORDS-1', type: 'server', zone: 'clinic', ip: '172.18.2.10', mask: '255.255.255.0', gateway: '172.18.2.1', x: 1, y: 2 },
+        { id: 'kiosk1', label: 'KIOSK-1', type: 'pc', zone: 'clinic', ip: '172.18.2.50', mask: '255.255.255.0', gateway: '172.18.3.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'rec1' }, { from: 'sw1', to: 'kiosk1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'kiosk1',
+        prompt: 'KIOSK-1 syncs locally but not to the cloud. Fix its default gateway.',
+        explanation: 'KIOSK-1 points to 172.18.3.1, which is outside the 172.18.2.0/24 clinic subnet, so cloud-bound traffic is never forwarded. The router’s interface on this segment is 172.18.2.1.',
+        payload: { slots: [
+          { id: 'gateway', label: 'KIOSK-1 default gateway', options: [
+            { id: 'a', text: '172.18.2.1' }, { id: 'b', text: '172.18.3.1' }, { id: 'c', text: '172.28.2.1' } ] }
+        ] },
+        answer: { slots: { gateway: 'a' } } }
+    ]
+  },
+
+  // 13 — wrong mask, /28 vs /24, 192.168.x with server + 2 PCs
+  {
+    id: 'np-diag-mask-28-conference',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Correct the conference room mask',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'A conference room LAN 192.168.70.0/24 has a router, a switch, a media server, and a presenter’s laptop. The laptop can’t stream to the media server despite a healthy link light.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '192.168.70.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'conf', ip: '192.168.70.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'conf', ip: '192.168.70.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'media1', label: 'MEDIA-1', type: 'server', zone: 'conf', ip: '192.168.70.20', mask: '255.255.255.0', gateway: '192.168.70.1', x: 1, y: 2 },
+        { id: 'lap9', label: 'LAP-9', type: 'pc', zone: 'conf', ip: '192.168.70.35', mask: '255.255.255.240', gateway: '192.168.70.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'media1' }, { from: 'sw1', to: 'lap9' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'lap9',
+        prompt: 'LAP-9’s mask disagrees with the documented LAN. Fix it.',
+        explanation: 'LAP-9 carries a /28 mask (255.255.255.240), spanning only 192.168.70.32–.47. MEDIA-1 at .20 falls outside that block from LAP-9’s view. The documented LAN mask is /24.',
+        payload: { slots: [
+          { id: 'mask', label: 'LAP-9 subnet mask', options: [
+            { id: 'a', text: '255.255.255.0' }, { id: 'b', text: '255.255.255.240' }, { id: 'c', text: '255.255.255.248' } ] }
+        ] },
+        answer: { slots: { mask: 'a' } } }
+    ]
+  },
+
+  // 14 — diagnose + reconfigure, wrong gateway, 172.16-31
+  {
+    id: 'np-diag-warehouse-diagnose-gw',
+    cert: 'netplus', objective: '1.4', topic: 'Default gateways',
+    title: 'Diagnose and repair the scanner gateway',
+    estMinutes: 5, archetype: 'diagram',
+    scenario: 'Warehouse inventory segment 172.29.12.0/24 has a router, a switch, an inventory server, and a handheld scanner base station. The base station can sync to the inventory server but can’t reach the cloud inventory API.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '172.29.12.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'wh2', ip: '172.29.12.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'wh2', ip: '172.29.12.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'inv1', label: 'INV-1', type: 'server', zone: 'wh2', ip: '172.29.12.15', mask: '255.255.255.0', gateway: '172.29.12.1', x: 1, y: 2 },
+        { id: 'scanbase1', label: 'SCANBASE-1', type: 'pc', zone: 'wh2', ip: '172.29.12.60', mask: '255.255.255.0', gateway: '172.29.13.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'inv1' }, { from: 'sw1', to: 'scanbase1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1,
+        prompt: 'Which device is misconfigured?',
+        explanation: 'SCANBASE-1’s gateway (172.29.13.1) is outside the documented 172.29.12.0/24 subnet, so it cannot forward off-segment traffic to the cloud API.',
+        payload: { slots: [
+          { id: 'device', label: 'Misconfigured device', options: [
+            { id: 'a', text: 'INV-1' }, { id: 'b', text: 'SCANBASE-1' }, { id: 'c', text: 'SW-1' } ] }
+        ] },
+        answer: { slots: { device: 'b' } } },
+      { id: 's2', type: 'configure', points: 1, deviceId: 'scanbase1',
+        prompt: 'Fix SCANBASE-1’s default gateway.',
+        explanation: 'The router’s interface on this segment is 172.29.12.1; pointing SCANBASE-1 there restores its route to the cloud API.',
+        payload: { slots: [
+          { id: 'gateway', label: 'SCANBASE-1 default gateway', options: [
+            { id: 'a', text: '172.29.12.1' }, { id: 'b', text: '172.29.13.1' }, { id: 'c', text: '172.19.12.1' } ] }
+        ] },
+        answer: { slots: { gateway: 'a' } } }
+    ]
+  },
+
+  // 15 — wrong host IP, 192.168.x, small office with 2 PCs + printer
+  {
+    id: 'np-diag-accounting-wrongnet',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Move the accounting PC back on-net',
+    estMinutes: 4, archetype: 'diagram',
+    scenario: 'Accounting office LAN 192.168.90.0/24 has a router, a switch, a shared printer, and an accounting PC. The accountant can’t print month-end reports and gets destination-unreachable errors.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '192.168.90.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'acct', ip: '192.168.90.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'acct', ip: '192.168.90.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'prn2', label: 'PRN-2', type: 'printer', zone: 'acct', ip: '192.168.90.25', mask: '255.255.255.0', gateway: '192.168.90.1', x: 1, y: 2 },
+        { id: 'actpc1', label: 'ACCT-PC1', type: 'pc', zone: 'acct', ip: '192.168.91.25', mask: '255.255.255.0', gateway: '192.168.90.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'prn2' }, { from: 'sw1', to: 'actpc1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'actpc1',
+        prompt: 'ACCT-PC1 is on the wrong network. Fix its IP address.',
+        explanation: 'ACCT-PC1 holds 192.168.91.25, a different /24 than the documented accounting LAN (192.168.90.0/24), so it cannot reach PRN-2 despite sharing a switch.',
+        payload: { slots: [
+          { id: 'ip', label: 'ACCT-PC1 IP address', options: [
+            { id: 'a', text: '192.168.90.25' }, { id: 'b', text: '192.168.91.25' }, { id: 'c', text: '192.168.9.25' } ] }
+        ] },
+        answer: { slots: { ip: 'a' } } }
+    ]
+  },
+
+  // 16 — wrong mask AND wrong gateway (ip-only slot unaffected), 10.x
+  {
+    id: 'np-diag-remote-office-mask-gw',
+    cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+    title: 'Fix the remote office workstation fully',
+    estMinutes: 5, archetype: 'diagram',
+    scenario: 'Remote sales office 10.40.2.0/24 has a router, a switch, a CRM server, and a sales workstation. The salesperson’s workstation can’t log into the CRM server or reach the VPN back to headquarters.',
+    assets: { reference: { kind: 'network',
+      given: { networkId: '10.40.2.0', mask: '255.255.255.0' },
+      devices: [
+        { id: 'rtr1', label: 'RTR-1', type: 'router', zone: 'sales', ip: '10.40.2.1', mask: '255.255.255.0', x: 2, y: 0 },
+        { id: 'sw1', label: 'SW-1', type: 'switch', zone: 'sales', ip: '10.40.2.2', mask: '255.255.255.0', x: 2, y: 1 },
+        { id: 'crm1', label: 'CRM-1', type: 'server', zone: 'sales', ip: '10.40.2.10', mask: '255.255.255.0', gateway: '10.40.2.1', x: 1, y: 2 },
+        { id: 'sales1', label: 'SALES-1', type: 'pc', zone: 'sales', ip: '10.40.2.140', mask: '255.255.255.128', gateway: '10.40.3.1', x: 3, y: 2, state: 'affected' }
+      ],
+      links: [ { from: 'rtr1', to: 'sw1' }, { from: 'sw1', to: 'crm1' }, { from: 'sw1', to: 'sales1' } ]
+    } },
+    steps: [
+      { id: 's1', type: 'configure', points: 1, deviceId: 'sales1',
+        prompt: 'SALES-1 has two configuration problems. Fix its subnet mask and default gateway.',
+        explanation: 'SALES-1’s /25 mask (255.255.255.128) puts its address .140 in the upper half (.128–.255) of the subnet, while RTR-1, SW-1, and CRM-1 (.1/.2/.10) sit in the lower half (.0–.127) — so SALES-1 sees CRM-1 as being on a different network. Its gateway 10.40.3.1 also sits outside the 10.40.2.0/24 segment entirely. Correcting both to the /24 mask and the router’s 10.40.2.1 interface restores both local and VPN reachability.',
+        payload: { slots: [
+          { id: 'mask', label: 'SALES-1 subnet mask', options: [
+            { id: 'a', text: '255.255.255.0' }, { id: 'b', text: '255.255.255.128' }, { id: 'c', text: '255.255.255.192' } ] },
+          { id: 'gateway', label: 'SALES-1 default gateway', options: [
+            { id: 'a', text: '10.40.2.1' }, { id: 'b', text: '10.40.3.1' }, { id: 'c', text: '10.4.2.1' } ] }
+        ] },
+        answer: { slots: { mask: 'a', gateway: 'a' } } }
+    ]
   }
+
 ];

--- a/features/sim-lab-seed-netplus.js
+++ b/features/sim-lab-seed-netplus.js
@@ -1607,6 +1607,209 @@ window.SIM_LAB_SEED_NETPLUS = [
         ] },
         answer: { slots: { mask: 'a', gateway: 'a' } } }
     ]
+  },
+
+  // ── Defense in Depth (Task 14, 2-agent gated) ──
+  { id: 'netplus-did-flat-office', cert: 'netplus',
+    objective: 'N10-009 Domain 4.1 — Explain common security concepts (defense in depth, network segmentation)',
+    topic: 'Defense in Depth', title: 'One firewall, one flat network', estMinutes: 5, archetype: 'defense',
+    scenario: 'A small office has a stateful firewall at the edge and nothing else. Behind it, every device including the public-facing web server sits on one flat internal subnet. The perimeter looks solid, but it is the only real control in the whole design.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Stateful firewall', state: 'present' },
+        { id: 'dmz', label: 'Screened subnet (DMZ)', state: 'missing' },
+        { id: 'internal', label: 'Internal LAN', control: 'Single flat subnet, no VLANs', state: 'missing' }
+      ],
+      core: { label: 'Servers and data', assets: [
+        { id: 'web1', label: 'WEB-1 (public web server)', exposed: true },
+        { id: 'fs1', label: 'FS-1 (file server)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'Which layer of defense is missing in this design?',
+        explanation: 'Past the one firewall, everything is flat. The public web server sits right next to internal data with no screened subnet or segmentation between them, so a single breach reaches everything.',
+        payload: { slots: [ { id: 'layer', label: 'Missing layer', options: [
+          { id: 'l1', text: 'A screened subnet (DMZ) isolating the public web server' },
+          { id: 'l2', text: 'A second stateful firewall at the edge' },
+          { id: 'l3', text: 'A faster internet connection' },
+          { id: 'l4', text: 'A larger switch chassis' }
+        ] } ] },
+        answer: { slots: { layer: 'l1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Add the correct control at each layer.',
+        explanation: 'A DMZ isolates the public server between two firewalls so a compromise stays away from internal data, and VLAN segmentation stops one foothold from reaching every device.',
+        payload: { slots: [
+          { id: 'perimeter', label: 'Perimeter', options: [
+            { id: 'p1', text: 'Stateful firewall at the edge' }, { id: 'p2', text: 'Open all inbound ports for compatibility' } ] },
+          { id: 'dmz', label: 'Public-facing servers', options: [
+            { id: 'd1', text: 'Place in a screened subnet (DMZ) between two firewalls' }, { id: 'd2', text: 'Place directly on the internal LAN' } ] },
+          { id: 'internal', label: 'Internal network', options: [
+            { id: 'i1', text: 'Segment into VLANs by role' }, { id: 'i2', text: 'Keep as one flat subnet' } ] }
+        ] },
+        answer: { slots: { perimeter: 'p1', dmz: 'd1', internal: 'i1' } } }
+    ]
+  },
+
+  { id: 'netplus-did-wifi-no-acl', cert: 'netplus',
+    objective: 'N10-009 Domain 4.1 — Explain common security concepts (segmentation, access control lists, hardening)',
+    topic: 'Defense in Depth', title: 'Guest Wi-Fi with a straight line to payroll', estMinutes: 5, archetype: 'defense',
+    scenario: 'A retail branch has a firewall at the edge and a guest Wi-Fi SSID for customers. The guest network shares the same VLAN as the back-office LAN, and there is no ACL restricting traffic between them, so any guest device can reach the payroll server.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Edge firewall', state: 'present' },
+        { id: 'network', label: 'Network segmentation', control: 'Guest Wi-Fi shares VLAN with back office, no ACL', state: 'missing' },
+        { id: 'endpoint', label: 'Endpoint', control: 'Host firewall on payroll server', state: 'present' }
+      ],
+      core: { label: 'Back-office systems', assets: [
+        { id: 'pay1', label: 'PAY-1 (payroll server)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'Which layer has the gap in this design?',
+        explanation: 'The edge firewall and the payroll server\'s host firewall are both present, but guest and back-office traffic share one VLAN with no ACL between them, so the segmentation layer is the gap.',
+        payload: { slots: [ { id: 'layer', label: 'Missing layer', options: [
+          { id: 'l1', text: 'Network segmentation between guest Wi-Fi and back office' },
+          { id: 'l2', text: 'The edge firewall' },
+          { id: 'l3', text: 'The payroll server\'s host firewall' },
+          { id: 'l4', text: 'Physical door locks on the server room' }
+        ] } ] },
+        answer: { slots: { layer: 'l1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Add the correct control at each layer.',
+        explanation: 'A dedicated guest VLAN with an ACL blocking guest-to-back-office traffic closes the gap, while keeping the existing perimeter and endpoint controls in place.',
+        payload: { slots: [
+          { id: 'perimeter', label: 'Perimeter', options: [
+            { id: 'p1', text: 'Edge firewall filtering inbound/outbound traffic' }, { id: 'p2', text: 'No perimeter control needed' } ] },
+          { id: 'network', label: 'Network', options: [
+            { id: 'n1', text: 'Separate guest VLAN with an ACL denying access to the back-office VLAN' }, { id: 'n2', text: 'Same VLAN for guests and staff to simplify support' } ] },
+          { id: 'endpoint', label: 'Endpoint', options: [
+            { id: 'e1', text: 'Host-based firewall on the payroll server' }, { id: 'e2', text: 'Disable the payroll server\'s firewall for easier troubleshooting' } ] }
+        ] },
+        answer: { slots: { perimeter: 'p1', network: 'n1', endpoint: 'e1' } } }
+    ]
+  },
+
+  { id: 'netplus-did-unmanaged-switch', cert: 'netplus',
+    objective: 'N10-009 Domain 4.1 — Explain common security concepts (port security, hardening, segmentation)',
+    topic: 'Defense in Depth', title: 'A closet switch anyone can plug into', estMinutes: 5, archetype: 'defense',
+    scenario: 'A branch office has a firewall at the edge and VLANs separating departments. In the wiring closet, an unmanaged switch feeds the finance VLAN, and any of its open ports will hand out an address and full access to whoever plugs in, no authentication required.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Edge firewall', state: 'present' },
+        { id: 'network', label: 'Network segmentation', control: 'VLANs by department', state: 'present' },
+        { id: 'endpoint', label: 'Endpoint / port access', control: 'Open ports on an unmanaged switch, no port security', state: 'missing' }
+      ],
+      core: { label: 'Finance VLAN', assets: [
+        { id: 'fin1', label: 'FIN-DB (finance database)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'Which layer has the gap in this design?',
+        explanation: 'The perimeter and VLAN segmentation are both in place, but the finance VLAN\'s wiring closet uses an unmanaged switch with no port security, so anyone who plugs in gets full network access. The endpoint/port-access layer is the gap.',
+        payload: { slots: [ { id: 'layer', label: 'Missing layer', options: [
+          { id: 'l1', text: 'Port security on the access-layer switch' },
+          { id: 'l2', text: 'The edge firewall' },
+          { id: 'l3', text: 'VLAN segmentation' },
+          { id: 'l4', text: 'DNS filtering' }
+        ] } ] },
+        answer: { slots: { layer: 'l1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Add the correct control at each layer.',
+        explanation: 'Replacing the unmanaged switch with a managed switch running 802.1X or MAC-based port security stops unauthenticated devices from joining the finance VLAN, while the perimeter and segmentation layers stay as they are.',
+        payload: { slots: [
+          { id: 'perimeter', label: 'Perimeter', options: [
+            { id: 'p1', text: 'Edge firewall filtering traffic to the internet' }, { id: 'p2', text: 'No firewall, rely on VLANs alone' } ] },
+          { id: 'network', label: 'Network', options: [
+            { id: 'n1', text: 'VLANs segmenting finance from other departments' }, { id: 'n2', text: 'One VLAN for the entire building' } ] },
+          { id: 'endpoint', label: 'Port access', options: [
+            { id: 'e1', text: 'Managed switch with 802.1X port security' }, { id: 'e2', text: 'Unmanaged switch with all ports open' } ] }
+        ] },
+        answer: { slots: { perimeter: 'p1', network: 'n1', endpoint: 'e1' } } }
+    ]
+  },
+
+  { id: 'netplus-did-vpn-split-tunnel', cert: 'netplus',
+    objective: 'N10-009 Domain 4.1 — Explain common security concepts (remote access security, segmentation)',
+    topic: 'Defense in Depth', title: 'A remote worker with a shortcut around the firewall', estMinutes: 5, archetype: 'defense',
+    scenario: 'The company firewall inspects all traffic entering headquarters, and the internal LAN is segmented into VLANs. Remote employees connect over a site-to-site capable VPN, but split tunneling is enabled, so their internet traffic bypasses the corporate firewall entirely while their VPN tunnel still reaches internal servers.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Edge firewall inspecting inbound HQ traffic', state: 'present' },
+        { id: 'remote', label: 'Remote access', control: 'VPN with split tunneling enabled', state: 'missing' },
+        { id: 'network', label: 'Network segmentation', control: 'VLANs by department', state: 'present' }
+      ],
+      core: { label: 'Internal servers', assets: [
+        { id: 'app1', label: 'APP-1 (internal app server)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'Which layer has the gap in this design?',
+        explanation: 'The edge firewall and internal VLANs are both fine, but split tunneling lets a remote laptop reach the open internet unfiltered at the same time its VPN tunnel reaches internal servers. A compromised laptop becomes a bridge straight past the perimeter.',
+        payload: { slots: [ { id: 'layer', label: 'Missing layer', options: [
+          { id: 'l1', text: 'Remote access control (split tunneling bypasses the firewall)' },
+          { id: 'l2', text: 'The edge firewall inspecting HQ traffic' },
+          { id: 'l3', text: 'VLAN segmentation inside HQ' },
+          { id: 'l4', text: 'Physical security of the server room' }
+        ] } ] },
+        answer: { slots: { layer: 'l1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Add the correct control at each layer.',
+        explanation: 'Forcing full-tunnel VPN routes all remote traffic through the corporate firewall for inspection, closing the bypass while the existing perimeter and segmentation layers remain effective.',
+        payload: { slots: [
+          { id: 'perimeter', label: 'Perimeter', options: [
+            { id: 'p1', text: 'Edge firewall inspecting all inbound and outbound traffic' }, { id: 'p2', text: 'Firewall inspecting only inbound traffic' } ] },
+          { id: 'remote', label: 'Remote access', options: [
+            { id: 'r1', text: 'Full-tunnel VPN routing all traffic through the corporate firewall' }, { id: 'r2', text: 'Split-tunnel VPN so internet traffic bypasses the firewall' } ] },
+          { id: 'network', label: 'Network', options: [
+            { id: 'n1', text: 'VLANs segmenting internal servers by department' }, { id: 'n2', text: 'One flat VLAN for all internal servers' } ] }
+        ] },
+        answer: { slots: { perimeter: 'p1', remote: 'r1', network: 'n1' } } }
+    ]
+  },
+
+  { id: 'netplus-did-iot-vlan', cert: 'netplus',
+    objective: 'N10-009 Domain 4.1 — Explain common security concepts (IoT segmentation, hardening)',
+    topic: 'Defense in Depth', title: 'Smart cameras on the same VLAN as the servers', estMinutes: 5, archetype: 'defense',
+    scenario: 'A warehouse has an edge firewall and VLAN segmentation for its office network. Recently installed IoT security cameras were plugged into the same VLAN as the inventory servers because it was the quickest way to get them online, and the cameras still use their factory-default credentials.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Edge firewall', state: 'present' },
+        { id: 'network', label: 'Network segmentation', control: 'IoT cameras share the server VLAN', state: 'missing' },
+        { id: 'endpoint', label: 'Endpoint hardening', control: 'Cameras still use default credentials', state: 'missing' }
+      ],
+      core: { label: 'Inventory servers', assets: [
+        { id: 'inv1', label: 'INV-1 (inventory server)', exposed: true },
+        { id: 'cam1', label: 'CAM-1 (default-credential camera)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'Which layer has the biggest gap here?',
+        explanation: 'Unhardened IoT devices sharing a VLAN with production servers is the core problem: a camera with default credentials is an easy foothold, and because there is no segmentation, that foothold reaches the inventory server directly.',
+        payload: { slots: [ { id: 'layer', label: 'Missing layer', options: [
+          { id: 'l1', text: 'IoT devices are not segmented from servers and still use default credentials' },
+          { id: 'l2', text: 'The edge firewall is misconfigured' },
+          { id: 'l3', text: 'The warehouse has too much bandwidth' },
+          { id: 'l4', text: 'The inventory server is too old' }
+        ] } ] },
+        answer: { slots: { layer: 'l1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Add the correct control at each layer.',
+        explanation: 'Moving IoT devices to a dedicated VLAN with no route to servers, and changing default credentials on every camera, closes both gaps while the perimeter firewall stays as-is.',
+        payload: { slots: [
+          { id: 'perimeter', label: 'Perimeter', options: [
+            { id: 'p1', text: 'Edge firewall filtering internet-bound traffic' }, { id: 'p2', text: 'No firewall needed for a warehouse' } ] },
+          { id: 'network', label: 'Network', options: [
+            { id: 'n1', text: 'Dedicated IoT VLAN isolated from the server VLAN' }, { id: 'n2', text: 'Keep IoT devices on the server VLAN for convenience' } ] },
+          { id: 'endpoint', label: 'Endpoint', options: [
+            { id: 'e1', text: 'Change default credentials on every camera' }, { id: 'e2', text: 'Leave factory-default credentials in place' } ] }
+        ] },
+        answer: { slots: { perimeter: 'p1', network: 'n1', endpoint: 'e1' } } }
+    ]
   }
 
 ];

--- a/features/sim-lab-seed-secplus.js
+++ b/features/sim-lab-seed-secplus.js
@@ -2107,7 +2107,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (defense in depth, control categories)',
     topic: 'Defense in Depth', title: 'Strong wall, hollow inside', estMinutes: 6, archetype: 'defense',
     scenario: 'A security review of Northwind HQ finds a capable next-gen firewall at the edge and almost nothing behind it. Endpoints are unmanaged, the database stores records in clear text, and one shared admin account opens everything. A single phishing click puts an attacker next to the crown jewels.',
-    assets: { reference: { kind: 'layered',
+    assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
         { id: 'perimeter', label: 'Perimeter', control: 'Next-gen firewall', state: 'present' },
         { id: 'endpoint', label: 'Endpoint', control: 'EDR and host hardening', state: 'missing' },
@@ -2159,7 +2159,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (zero trust, control categories)',
     topic: 'Defense in Depth', title: 'A clinic that trusts anything already inside', estMinutes: 6, archetype: 'defense',
     scenario: 'A regional clinic passed its firewall audit with flying colors, but once inside the network every workstation can reach the patient records database directly, there is no logging on that database, and staff share one login for the scheduling system. An attacker who lands on any workstation has an unmonitored path to patient data.',
-    assets: { reference: { kind: 'layered',
+    assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
         { id: 'perimeter', label: 'Perimeter', control: 'Audited edge firewall', state: 'present' },
         { id: 'network', label: 'Network segmentation', control: 'Micro-segmentation isolating the records database', state: 'missing' },
@@ -2210,7 +2210,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (cloud security, control categories)',
     topic: 'Defense in Depth', title: 'A cloud app with one line of defense', estMinutes: 6, archetype: 'defense',
     scenario: 'A startup moved its customer app to the cloud and configured a web application firewall in front of it. Behind the WAF, the storage bucket holding customer uploads is publicly readable, the application server runs with an overly permissive IAM role, and there is no vulnerability scanning of the container images before they deploy.',
-    assets: { reference: { kind: 'layered',
+    assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
         { id: 'perimeter', label: 'Perimeter', control: 'Web application firewall', state: 'present' },
         { id: 'data', label: 'Data', control: 'Private bucket policy with least-privilege access', state: 'missing' },
@@ -2261,7 +2261,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (third-party access, control categories)',
     topic: 'Defense in Depth', title: 'A vendor with the keys to everything', estMinutes: 6, archetype: 'defense',
     scenario: 'A manufacturing plant lets a third-party HVAC vendor remote into its network to service building controls. The vendor connects through a properly configured VPN, but from there the vendor account can reach the plant\'s production control systems, sessions are never recorded, and the vendor account has never been reviewed since it was created two years ago.',
-    assets: { reference: { kind: 'layered',
+    assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
         { id: 'perimeter', label: 'Perimeter', control: 'VPN gateway for vendor remote access', state: 'present' },
         { id: 'network', label: 'Network segmentation', control: 'Jump host isolating vendor access from production systems', state: 'missing' },
@@ -2312,7 +2312,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (defense in depth, control categories)',
     topic: 'Defense in Depth', title: 'One phishing email away from total loss', estMinutes: 6, archetype: 'defense',
     scenario: 'A law firm\'s branch office relies on email spam filtering as its only defense against ransomware. Endpoints have no EDR, backups are stored on a network share reachable from every workstation, and there is no security awareness training, so staff routinely click on suspicious attachments.',
-    assets: { reference: { kind: 'layered',
+    assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
         { id: 'perimeter', label: 'Perimeter', control: 'Email spam filtering', state: 'present' },
         { id: 'endpoint', label: 'Endpoint', control: 'EDR with ransomware behavior detection', state: 'missing' },

--- a/features/sim-lab-seed-secplus.js
+++ b/features/sim-lab-seed-secplus.js
@@ -2109,7 +2109,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     scenario: 'A security review of Northwind HQ finds a capable next-gen firewall at the edge and almost nothing behind it. Endpoints are unmanaged, the database stores records in clear text, and one shared admin account opens everything. A single phishing click puts an attacker next to the crown jewels.',
     assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
-        { id: 'perimeter', label: 'Perimeter', control: 'Next-gen firewall', state: 'present' },
+        { id: 'perimeter', label: 'Perimeter', control: 'Next-gen firewall', state: 'present', device: { label: 'FW-1' } },
         { id: 'endpoint', label: 'Endpoint', control: 'EDR and host hardening', state: 'missing' },
         { id: 'data', label: 'Data', control: 'Encryption at rest and DLP', state: 'missing' },
         { id: 'identity', label: 'Identity', control: 'MFA and least privilege', state: 'missing' }
@@ -2161,7 +2161,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     scenario: 'A regional clinic passed its firewall audit with flying colors, but once inside the network every workstation can reach the patient records database directly, there is no logging on that database, and staff share one login for the scheduling system. An attacker who lands on any workstation has an unmonitored path to patient data.',
     assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
-        { id: 'perimeter', label: 'Perimeter', control: 'Audited edge firewall', state: 'present' },
+        { id: 'perimeter', label: 'Perimeter', control: 'Audited edge firewall', state: 'present', device: { label: 'FW-1' } },
         { id: 'network', label: 'Network segmentation', control: 'Micro-segmentation isolating the records database', state: 'missing' },
         { id: 'monitoring', label: 'Monitoring', control: 'Database access logging and alerting', state: 'missing' },
         { id: 'identity', label: 'Identity', control: 'Unique accounts and least privilege', state: 'missing' }
@@ -2212,7 +2212,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     scenario: 'A startup moved its customer app to the cloud and configured a web application firewall in front of it. Behind the WAF, the storage bucket holding customer uploads is publicly readable, the application server runs with an overly permissive IAM role, and there is no vulnerability scanning of the container images before they deploy.',
     assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
-        { id: 'perimeter', label: 'Perimeter', control: 'Web application firewall', state: 'present' },
+        { id: 'perimeter', label: 'Perimeter', control: 'Web application firewall', state: 'present', device: { label: 'WAF-1' } },
         { id: 'data', label: 'Data', control: 'Private bucket policy with least-privilege access', state: 'missing' },
         { id: 'identity', label: 'Identity', control: 'Scoped IAM role for the application server', state: 'missing' },
         { id: 'application', label: 'Application', control: 'Vulnerability scanning in the CI/CD pipeline', state: 'missing' }
@@ -2263,7 +2263,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     scenario: 'A manufacturing plant lets a third-party HVAC vendor remote into its network to service building controls. The vendor connects through a properly configured VPN, but from there the vendor account can reach the plant\'s production control systems, sessions are never recorded, and the vendor account has never been reviewed since it was created two years ago.',
     assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
-        { id: 'perimeter', label: 'Perimeter', control: 'VPN gateway for vendor remote access', state: 'present' },
+        { id: 'perimeter', label: 'Perimeter', control: 'VPN gateway for vendor remote access', state: 'present', device: { label: 'VPN-1' } },
         { id: 'network', label: 'Network segmentation', control: 'Jump host isolating vendor access from production systems', state: 'missing' },
         { id: 'monitoring', label: 'Monitoring', control: 'Session recording for third-party access', state: 'missing' },
         { id: 'identity', label: 'Identity', control: 'Periodic access review of vendor accounts', state: 'missing' }
@@ -2314,7 +2314,7 @@ window.SIM_LAB_SEED_SECPLUS = [
     scenario: 'A law firm\'s branch office relies on email spam filtering as its only defense against ransomware. Endpoints have no EDR, backups are stored on a network share reachable from every workstation, and there is no security awareness training, so staff routinely click on suspicious attachments.',
     assets: { reference: { kind: 'layered', layout: 'stacked',
       layers: [
-        { id: 'perimeter', label: 'Perimeter', control: 'Email spam filtering', state: 'present' },
+        { id: 'perimeter', label: 'Perimeter', control: 'Email spam filtering', state: 'present', device: { label: 'SEG-1' } },
         { id: 'endpoint', label: 'Endpoint', control: 'EDR with ransomware behavior detection', state: 'missing' },
         { id: 'backup', label: 'Backup', control: 'Immutable, network-isolated backups', state: 'missing' },
         { id: 'awareness', label: 'Personnel', control: 'Security awareness training', state: 'missing' }

--- a/features/sim-lab-seed-secplus.js
+++ b/features/sim-lab-seed-secplus.js
@@ -1265,5 +1265,840 @@ window.SIM_LAB_SEED_SECPLUS = [
         },
         answer: { pairs: { gdpr: 'deureg', rtbf: 'ddelete', sovereignty: 'dlaws', minimization: 'donlyneed', anon: 'dstrip' } } }
     ]
+  },
+
+  // ===== Sec+ Incident Response PBQ bank (Task 13, 2-agent consensus gated) =====
+  // 1. Phishing/BEC — Detection & Analysis emphasis
+  {
+    id: 'sp-ir-bec-wiretransfer', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'BEC wire-transfer fraud', estMinutes: 5, archetype: 'incident',
+    scenario: 'The CFO\'s assistant received an email that appeared to come from the CEO, urgently requesting a same-day wire transfer to a "new vendor." The domain was one character off from the real company domain. The assistant initiated the transfer before Accounting flagged it.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'mail', label: 'Spoofed "CEO" email arrives requesting urgent wire transfer', time: 'T+0m', severity: 'med' },
+      { id: 's2', icon: 'search', label: 'Assistant does not verify sender domain; replies to confirm details', time: 'T+12m', severity: 'med' },
+      { id: 's3', icon: 'bank', label: 'Wire transfer of $42,000 initiated to attacker-controlled account', time: 'T+40m', severity: 'high' },
+      { id: 's4', icon: 'alert', label: 'Accounting notices the vendor was never onboarded and halts further payments', time: 'T+70m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A look-alike domain plus a spoofed executive identity requesting an urgent, unverified wire transfer is the classic pattern for Business Email Compromise (BEC). Given money already left the organization, this is high severity, and the first action is to stop further loss by contacting the bank and freezing the transaction where possible.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'bank', text: 'Contact the bank to attempt to recall or freeze the wire transfer' },
+            { id: 'reset', text: 'Reset the CFO assistant\'s email password' },
+            { id: 'block', text: 'Block the sender domain at the email gateway' },
+            { id: 'train', text: 'Schedule phishing-awareness training for Accounting' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'high', first: 'bank' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'NIST SP 800-61 sequencing: contain the financial loss (bank), then eradicate the vector (block spoofed domain), then recover (verify no other fraudulent payments) before lessons learned (payment-verification procedure).',
+        payload: { items: [
+          { id: 'a', label: 'Contact the bank to attempt to recall the wire transfer' },
+          { id: 'b', label: 'Block the look-alike domain at the email gateway' },
+          { id: 'c', label: 'Audit recent outgoing payments for other fraudulent transfers' },
+          { id: 'd', label: 'Implement a call-back verification policy for wire requests' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 2. Ransomware — Containment emphasis
+  {
+    id: 'sp-ir-ransomware-fileserver', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Ransomware on the file server', estMinutes: 5, archetype: 'incident',
+    scenario: 'Employees report they can no longer open shared documents. File names on SRV-FILE now end in ".locked" and a ransom note appears in every folder. The backup server on the same VLAN is also showing signs of encryption activity.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'lock', label: 'Users report shared files renamed with .locked extension', time: 'T+0m', severity: 'high' },
+      { id: 's2', icon: 'note', label: 'Ransom note found in every network share', time: 'T+5m', severity: 'crit' },
+      { id: 's3', icon: 'disk', label: 'Backup server on the same VLAN shows encryption activity starting', time: 'T+9m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'Active ransomware spreading to the backup server is a critical incident — it threatens both production data and recovery capability. The first action must be to isolate the affected segment from the network to stop the encryption from spreading further, before any eradication or recovery work begins.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'isolate', text: 'Isolate SRV-FILE and the backup server from the network' },
+            { id: 'restore', text: 'Immediately restore SRV-FILE from the most recent backup' },
+            { id: 'pay', text: 'Pay the ransom to get the decryption key' },
+            { id: 'patch', text: 'Patch SRV-FILE\'s operating system' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'isolate' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Isolate first to stop the spread, then eradicate the ransomware binary/persistence, then recover from a verified clean, offline backup, and finally document lessons learned (e.g., segmenting backups, tightening RDP/exposed services).',
+        payload: { items: [
+          { id: 'a', label: 'Isolate the affected servers from the network' },
+          { id: 'b', label: 'Identify and remove the ransomware and any persistence mechanisms' },
+          { id: 'c', label: 'Restore data from a verified offline/immutable backup' },
+          { id: 'd', label: 'Document the incident and segment backups from production' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 3. DDoS — Preparation/Detection emphasis
+  {
+    id: 'sp-ir-ddos-webstore', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Volumetric DDoS against the storefront', estMinutes: 4, archetype: 'incident',
+    scenario: 'The e-commerce site becomes unreachable. Monitoring shows inbound traffic spiking to 40x baseline from thousands of distinct source IPs, all hitting the homepage with identical GET requests. No unusual database queries or file changes are observed.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'chart', label: 'Inbound traffic spikes to 40x normal baseline', time: 'T+0m', severity: 'high' },
+      { id: 's2', icon: 'globe', label: 'Thousands of distinct source IPs send identical GET requests', time: 'T+2m', severity: 'high' },
+      { id: 's3', icon: 'down', label: 'Web servers become unresponsive; legitimate customers cannot check out', time: 'T+6m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A volumetric flood from many distinct IPs with no data compromise is a distributed denial-of-service attack against availability. Because the storefront is fully down, this is critical. The first action is to engage upstream DDoS mitigation (scrubbing/rate limiting via the CDN or ISP), not to patch or investigate individual hosts.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'scrub', text: 'Enable upstream DDoS scrubbing / rate limiting via the CDN or ISP' },
+            { id: 'reboot', text: 'Reboot the web servers' },
+            { id: 'patch', text: 'Patch the web application for SQL injection' },
+            { id: 'forensics', text: 'Begin a full disk forensic image of the database server' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'scrub' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by engaging upstream mitigation, eradicate by blackholing/blocking the worst offending sources, recover by confirming normal service, then apply lessons learned by adding a standing DDoS mitigation contract or capacity plan.',
+        payload: { items: [
+          { id: 'a', label: 'Engage upstream DDoS scrubbing / rate limiting' },
+          { id: 'b', label: 'Block or blackhole the highest-volume offending source ranges' },
+          { id: 'c', label: 'Confirm the storefront is reachable and responsive again' },
+          { id: 'd', label: 'Establish a standing DDoS mitigation service and capacity plan' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 4. Insider threat — Lessons learned emphasis, network reference
+  {
+    id: 'sp-ir-insider-exfil', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Departing employee data theft', esta: null, estMinutes: 5, archetype: 'incident',
+    scenario: 'A sales engineer submitted their resignation this morning. DLP logs show that last night, from their laptop, the entire customer contract repository was copied to a personal USB drive and uploaded to a personal cloud storage account.',
+    assets: { reference: { kind: 'network', devices: [
+      { id: 'lap', label: 'SE-LAPTOP', type: 'workstation', zone: 'internal', x: 60, y: 90, state: 'compromised' },
+      { id: 'usb', label: 'USB Drive', type: 'device', zone: 'internal', x: 220, y: 90, state: 'affected' },
+      { id: 'fs', label: 'CONTRACTS-SHARE', type: 'server', zone: 'internal', x: 60, y: 170, state: 'affected' },
+      { id: 'cloud', label: 'Personal Cloud', type: 'external', zone: 'external', x: 400, y: 90, state: 'clean' }
+    ], links: [
+      { from: 'fs', to: 'lap', kind: 'attack' },
+      { from: 'lap', to: 'usb', kind: 'attack' },
+      { from: 'lap', to: 'cloud', kind: 'attack' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A trusted insider exfiltrating an entire contract repository to personal storage right before departure is a high-severity insider threat and data-loss event. The first action is to immediately suspend the employee\'s account and access to prevent further exfiltration, before any conversation or investigation continues.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'suspend', text: 'Immediately suspend the employee\'s account and remote access' },
+            { id: 'confront', text: 'Have the employee\'s manager ask them about the USB drive' },
+            { id: 'wipe', text: 'Remote-wipe the laptop without preserving evidence' },
+            { id: 'ignore', text: 'Wait until the employee\'s last day to review the logs' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'high', first: 'suspend' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by cutting off access, preserve evidence (forensic image) before eradicating anything, involve HR/Legal for the personnel and possible legal action, then update DLP/offboarding policy as the lessons-learned output.',
+        payload: { items: [
+          { id: 'a', label: 'Suspend account access and revoke remote/VPN sessions' },
+          { id: 'b', label: 'Forensically preserve the laptop and DLP logs as evidence' },
+          { id: 'c', label: 'Loop in HR and Legal regarding the data theft' },
+          { id: 'd', label: 'Update the offboarding checklist and DLP policy' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 5. Malware/C2 beacon — Detection & Analysis emphasis
+  {
+    id: 'sp-ir-c2-beacon', cert: 'secplus', objective: '4.9', topic: 'Incident Response',
+    title: 'Beaconing workstation', estMinutes: 4, archetype: 'incident',
+    scenario: 'The SIEM flags a workstation making a DNS query to a newly registered domain every 60 seconds, each time exchanging a small, consistent amount of data. No user is logged in overnight when the beaconing continues.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'radio', label: 'SIEM detects periodic DNS queries to a newly registered domain every 60s', time: 'T+0m', severity: 'med' },
+      { id: 's2', icon: 'moon', label: 'Beaconing continues overnight with no user logged in', time: 'T+8h', severity: 'high' },
+      { id: 's3', icon: 'data', label: 'Small, consistent data exchange on each beacon suggests command-and-control', time: 'T+8h5m', severity: 'high' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'Regular, low-and-slow beaconing to a newly registered domain with no user activity is a textbook command-and-control (C2) indicator. This is high severity because an attacker likely has a foothold. The first action is to isolate the host from the network to cut off the C2 channel while preserving it for analysis.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'isolate', text: 'Isolate the workstation from the network (keep it powered on)' },
+            { id: 'poweroff', text: 'Power off the workstation immediately' },
+            { id: 'ignore', text: 'Whitelist the domain since it may be a false positive' },
+            { id: 'reimage', text: 'Reimage the workstation right away' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'high', first: 'isolate' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Isolate to stop further C2 traffic while preserving volatile memory for analysis, analyze/eradicate the malware once identified, recover by reimaging or verifying clean, then feed the C2 domain into blocklists as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Isolate the host from the network without powering it off' },
+          { id: 'b', label: 'Capture memory and identify the malware and its persistence mechanism' },
+          { id: 'c', label: 'Reimage the host and restore from a known-good state' },
+          { id: 'd', label: 'Add the C2 domain to threat intel blocklists' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 6. Web app attack — SQLi — Detection & Analysis emphasis
+  {
+    id: 'sp-ir-sqli-customerdb', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'SQL injection against the customer portal', estMinutes: 5, archetype: 'incident',
+    scenario: 'WAF logs show a login form receiving requests with payloads like `\' OR 1=1--`. Shortly after, the database server logs an unusually large SELECT query returning the entire customers table, executed under the web application\'s service account.',
+    assets: { reference: { kind: 'network', devices: [
+      { id: 'atk', label: 'Attacker', type: 'external', zone: 'external', x: 40, y: 90, state: 'clean' },
+      { id: 'waf', label: 'WAF', type: 'firewall', zone: 'dmz', x: 200, y: 90, state: 'clean' },
+      { id: 'web', label: 'WEB-PORTAL', type: 'server', zone: 'dmz', x: 340, y: 90, state: 'affected' },
+      { id: 'db', label: 'CUSTOMER-DB', type: 'database', zone: 'internal', x: 480, y: 90, state: 'compromised' }
+    ], links: [
+      { from: 'atk', to: 'waf', kind: 'attack' },
+      { from: 'waf', to: 'web', kind: 'attack' },
+      { from: 'web', to: 'db', kind: 'attack' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A classic SQL injection payload followed by a bulk SELECT that dumped the entire customers table is a critical confirmed data breach. The first action is to take the vulnerable login form/endpoint offline (or block it at the WAF) to stop further injection while the application is fixed.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'block', text: 'Block the vulnerable endpoint at the WAF and take it offline' },
+            { id: 'rotate', text: 'Rotate all customer passwords immediately without investigating' },
+            { id: 'ignore', text: 'Monitor the endpoint for a few more days to gather evidence' },
+            { id: 'delete', text: 'Delete the WAF logs to reduce noise' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'block' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by blocking the vulnerable endpoint, eradicate by patching the injection flaw (parameterized queries), recover by restoring the service and rotating exposed credentials, then notify affected customers/regulators as required and document lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Block the vulnerable endpoint at the WAF' },
+          { id: 'b', label: 'Patch the application to use parameterized queries' },
+          { id: 'c', label: 'Rotate database credentials and restore the service' },
+          { id: 'd', label: 'Notify affected customers per breach-notification requirements' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 7. Web app attack — XSS — Eradication emphasis
+  {
+    id: 'sp-ir-xss-comments', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Stored XSS harvesting session cookies', estMinutes: 4, archetype: 'incident',
+    scenario: 'A support forum\'s comment field was found to store `<script>` tags that quietly send visiting users\' session cookies to an external server. Several customer accounts have since shown logins from unfamiliar locations.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'code', label: 'Malicious script stored in a public comment field', time: 'T-3d', severity: 'med' },
+      { id: 's2', icon: 'cookie', label: 'Script silently exfiltrates visiting users\' session cookies', time: 'T-2d', severity: 'high' },
+      { id: 's3', icon: 'login', label: 'Multiple customer accounts show logins from unfamiliar locations', time: 'T+0m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'Stored XSS that has already led to session hijacking and unauthorized account access across multiple customers is a critical, active incident. The first action is to remove the malicious comment content and invalidate the stolen sessions so the attacker loses access even before the underlying flaw is patched.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'purge', text: 'Remove the malicious comment content and invalidate active sessions' },
+            { id: 'shutdown', text: 'Permanently shut down the forum feature' },
+            { id: 'ignore', text: 'Ask affected users to clear their browser cache' },
+            { id: 'wait', text: 'Wait for the next scheduled maintenance window to fix it' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'purge' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by purging the payload and killing active sessions, eradicate the root cause by adding output encoding/CSP so injected scripts cannot execute, recover by having affected users re-authenticate, then document input-validation lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Remove the malicious script and invalidate stolen sessions' },
+          { id: 'b', label: 'Add output encoding and a Content Security Policy to the comment field' },
+          { id: 'c', label: 'Force affected users to re-authenticate and reset passwords' },
+          { id: 'd', label: 'Add input-validation testing to the secure development lifecycle' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 8. Credential stuffing / brute force — Forensics & Investigations (data-source selection, chain of custody)
+  {
+    id: 'sp-ir-credstuffing-login', cert: 'secplus', objective: '4.9', topic: 'Forensics & Investigations',
+    title: 'Credential stuffing against the customer login — evidence handling', estMinutes: 4, archetype: 'incident',
+    scenario: 'Tens of thousands of login attempts hit the customer login in an hour, using username/password pairs matching a recently leaked third-party breach dump. About 3% succeed. Legal has asked the security team to determine which requests came from which source IPs and to preserve evidence in case law enforcement gets involved.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'list', label: 'Tens of thousands of login attempts in one hour using leaked breach-dump credentials', time: 'T+0m', severity: 'med' },
+      { id: 's2', icon: 'unlock', label: 'About 3% of attempts succeed (password reuse)', time: 'T+35m', severity: 'high' },
+      { id: 's3', icon: 'key', label: 'Successful logins immediately followed by password-reset requests', time: 'T+36m', severity: 'high' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Select the investigation approach.',
+        explanation: 'The application/authentication log is the correct data source here — it records username, source IP, timestamp, and outcome for every login attempt, which is exactly what\'s needed to correlate the attack pattern to specific accounts and sources. Once evidence is identified for a legal hold, the exported log data must be hashed at collection time so its integrity can be proven later; this is the starting point of chain of custody, not an optional extra step.',
+        payload: { slots: [
+          { id: 'source', label: 'Best data source to correlate attempts to accounts/IPs', options: [
+            { id: 'authlog', text: 'Authentication/application logs (username, source IP, timestamp, outcome)' },
+            { id: 'dnslog', text: 'DNS resolver query logs' },
+            { id: 'netflow', text: 'NetFlow summary records only' },
+            { id: 'antivirus', text: 'Endpoint antivirus logs' }
+          ] },
+          { id: 'first', label: 'First evidence-handling action', options: [
+            { id: 'hash', text: 'Export the relevant log data and generate a cryptographic hash of it' },
+            { id: 'editlogs', text: 'Edit the log file to remove unrelated entries before saving it' },
+            { id: 'emailself', text: 'Email the raw log file to your personal account for safekeeping' },
+            { id: 'deleteold', text: 'Delete older log entries to keep the file size manageable' }
+          ] }
+        ] },
+        answer: { slots: { source: 'authlog', first: 'hash' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the evidence-handling steps to preserve a defensible chain of custody.',
+        explanation: 'Proper evidence handling: identify and collect the relevant log source first, hash it immediately at collection to prove integrity, document who collected it and when on a chain-of-custody form, then store the original in a access-controlled, tamper-evident location and work only from a copy going forward.',
+        payload: { items: [
+          { id: 'a', label: 'Identify and export the relevant authentication log records' },
+          { id: 'b', label: 'Generate a cryptographic hash of the exported log data' },
+          { id: 'c', label: 'Complete a chain-of-custody form documenting collector, time, and hash' },
+          { id: 'd', label: 'Store the original in a secured, access-controlled location and analyze only a copy' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 9. Data exfiltration — Recovery emphasis
+  {
+    id: 'sp-ir-exfil-cloudstorage', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Large outbound transfer to unknown cloud storage', estMinutes: 5, archetype: 'incident',
+    scenario: 'DLP alerts on a database server sending 15GB to an unfamiliar cloud storage IP over HTTPS at 3am, well outside the nightly backup window. The transfer used credentials belonging to a service account that should only ever run internal batch jobs.',
+    assets: { reference: { kind: 'network', devices: [
+      { id: 'db', label: 'DB-PROD', type: 'database', zone: 'internal', x: 60, y: 90, state: 'compromised' },
+      { id: 'fw', label: 'FW-EDGE', type: 'firewall', zone: 'dmz', x: 240, y: 90, state: 'clean' },
+      { id: 'ext', label: 'Unknown Cloud Storage', type: 'external', zone: 'external', x: 420, y: 90, state: 'clean' }
+    ], links: [
+      { from: 'db', to: 'fw', kind: 'attack' },
+      { from: 'fw', to: 'ext', kind: 'attack' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A production database sending 15GB to unrecognized external cloud storage at an abnormal hour, using a service account outside its normal behavior, is a critical data-exfiltration event. The first action is to block outbound traffic to that destination and disable the misused service account to stop the ongoing transfer.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'blockeg', text: 'Block outbound traffic to the destination and disable the service account' },
+            { id: 'restart', text: 'Restart the database service' },
+            { id: 'ignorelog', text: 'Note it for the weekly security review' },
+            { id: 'grantmore', text: 'Grant the service account broader access to investigate' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'blockeg' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by cutting the egress path and disabling the compromised credential, eradicate by finding how the credential was obtained (e.g., leaked key) and rotating it, recover by verifying database integrity and restoring least-privilege scope, then tighten egress filtering and DLP rules as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Block the outbound destination and disable the service account' },
+          { id: 'b', label: 'Determine how the credential was compromised and rotate it' },
+          { id: 'c', label: 'Verify database integrity and restore least-privilege scope' },
+          { id: 'd', label: 'Tighten egress filtering and DLP rules for service accounts' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 10. Supply-chain — Preparation/Detection emphasis
+  {
+    id: 'sp-ir-supplychain-update', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Malicious vendor software update', estMinutes: 5, archetype: 'incident',
+    scenario: 'A routine update from a trusted network-monitoring vendor was pushed to 200 endpoints overnight. The next morning, EDR flags that the updated binary is contacting a command-and-control server not associated with the vendor at all.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'download', label: 'Trusted vendor pushes a routine software update to 200 endpoints', time: 'T-8h', severity: 'low' },
+      { id: 's2', icon: 'shield', label: 'EDR flags the updated binary contacting an unrecognized external server', time: 'T+0m', severity: 'crit' },
+      { id: 's3', icon: 'network', label: 'The same binary is now present across all 200 endpoints', time: 'T+0m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A trusted vendor\'s update binary calling out to a server unrelated to that vendor, and already present across 200 machines, is a critical supply-chain compromise — the blast radius is organization-wide. The first action is to halt/roll back the update and block the malicious binary\'s network communication across all affected endpoints.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'rollback', text: 'Roll back the update and block the malicious binary\'s network access org-wide' },
+            { id: 'trustvendor', text: 'Contact the vendor and wait for their guidance before acting' },
+            { id: 'onehost', text: 'Isolate only the one endpoint that triggered the alert' },
+            { id: 'reinstall', text: 'Reinstall the vendor software on all endpoints' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'rollback' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by rolling back the compromised update and blocking its C2 traffic fleet-wide, eradicate by removing the malicious binary from every endpoint, recover by validating a clean vendor build before redeploying, then add software supply-chain vetting (code signing verification, staged rollout) as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Roll back the update and block the malicious binary\'s C2 traffic fleet-wide' },
+          { id: 'b', label: 'Remove the malicious binary from all 200 endpoints' },
+          { id: 'c', label: 'Validate a clean vendor build before redeploying' },
+          { id: 'd', label: 'Add staged rollout and code-signing verification for vendor updates' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 11. On-path / MITM — Detection & Analysis emphasis, network reference
+  {
+    id: 'sp-ir-onpath-conference', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'On-path attack at the branch office', estMinutes: 5, archetype: 'incident',
+    scenario: 'Staff at a branch office report certificate warnings when reaching internal HR systems. Network captures show ARP tables listing a rogue laptop as the default gateway MAC address, and its traffic is being relayed on to the real gateway after being decrypted and re-encrypted.',
+    assets: { reference: { kind: 'network', devices: [
+      { id: 'wks', label: 'BRANCH-WKS', type: 'workstation', zone: 'internal', x: 40, y: 90, state: 'affected' },
+      { id: 'rogue', label: 'Rogue Laptop', type: 'attacker', zone: 'internal', x: 200, y: 150, state: 'compromised' },
+      { id: 'gw', label: 'GW-BRANCH', type: 'router', zone: 'internal', x: 360, y: 90, state: 'clean' },
+      { id: 'hr', label: 'HR-APP', type: 'server', zone: 'internal', x: 500, y: 90, state: 'clean' }
+    ], links: [
+      { from: 'wks', to: 'rogue', kind: 'attack' },
+      { from: 'rogue', to: 'gw', kind: 'attack' },
+      { from: 'gw', to: 'hr', kind: 'normal' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'ARP spoofing that places a rogue device between clients and the real gateway, decrypting and re-encrypting traffic in transit, is a classic on-path (man-in-the-middle) attack capable of harvesting HR credentials. This is high severity given sensitive HR data is exposed. The first action is to physically or logically remove the rogue device from the network.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'removerogue', text: 'Disconnect the rogue laptop from the network' },
+            { id: 'ignorecerts', text: 'Tell users to click through the certificate warnings' },
+            { id: 'reboot', text: 'Reboot the branch gateway router' },
+            { id: 'patchhr', text: 'Patch the HR application server' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'high', first: 'removerogue' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by removing the rogue device, eradicate by clearing poisoned ARP tables and confirming no other rogue devices exist, recover by having affected users change passwords entered during the attack, then add dynamic ARP inspection / 802.1X port security as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Disconnect the rogue laptop from the network' },
+          { id: 'b', label: 'Clear poisoned ARP tables and sweep for other rogue devices' },
+          { id: 'c', label: 'Have affected users change passwords entered during the attack' },
+          { id: 'd', label: 'Enable dynamic ARP inspection and 802.1X port security' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 12. DNS poisoning — Containment emphasis
+  {
+    id: 'sp-ir-dns-poison-portal', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'DNS cache poisoning redirects the employee portal', estMinutes: 4, archetype: 'incident',
+    scenario: 'Employees typing the internal HR portal URL are landing on a convincing fake login page that harvests credentials. The internal DNS resolver\'s cache shows the portal\'s hostname now resolves to an external IP address that was never configured by IT.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'dns', label: 'Internal DNS resolver cache shows the portal hostname resolving to an unfamiliar external IP', time: 'T+0m', severity: 'high' },
+      { id: 's2', icon: 'globe', label: 'Employees are silently redirected to a fake login page', time: 'T+3m', severity: 'high' },
+      { id: 's3', icon: 'key', label: 'Several employees have already entered their credentials on the fake page', time: 'T+15m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A poisoned DNS cache silently redirecting employees to a credential-harvesting page, with credentials already captured, is a critical incident. The first action is to flush the poisoned DNS cache and correct the record so users stop being redirected before any further credentials are stolen.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'flush', text: 'Flush the poisoned DNS cache and correct the record' },
+            { id: 'shutdownportal', text: 'Permanently decommission the HR portal' },
+            { id: 'emailall', text: 'Email all employees the new correct URL and take no other action' },
+            { id: 'ignoreit', text: 'Wait for the TTL to expire naturally' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'flush' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by flushing and correcting the DNS cache, eradicate by identifying and closing the DNS server vulnerability that allowed poisoning, recover by forcing password resets for anyone who used the fake page, then enable DNSSEC as the lessons-learned control.',
+        payload: { items: [
+          { id: 'a', label: 'Flush the poisoned DNS cache and correct the record' },
+          { id: 'b', label: 'Identify and patch the DNS server vulnerability that allowed poisoning' },
+          { id: 'c', label: 'Force password resets for employees who used the fake login page' },
+          { id: 'd', label: 'Enable DNSSEC on the internal DNS infrastructure' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 13. Privilege escalation — Eradication emphasis
+  {
+    id: 'sp-ir-privesc-admin', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Standard user escalates to domain admin', estMinutes: 5, archetype: 'incident',
+    scenario: 'A help-desk technician\'s standard account is observed creating a new account and adding it to the Domain Admins group, an action that account has no legitimate reason to perform. The new account then accesses several servers it has never touched before.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'user', label: 'Help-desk standard account creates a new user account', time: 'T+0m', severity: 'med' },
+      { id: 's2', icon: 'shield', label: 'New account is added to the Domain Admins group', time: 'T+1m', severity: 'crit' },
+      { id: 's3', icon: 'server', label: 'New privileged account accesses multiple servers never touched before', time: 'T+6m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A low-privilege account performing a privilege-escalation action it has no business reason to perform, followed by that new privileged account touching unfamiliar servers, is a critical compromise — likely exploiting a vulnerability or stolen credentials to gain domain-wide control. The first action is to disable both the compromised account and the newly created rogue admin account.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'disableboth', text: 'Disable both the compromised help-desk account and the rogue admin account' },
+            { id: 'reset1', text: 'Just reset the help-desk account\'s password and continue monitoring' },
+            { id: 'ignoreacct', text: 'Leave the accounts active to see what else the attacker does' },
+            { id: 'promote', text: 'Promote a different account to admin to compare behavior' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'disableboth' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by disabling both accounts, eradicate by finding and patching the privilege-escalation vector (misconfigured ACL or vulnerability) so it cannot be repeated, recover by auditing everything the rogue admin account touched and restoring integrity, then tighten group-membership change alerting as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Disable the compromised account and the rogue admin account' },
+          { id: 'b', label: 'Identify and fix the privilege-escalation vector (misconfigured ACL/vuln)' },
+          { id: 'c', label: 'Audit every server the rogue admin account touched and restore integrity' },
+          { id: 'd', label: 'Enable real-time alerting on privileged group membership changes' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 14. Phishing/BEC — attachment dropper, single-step triage focus
+  {
+    id: 'sp-ir-phishing-macro-drop', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Macro-enabled attachment drops a loader', estMinutes: 4, archetype: 'incident',
+    scenario: 'An HR employee opened an attachment titled "Candidate_Resume.docm" and enabled macros when prompted. Within a minute, EDR observed the Office process spawning PowerShell, which downloaded a second-stage payload from a paste site.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'mail', label: 'HR employee opens "Candidate_Resume.docm" and enables macros', time: 'T+0m', severity: 'med' },
+      { id: 's2', icon: 'terminal', label: 'Office process spawns PowerShell (unusual parent-child relationship)', time: 'T+1m', severity: 'high' },
+      { id: 's3', icon: 'download', label: 'PowerShell downloads a second-stage payload from a paste site', time: 'T+1m30s', severity: 'high' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'Office spawning PowerShell right after macros are enabled, followed by a payload download, is a well-known malicious-document infection chain (initial access via phishing, then execution). This is high severity since a second-stage payload is already on the host. The first action is to isolate the workstation from the network before the payload can call out again or spread.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'isolatehost', text: 'Isolate the HR employee\'s workstation from the network' },
+            { id: 'deletefile', text: 'Just delete the attachment from the mail server' },
+            { id: 'ignorepwsh', text: 'Assume PowerShell activity is normal admin scripting' },
+            { id: 'rebootonly', text: 'Reboot the workstation and move on' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'high', first: 'isolatehost' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by isolating the host, eradicate the dropper and any second-stage payload, recover by reimaging or verifying a clean state, then disable Office macros by default org-wide as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Isolate the workstation from the network' },
+          { id: 'b', label: 'Identify and remove the dropper and second-stage payload' },
+          { id: 'c', label: 'Reimage the workstation or verify it is clean before returning to service' },
+          { id: 'd', label: 'Disable Office macros by default across the organization' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 15. Ransomware — double extortion, network reference
+  {
+    id: 'sp-ir-ransomware-doubleextortion', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Double-extortion ransomware with data leak threat', estMinutes: 5, archetype: 'incident',
+    scenario: 'Overnight, the accounting server was encrypted and a ransom note claims 200GB of financial data was also copied out before encryption, threatening to publish it if payment is not made within 72 hours. Firewall logs confirm a large outbound transfer to an unfamiliar IP just before the encryption began.',
+    assets: { reference: { kind: 'network', devices: [
+      { id: 'acct', label: 'ACCT-SRV', type: 'server', zone: 'internal', x: 60, y: 90, state: 'compromised' },
+      { id: 'fw', label: 'FW-CORE', type: 'firewall', zone: 'dmz', x: 240, y: 90, state: 'clean' },
+      { id: 'ext', label: 'Attacker Exfil Host', type: 'external', zone: 'external', x: 420, y: 90, state: 'clean' }
+    ], links: [
+      { from: 'acct', to: 'fw', kind: 'attack' },
+      { from: 'fw', to: 'ext', kind: 'attack' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'Encryption combined with confirmed pre-encryption exfiltration and an extortion threat is double-extortion ransomware — a critical incident involving both availability loss and a confirmed breach. The first action is to isolate the accounting server and block the outbound path to the attacker\'s exfil host to stop any further data loss.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'isolateblock', text: 'Isolate the accounting server and block the outbound exfil path' },
+            { id: 'paynow', text: 'Pay the ransom before the 72-hour deadline' },
+            { id: 'restorefirst', text: 'Restore from backup immediately without isolating first' },
+            { id: 'publicstatement', text: 'Issue a public statement before containing the incident' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'isolateblock' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by isolating the host and blocking exfil, eradicate the ransomware and access used for exfiltration, recover from clean backups once the environment is verified safe, then engage legal/breach-notification obligations given confirmed data theft as part of lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Isolate the server and block the exfiltration path' },
+          { id: 'b', label: 'Remove the ransomware and close the access used for exfiltration' },
+          { id: 'c', label: 'Restore the server from a verified clean backup' },
+          { id: 'd', label: 'Engage legal counsel for breach-notification obligations' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 16. Insider threat — sabotage variant, Recovery emphasis
+  {
+    id: 'sp-ir-insider-sabotage', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Disgruntled admin deletes production backups', estMinutes: 5, archetype: 'incident',
+    scenario: 'A system administrator who was passed over for promotion used their still-active credentials after hours to delete the last 30 days of production database backups. The deletion was discovered the next morning when a routine restore test failed.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'clock', label: 'Admin logs in after hours using still-active credentials', time: 'T-14h', severity: 'med' },
+      { id: 's2', icon: 'trash', label: '30 days of production database backups deleted', time: 'T-13h45m', severity: 'crit' },
+      { id: 's3', icon: 'alert', label: 'Routine restore test fails the next morning, revealing the deletion', time: 'T+0m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'Deliberate, after-hours deletion of a month of backups by a disgruntled insider is a critical sabotage incident — it directly threatens recovery capability if production data is ever lost. The first action is to revoke that administrator\'s credentials and access immediately to prevent further destructive actions.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'revoke', text: 'Revoke the administrator\'s credentials and access immediately' },
+            { id: 'talkfirst', text: 'Schedule a one-on-one conversation before taking any action' },
+            { id: 'restoreonly', text: 'Try to restore backups without addressing account access' },
+            { id: 'ignorepast', text: 'Take no action since the backups are already gone' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'revoke' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by revoking access, eradicate by auditing for any other destructive actions or lingering access the admin retained, recover by pulling backups from an offsite/immutable copy if one exists and validating integrity, then require offboarding/access-review changes and separation-of-duties for backup deletion as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Revoke the administrator\'s credentials and access' },
+          { id: 'b', label: 'Audit for other destructive actions or retained access' },
+          { id: 'c', label: 'Recover backups from an offsite/immutable copy and validate integrity' },
+          { id: 'd', label: 'Require approval workflows and offsite immutability for backup deletion' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 17. Malware — worm lateral spread, Containment emphasis, network reference
+  {
+    id: 'sp-ir-worm-lateral-spread', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Self-propagating worm spreading via SMB', estMinutes: 5, archetype: 'incident',
+    scenario: 'Within 20 minutes, three additional workstations became infected after the first one, each exploiting an unpatched SMB vulnerability to spread automatically with no user interaction. The infection rate is accelerating.',
+    assets: { reference: { kind: 'network', devices: [
+      { id: 'w1', label: 'WKS-01', type: 'workstation', zone: 'internal', x: 40, y: 60, state: 'compromised' },
+      { id: 'w2', label: 'WKS-02', type: 'workstation', zone: 'internal', x: 180, y: 60, state: 'compromised' },
+      { id: 'w3', label: 'WKS-03', type: 'workstation', zone: 'internal', x: 320, y: 60, state: 'affected' },
+      { id: 'w4', label: 'WKS-04', type: 'workstation', zone: 'internal', x: 460, y: 60, state: 'clean' }
+    ], links: [
+      { from: 'w1', to: 'w2', kind: 'attack' },
+      { from: 'w2', to: 'w3', kind: 'attack' },
+      { from: 'w3', to: 'w4', kind: 'normal' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A self-propagating worm exploiting an unpatched SMB vulnerability with no user interaction and an accelerating infection rate is a critical incident that can compromise the entire network quickly. The first action is to segment/disable SMB (or the affected VLAN) network-wide to halt the automatic spread before individual hosts are cleaned.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'blocksmb', text: 'Block or disable SMB network-wide to halt automatic spread' },
+            { id: 'cleanone', text: 'Clean only the first infected workstation and monitor' },
+            { id: 'patchfirst', text: 'Patch the SMB vulnerability on all hosts before containing anything' },
+            { id: 'waitandsee', text: 'Wait to see how many more hosts get infected before acting' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'blocksmb' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by blocking the spreading vector network-wide, eradicate the worm from every infected host, recover by patching the vulnerability before re-enabling SMB, then apply network segmentation as the lessons-learned control to limit future lateral movement.',
+        payload: { items: [
+          { id: 'a', label: 'Block SMB network-wide to halt the spread' },
+          { id: 'b', label: 'Remove the worm from all infected hosts' },
+          { id: 'c', label: 'Patch the SMB vulnerability before re-enabling SMB traffic' },
+          { id: 'd', label: 'Segment the network to limit future lateral movement' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 18. Web app attack — API abuse / broken access control, Detection emphasis
+  {
+    id: 'sp-ir-api-idor', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Broken access control exposes other customers\' orders', estMinutes: 4, archetype: 'incident',
+    scenario: 'A customer reports that changing an order ID number in the mobile app\'s API URL let them view a stranger\'s order details, including a shipping address and partial card number. Logs show the same technique being used by dozens of sequential requests from one IP over the past hour.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'bug', label: 'Customer reports viewing another customer\'s order by changing the ID in the URL', time: 'T+0m', severity: 'high' },
+      { id: 's2', icon: 'list', label: 'Logs show dozens of sequential order-ID requests from one IP over the past hour', time: 'T-1h', severity: 'crit' },
+      { id: 's3', icon: 'data', label: 'Exposed data includes shipping addresses and partial card numbers', time: 'T-1h', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'An insecure direct object reference (IDOR) letting one user enumerate and view other customers\' orders — already actively exploited for at least an hour, exposing PII and partial payment data — is a critical incident. The first action is to disable or patch the vulnerable API endpoint immediately to stop further data exposure.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'disableapi', text: 'Disable or patch the vulnerable API endpoint immediately' },
+            { id: 'thankcustomer', text: 'Thank the reporting customer and take no further action' },
+            { id: 'blockip', text: 'Block only the one reporting customer\'s IP address' },
+            { id: 'ignoreapi', text: 'Schedule the fix for the next sprint' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'disableapi' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by shutting off the exposed endpoint, eradicate by adding proper authorization checks to every order-lookup call, recover by determining the scope of exposed records and notifying affected customers, then add automated access-control testing as lessons learned.',
+        payload: { items: [
+          { id: 'a', label: 'Disable or patch the vulnerable API endpoint' },
+          { id: 'b', label: 'Add proper authorization checks to all order-lookup calls' },
+          { id: 'c', label: 'Determine the scope of exposed records and notify affected customers' },
+          { id: 'd', label: 'Add automated access-control testing to the release pipeline' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 19. Credential/password attack — brute force against VPN — Forensics & Investigations (log-source selection, artifact correlation)
+  {
+    id: 'sp-ir-bruteforce-vpn', cert: 'secplus', objective: '4.9', topic: 'Forensics & Investigations',
+    title: 'Brute-force attack against the VPN gateway — investigating scope', estMinutes: 4, archetype: 'incident',
+    scenario: 'The VPN concentrator logs show over 5,000 failed login attempts against a single username from one external IP over 30 minutes, followed by one successful authentication using that same username. The investigator now needs to determine what the attacker actually did once inside, and to build a timeline other analysts can reproduce.',
+    assets: { reference: { kind: 'network', devices: [
+      { id: 'atk', label: 'Attacker', type: 'external', zone: 'external', x: 40, y: 90, state: 'clean' },
+      { id: 'vpn', label: 'VPN-GW', type: 'router', zone: 'dmz', x: 240, y: 90, state: 'affected' },
+      { id: 'internal', label: 'Internal Network', type: 'network', zone: 'internal', x: 440, y: 90, state: 'clean' }
+    ], links: [
+      { from: 'atk', to: 'vpn', kind: 'attack' },
+      { from: 'vpn', to: 'internal', kind: 'attack' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Select the investigation approach.',
+        explanation: 'To see what the attacker did after authenticating — which internal hosts they touched and what actions they took — the investigator needs internal firewall/NetFlow records and endpoint/authentication logs from the systems the session reached, not just the VPN concentrator\'s own login log (which only proves the successful auth, not post-auth activity). Because clocks drift between devices, correlating the VPN log against those other sources first requires normalizing all timestamps to a common reference (e.g., UTC/NTP-synced) so events can be placed on one accurate timeline.',
+        payload: { slots: [
+          { id: 'source', label: 'Best additional data source for post-authentication activity', options: [
+            { id: 'internallogs', text: 'Internal firewall/NetFlow and endpoint logs for hosts reached via the VPN session' },
+            { id: 'dnszone', text: 'The public DNS zone file for the company domain' },
+            { id: 'vendoradvisory', text: 'The VPN vendor\'s public security advisory page' },
+            { id: 'helpdesk', text: 'General help-desk ticket volume for the day' }
+          ] },
+          { id: 'first', label: 'Prerequisite before correlating events across sources', options: [
+            { id: 'normalize', text: 'Normalize all log timestamps to a common time reference (e.g., UTC/NTP)' },
+            { id: 'deletevpn', text: 'Delete the VPN log once the internal logs are pulled' },
+            { id: 'guesstime', text: 'Estimate timing by eye without reconciling clocks' },
+            { id: 'skipauth', text: 'Skip the VPN log since the internal logs are more detailed' }
+          ] }
+        ] },
+        answer: { slots: { source: 'internallogs', first: 'normalize' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the investigation steps to build a reproducible timeline.',
+        explanation: 'Sound artifact correlation: pull the VPN log establishing the successful-auth timestamp, gather internal firewall/NetFlow and endpoint logs covering that session window, normalize all timestamps to a common reference so events line up correctly, then correlate the sources into a single reproducible timeline of attacker activity.',
+        payload: { items: [
+          { id: 'a', label: 'Pull the VPN concentrator log establishing the successful-authentication timestamp' },
+          { id: 'b', label: 'Gather internal firewall/NetFlow and endpoint logs covering that session window' },
+          { id: 'c', label: 'Normalize timestamps across all sources to a common time reference' },
+          { id: 'd', label: 'Correlate the sources into a single reproducible timeline of attacker activity' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
+  },
+
+  // 20. DDoS — application-layer variant, Lessons learned emphasis
+  {
+    id: 'sp-ir-ddos-applayer-api', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
+    title: 'Application-layer DDoS against the search API', estMinutes: 4, archetype: 'incident',
+    scenario: 'The product search API begins timing out under a flood of expensive, complex search queries sent from a botnet of a few hundred hosts — low in volume compared to a typical flood, but each request consumes significant database CPU. The database server is pegged at 100% CPU.',
+    assets: { reference: { kind: 'timeline', stages: [
+      { id: 's1', icon: 'search', label: 'Search API receives a flood of expensive, complex queries from ~300 hosts', time: 'T+0m', severity: 'high' },
+      { id: 's2', icon: 'cpu', label: 'Database server CPU pegged at 100%', time: 'T+4m', severity: 'crit' },
+      { id: 's3', icon: 'down', label: 'Search functionality becomes unusable site-wide', time: 'T+6m', severity: 'crit' }
+    ] } },
+    steps: [
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Triage this incident.',
+        explanation: 'A relatively low request volume causing full resource exhaustion is application-layer (Layer 7) DDoS — attackers targeting the most expensive operation rather than raw bandwidth. Because search is unusable site-wide, this is critical. The first action is to rate-limit or throttle the expensive search endpoint to relieve database load.',
+        payload: { slots: [
+          { id: 'sev', label: 'Severity', options: [
+            { id: 'low', text: 'Low' }, { id: 'med', text: 'Medium' },
+            { id: 'high', text: 'High' }, { id: 'crit', text: 'Critical' }
+          ] },
+          { id: 'first', label: 'First containment action', options: [
+            { id: 'throttle', text: 'Rate-limit or throttle the expensive search endpoint' },
+            { id: 'scaledb', text: 'Permanently upgrade database hardware as the only fix' },
+            { id: 'blockall', text: 'Block all inbound traffic to the entire site' },
+            { id: 'ignoreload', text: 'Ignore it since the flood volume is relatively low' }
+          ] }
+        ] },
+        answer: { slots: { sev: 'crit', first: 'throttle' } } },
+      { id: 'o1', type: 'order', points: 1,
+        prompt: 'Order the response steps.',
+        explanation: 'Contain by throttling the abused endpoint, eradicate by blocking the identified botnet source ranges, recover by confirming search returns to normal performance, then add query complexity limits and WAF rules as the lessons-learned control against future application-layer floods.',
+        payload: { items: [
+          { id: 'a', label: 'Rate-limit or throttle the expensive search endpoint' },
+          { id: 'b', label: 'Block the identified botnet source IP ranges' },
+          { id: 'c', label: 'Confirm search performance has returned to normal' },
+          { id: 'd', label: 'Add query complexity limits and WAF rules for future protection' }
+        ] },
+        answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
+    ]
   }
 ];

--- a/features/sim-lab-seed-secplus.js
+++ b/features/sim-lab-seed-secplus.js
@@ -1392,7 +1392,7 @@ window.SIM_LAB_SEED_SECPLUS = [
   // 4. Insider threat — Lessons learned emphasis, network reference
   {
     id: 'sp-ir-insider-exfil', cert: 'secplus', objective: '4.8', topic: 'Incident Response',
-    title: 'Departing employee data theft', esta: null, estMinutes: 5, archetype: 'incident',
+    title: 'Departing employee data theft', estMinutes: 5, archetype: 'incident',
     scenario: 'A sales engineer submitted their resignation this morning. DLP logs show that last night, from their laptop, the entire customer contract repository was copied to a personal USB drive and uploaded to a personal cloud storage account.',
     assets: { reference: { kind: 'network', devices: [
       { id: 'lap', label: 'SE-LAPTOP', type: 'workstation', zone: 'internal', x: 60, y: 90, state: 'compromised' },

--- a/features/sim-lab-seed-secplus.js
+++ b/features/sim-lab-seed-secplus.js
@@ -2100,5 +2100,263 @@ window.SIM_LAB_SEED_SECPLUS = [
         ] },
         answer: { correctOrder: ['a', 'b', 'c', 'd'] } }
     ]
+  },
+
+  // ── Defense in Depth (Task 14, 2-agent gated) ──
+  { id: 'secplus-did-hollow-perimeter', cert: 'secplus',
+    objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (defense in depth, control categories)',
+    topic: 'Defense in Depth', title: 'Strong wall, hollow inside', estMinutes: 6, archetype: 'defense',
+    scenario: 'A security review of Northwind HQ finds a capable next-gen firewall at the edge and almost nothing behind it. Endpoints are unmanaged, the database stores records in clear text, and one shared admin account opens everything. A single phishing click puts an attacker next to the crown jewels.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Next-gen firewall', state: 'present' },
+        { id: 'endpoint', label: 'Endpoint', control: 'EDR and host hardening', state: 'missing' },
+        { id: 'data', label: 'Data', control: 'Encryption at rest and DLP', state: 'missing' },
+        { id: 'identity', label: 'Identity', control: 'MFA and least privilege', state: 'missing' }
+      ],
+      core: { label: 'Crown-jewel data', assets: [
+        { id: 'db1', label: 'DB-1 (customer records, clear text)', exposed: true },
+        { id: 'dc1', label: 'DC-1 (identity store)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'What is the core flaw in this architecture?',
+        explanation: 'Everything rides on one control. Once the perimeter is bypassed, by phishing or an insider, nothing else slows the attacker before the data because there are no endpoint, data, or identity controls behind the firewall.',
+        payload: { slots: [ { id: 'flaw', label: 'Core flaw', options: [
+          { id: 'f1', text: 'It is a hard shell with a soft center: one perimeter, no inner controls' },
+          { id: 'f2', text: 'The firewall vendor is not on the approved list' },
+          { id: 'f3', text: 'The network uses too many subnets' },
+          { id: 'f4', text: 'The database server is running on outdated hardware' }
+        ] } ] },
+        answer: { slots: { flaw: 'f1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Build the inner layers.',
+        explanation: 'EDR and hardening give each host its own line of defense, encryption and DLP protect the data itself, and MFA with least privilege shrinks what a stolen credential can do.',
+        payload: { slots: [
+          { id: 'endpoint', label: 'Endpoint layer', options: [
+            { id: 'a1', text: 'EDR plus host hardening' }, { id: 'a2', text: 'A louder antivirus pop-up' }, { id: 'a3', text: 'Local admin rights for every user' } ] },
+          { id: 'data', label: 'Data layer', options: [
+            { id: 'b1', text: 'Encryption at rest plus DLP' }, { id: 'b2', text: 'A nightly backup, nothing else' }, { id: 'b3', text: 'Public read access for convenience' } ] },
+          { id: 'identity', label: 'Identity layer', options: [
+            { id: 'c1', text: 'MFA plus least privilege' }, { id: 'c2', text: 'One shared admin account' }, { id: 'c3', text: 'Longer passwords, no other change' } ] }
+        ] },
+        answer: { slots: { endpoint: 'a1', data: 'b1', identity: 'c1' } } },
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'MFA is best classified as which control type?',
+        explanation: 'MFA is enforced by technology (technical) and stops misuse before it happens (preventive), not after an event has already occurred.',
+        payload: { slots: [ { id: 'type', label: 'Control type', options: [
+          { id: 't1', text: 'Technical, preventive' },
+          { id: 't2', text: 'Physical, detective' },
+          { id: 't3', text: 'Managerial, corrective' },
+          { id: 't4', text: 'Operational, compensating' }
+        ] } ] },
+        answer: { slots: { type: 't1' } } }
+    ]
+  },
+
+  { id: 'secplus-did-clinic-breach', cert: 'secplus',
+    objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (zero trust, control categories)',
+    topic: 'Defense in Depth', title: 'A clinic that trusts anything already inside', estMinutes: 6, archetype: 'defense',
+    scenario: 'A regional clinic passed its firewall audit with flying colors, but once inside the network every workstation can reach the patient records database directly, there is no logging on that database, and staff share one login for the scheduling system. An attacker who lands on any workstation has an unmonitored path to patient data.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Audited edge firewall', state: 'present' },
+        { id: 'network', label: 'Network segmentation', control: 'Micro-segmentation isolating the records database', state: 'missing' },
+        { id: 'monitoring', label: 'Monitoring', control: 'Database access logging and alerting', state: 'missing' },
+        { id: 'identity', label: 'Identity', control: 'Unique accounts and least privilege', state: 'missing' }
+      ],
+      core: { label: 'Patient records', assets: [
+        { id: 'phi1', label: 'PHI-DB (patient records)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'What is the core flaw in this architecture?',
+        explanation: 'The design assumes anything past the firewall is safe. Every workstation has an unrestricted, unlogged path to the database, and shared logins mean no one can be held accountable for access. This is the opposite of zero trust.',
+        payload: { slots: [ { id: 'flaw', label: 'Core flaw', options: [
+          { id: 'f1', text: 'Implicit trust inside the network: no segmentation, no logging, no accountability' },
+          { id: 'f2', text: 'The firewall audit was performed by an unqualified vendor' },
+          { id: 'f3', text: 'The clinic uses too many workstations' },
+          { id: 'f4', text: 'The database server needs a hardware upgrade' }
+        ] } ] },
+        answer: { slots: { flaw: 'f1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Build the inner layers.',
+        explanation: 'Micro-segmentation limits which hosts can reach the database at all, logging and alerting give visibility into who touches patient data, and unique accounts with least privilege restore accountability.',
+        payload: { slots: [
+          { id: 'network', label: 'Network layer', options: [
+            { id: 'a1', text: 'Micro-segmentation restricting database access to approved application servers' }, { id: 'a2', text: 'Allow every workstation to reach the database directly' }, { id: 'a3', text: 'Remove the firewall since it already passed audit' } ] },
+          { id: 'monitoring', label: 'Monitoring layer', options: [
+            { id: 'b1', text: 'Database access logging with alerting on anomalous queries' }, { id: 'b2', text: 'No logging, to save disk space' }, { id: 'b3', text: 'A monthly manual spreadsheet review' } ] },
+          { id: 'identity', label: 'Identity layer', options: [
+            { id: 'c1', text: 'Unique accounts per staff member with least privilege' }, { id: 'c2', text: 'One shared scheduling login for the whole clinic' }, { id: 'c3', text: 'Passwords that never expire' } ] }
+        ] },
+        answer: { slots: { network: 'a1', monitoring: 'b1', identity: 'c1' } } },
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Database access logging and alerting is best classified as which control type?',
+        explanation: 'Logging and alerting are enforced through technology (technical) and identify malicious activity after it has started rather than preventing it outright, which makes it detective.',
+        payload: { slots: [ { id: 'type', label: 'Control type', options: [
+          { id: 't1', text: 'Technical, detective' },
+          { id: 't2', text: 'Managerial, preventive' },
+          { id: 't3', text: 'Physical, deterrent' },
+          { id: 't4', text: 'Operational, corrective' }
+        ] } ] },
+        answer: { slots: { type: 't1' } } }
+    ]
+  },
+
+  { id: 'secplus-did-cloud-bucket', cert: 'secplus',
+    objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (cloud security, control categories)',
+    topic: 'Defense in Depth', title: 'A cloud app with one line of defense', estMinutes: 6, archetype: 'defense',
+    scenario: 'A startup moved its customer app to the cloud and configured a web application firewall in front of it. Behind the WAF, the storage bucket holding customer uploads is publicly readable, the application server runs with an overly permissive IAM role, and there is no vulnerability scanning of the container images before they deploy.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Web application firewall', state: 'present' },
+        { id: 'data', label: 'Data', control: 'Private bucket policy with least-privilege access', state: 'missing' },
+        { id: 'identity', label: 'Identity', control: 'Scoped IAM role for the application server', state: 'missing' },
+        { id: 'application', label: 'Application', control: 'Vulnerability scanning in the CI/CD pipeline', state: 'missing' }
+      ],
+      core: { label: 'Customer data', assets: [
+        { id: 'bkt1', label: 'BKT-1 (public storage bucket)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'What is the core flaw in this architecture?',
+        explanation: 'The WAF only inspects web traffic to the app; it does nothing to protect a publicly readable storage bucket, an overprivileged IAM role, or unscanned container images. One control at the edge cannot cover every layer of a cloud stack.',
+        payload: { slots: [ { id: 'flaw', label: 'Core flaw', options: [
+          { id: 'f1', text: 'A single WAF is treated as sufficient while storage, identity, and the build pipeline are left uncontrolled' },
+          { id: 'f2', text: 'The WAF vendor is not FedRAMP certified' },
+          { id: 'f3', text: 'The application server is undersized for the traffic' },
+          { id: 'f4', text: 'The cloud region is too far from customers' }
+        ] } ] },
+        answer: { slots: { flaw: 'f1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Build the inner layers.',
+        explanation: 'A private bucket policy stops public read access to customer uploads, a scoped IAM role limits what the app server can do if compromised, and pipeline scanning catches vulnerable images before they ever deploy.',
+        payload: { slots: [
+          { id: 'data', label: 'Data layer', options: [
+            { id: 'a1', text: 'Private bucket policy granting access only to the application role' }, { id: 'a2', text: 'Public read access so the app can serve files directly' }, { id: 'a3', text: 'No bucket policy, rely on the WAF' } ] },
+          { id: 'identity', label: 'Identity layer', options: [
+            { id: 'b1', text: 'IAM role scoped to only the permissions the app needs' }, { id: 'b2', text: 'Administrator role for the application server, to avoid access errors' }, { id: 'b3', text: 'Shared root credentials for all services' } ] },
+          { id: 'application', label: 'Application layer', options: [
+            { id: 'c1', text: 'Vulnerability scanning of container images in CI/CD' }, { id: 'c2', text: 'Skip scanning to speed up deployments' }, { id: 'c3', text: 'Scan images once per year' } ] }
+        ] },
+        answer: { slots: { data: 'a1', identity: 'b1', application: 'c1' } } },
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Scoping the IAM role to least privilege is best classified as which control type?',
+        explanation: 'Least-privilege IAM scoping is enforced by the cloud platform itself (technical) and limits what an attacker can do before any damage occurs, making it preventive.',
+        payload: { slots: [ { id: 'type', label: 'Control type', options: [
+          { id: 't1', text: 'Technical, preventive' },
+          { id: 't2', text: 'Managerial, detective' },
+          { id: 't3', text: 'Physical, preventive' },
+          { id: 't4', text: 'Operational, corrective' }
+        ] } ] },
+        answer: { slots: { type: 't1' } } }
+    ]
+  },
+
+  { id: 'secplus-did-vendor-remote-access', cert: 'secplus',
+    objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (third-party access, control categories)',
+    topic: 'Defense in Depth', title: 'A vendor with the keys to everything', estMinutes: 6, archetype: 'defense',
+    scenario: 'A manufacturing plant lets a third-party HVAC vendor remote into its network to service building controls. The vendor connects through a properly configured VPN, but from there the vendor account can reach the plant\'s production control systems, sessions are never recorded, and the vendor account has never been reviewed since it was created two years ago.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'VPN gateway for vendor remote access', state: 'present' },
+        { id: 'network', label: 'Network segmentation', control: 'Jump host isolating vendor access from production systems', state: 'missing' },
+        { id: 'monitoring', label: 'Monitoring', control: 'Session recording for third-party access', state: 'missing' },
+        { id: 'identity', label: 'Identity', control: 'Periodic access review of vendor accounts', state: 'missing' }
+      ],
+      core: { label: 'Production control systems', assets: [
+        { id: 'ics1', label: 'ICS-1 (production controller)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'What is the core flaw in this architecture?',
+        explanation: 'The VPN itself is fine, but past it the vendor has an unrestricted, unrecorded, never-reviewed path straight to production controllers. A compromised vendor credential or a disgruntled contractor would go unnoticed indefinitely.',
+        payload: { slots: [ { id: 'flaw', label: 'Core flaw', options: [
+          { id: 'f1', text: 'Third-party access is unrestricted, unmonitored, and never reviewed once inside the VPN' },
+          { id: 'f2', text: 'The VPN uses outdated encryption' },
+          { id: 'f3', text: 'The HVAC vendor is not licensed in the state' },
+          { id: 'f4', text: 'The production controllers need a firmware update' }
+        ] } ] },
+        answer: { slots: { flaw: 'f1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Build the inner layers.',
+        explanation: 'A jump host limits the vendor to only the systems they need, session recording gives an audit trail of everything the vendor does, and periodic access review catches accounts that should have been revoked long ago.',
+        payload: { slots: [
+          { id: 'network', label: 'Network layer', options: [
+            { id: 'a1', text: 'Jump host restricting vendor access to HVAC systems only' }, { id: 'a2', text: 'Direct vendor access to the full production network' }, { id: 'a3', text: 'No restriction, since the VPN is already trusted' } ] },
+          { id: 'monitoring', label: 'Monitoring layer', options: [
+            { id: 'b1', text: 'Session recording for all third-party remote access' }, { id: 'b2', text: 'No session logging, to respect vendor privacy' }, { id: 'b3', text: 'A yearly vendor satisfaction survey' } ] },
+          { id: 'identity', label: 'Identity layer', options: [
+            { id: 'c1', text: 'Quarterly access review of vendor accounts' }, { id: 'c2', text: 'Vendor accounts that never expire or get reviewed' }, { id: 'c3', text: 'One shared vendor account for all contractors' } ] }
+        ] },
+        answer: { slots: { network: 'a1', monitoring: 'b1', identity: 'c1' } } },
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Periodic access review of vendor accounts is best classified as which control type?',
+        explanation: 'Access reviews are a managerial policy activity, typically carried out on a schedule as part of governance, and they identify problems (like stale accounts) after the fact, which makes them detective.',
+        payload: { slots: [ { id: 'type', label: 'Control type', options: [
+          { id: 't1', text: 'Managerial, detective' },
+          { id: 't2', text: 'Technical, preventive' },
+          { id: 't3', text: 'Physical, deterrent' },
+          { id: 't4', text: 'Operational, compensating' }
+        ] } ] },
+        answer: { slots: { type: 't1' } } }
+    ]
+  },
+
+  { id: 'secplus-did-branch-office-ransomware', cert: 'secplus',
+    objective: 'SY0-701 Domain 3.2 — Compare and contrast security implications of architecture models (defense in depth, control categories)',
+    topic: 'Defense in Depth', title: 'One phishing email away from total loss', estMinutes: 6, archetype: 'defense',
+    scenario: 'A law firm\'s branch office relies on email spam filtering as its only defense against ransomware. Endpoints have no EDR, backups are stored on a network share reachable from every workstation, and there is no security awareness training, so staff routinely click on suspicious attachments.',
+    assets: { reference: { kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Email spam filtering', state: 'present' },
+        { id: 'endpoint', label: 'Endpoint', control: 'EDR with ransomware behavior detection', state: 'missing' },
+        { id: 'backup', label: 'Backup', control: 'Immutable, network-isolated backups', state: 'missing' },
+        { id: 'awareness', label: 'Personnel', control: 'Security awareness training', state: 'missing' }
+      ],
+      core: { label: 'Case files and client data', assets: [
+        { id: 'case-files', label: 'Case files & client data', exposed: true },
+        { id: 'shr1', label: 'SHR-1 (backup share reachable from every workstation)', exposed: true }
+      ] }
+    } },
+    steps: [
+      { id: 'd1', type: 'configure', points: 1,
+        prompt: 'What is the core flaw in this architecture?',
+        explanation: 'Spam filtering alone is not defense in depth. With no EDR to catch what slips through, no isolated backups to fall back on, and no trained staff to hesitate before clicking, one successful phishing email can encrypt both production data and its own backup.',
+        payload: { slots: [ { id: 'flaw', label: 'Core flaw', options: [
+          { id: 'f1', text: 'A single email filter is the only defense, with no endpoint, backup, or human layer behind it' },
+          { id: 'f2', text: 'The law firm uses too much email' },
+          { id: 'f3', text: 'The spam filter vendor changed pricing' },
+          { id: 'f4', text: 'The office needs a faster printer' }
+        ] } ] },
+        answer: { slots: { flaw: 'f1' } } },
+      { id: 'f1', type: 'configure', points: 1,
+        prompt: 'Build the inner layers.',
+        explanation: 'EDR catches ransomware behavior that slips past email filtering, immutable and network-isolated backups survive an encryption event, and trained staff are far less likely to trigger the infection in the first place.',
+        payload: { slots: [
+          { id: 'endpoint', label: 'Endpoint layer', options: [
+            { id: 'a1', text: 'EDR with ransomware behavior detection' }, { id: 'a2', text: 'Rely on spam filtering alone' }, { id: 'a3', text: 'Disable antivirus to improve performance' } ] },
+          { id: 'backup', label: 'Backup layer', options: [
+            { id: 'b1', text: 'Immutable backups isolated from the production network' }, { id: 'b2', text: 'Backups on a share reachable from every workstation' }, { id: 'b3', text: 'No backups, restore from vendor support instead' } ] },
+          { id: 'awareness', label: 'Personnel layer', options: [
+            { id: 'c1', text: 'Regular security awareness training with phishing simulations' }, { id: 'c2', text: 'No training, trust staff judgment' }, { id: 'c3', text: 'A one-time training video at hiring only' } ] }
+        ] },
+        answer: { slots: { endpoint: 'a1', backup: 'b1', awareness: 'c1' } } },
+      { id: 't1', type: 'configure', points: 1,
+        prompt: 'Security awareness training is best classified as which control type?',
+        explanation: 'Awareness training is a managerial/administrative program that reduces the likelihood of an incident before it happens, which makes it preventive rather than detective or corrective.',
+        payload: { slots: [ { id: 'type', label: 'Control type', options: [
+          { id: 't1', text: 'Managerial, preventive' },
+          { id: 't2', text: 'Technical, detective' },
+          { id: 't3', text: 'Physical, compensating' },
+          { id: 't4', text: 'Operational, corrective' }
+        ] } ] },
+        answer: { slots: { type: 't1' } } }
+    ]
   }
 ];

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -71,6 +71,103 @@
     return { ok: errs.length === 0, errors: errs };
   }
 
+  // --- subnetting/CIDR fidelity validator (Task 9) ---
+  // Pure math check that a Net+ `network` reference diagram is
+  // subnetting-sound, and that a paired `configure` step's correct answer
+  // actually fixes any flagged misconfiguration in-subnet.
+  //
+  // Slot -> field convention (kept minimal): a "reconfigure" configure step
+  // carries a `deviceId` naming which device it corrects. Slot ids are
+  // literally 'ip' / 'mask' / 'gateway'; each slot's correct option (per
+  // step.answer.slots[slotId]) is resolved to its option `text`, which is
+  // the corrected value for that field. Slots the step doesn't define are
+  // simply left unchanged on the device.
+
+  function _ipToInt(ip) {
+    var parts = String(ip).split('.').map(Number);
+    return (((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0);
+  }
+
+  function _maskToInt(mask) {
+    return _ipToInt(mask);
+  }
+
+  function _inSubnet(ip, netId, mask) {
+    var m = _maskToInt(mask);
+    return (_ipToInt(ip) & m) === (_ipToInt(netId) & m);
+  }
+
+  // Resolve a configure step's correct answer for a given slot id to the
+  // option's text (the symbolic "corrected value"), or undefined if the
+  // step has no such slot.
+  function _slFidelityResolveSlot(step, slotId) {
+    if (!step || !step.payload || !Array.isArray(step.payload.slots)) return undefined;
+    if (!step.answer || !step.answer.slots) return undefined;
+    var correctOptId = step.answer.slots[slotId];
+    if (!correctOptId) return undefined;
+    var slot = step.payload.slots.filter(function (sl) { return sl.id === slotId; })[0];
+    if (!slot || !Array.isArray(slot.options)) return undefined;
+    var opt = slot.options.filter(function (o) { return o.id === correctOptId; })[0];
+    return opt ? opt.text : undefined;
+  }
+
+  function simLabValidateNetworkFidelity(networkModel, configureStep) {
+    var errs = [];
+    if (!networkModel || networkModel.kind !== 'network' || !Array.isArray(networkModel.devices)) {
+      return { ok: false, errors: ['fidelity: not a valid network reference'] };
+    }
+
+    var given = networkModel.given || {};
+    var netId = given.networkId, mask = given.mask;
+    var seenIps = {};
+    var flaggedDeviceId = configureStep && configureStep.deviceId;
+
+    networkModel.devices.forEach(function (dev) {
+      if (!dev || !dev.ip || !dev.mask || !dev.zone) return;
+      if (seenIps[dev.ip]) errs.push('duplicate IP: ' + dev.ip + ' (' + seenIps[dev.ip] + ', ' + (dev.label || dev.id) + ')');
+      else seenIps[dev.ip] = dev.label || dev.id;
+
+      // The device targeted by the configure step is expected to be
+      // out-of-subnet pre-fix (that's the scenario's intentional misconfig
+      // to correct) — its subnet membership is asserted post-fix below, not
+      // here. All other devices must already be subnet-sound.
+      if (dev.id === flaggedDeviceId) return;
+
+      if (netId && mask) {
+        if (!_inSubnet(dev.ip, netId, mask)) {
+          errs.push((dev.label || dev.id) + ': IP ' + dev.ip + ' is out of subnet ' + netId + '/' + mask);
+        }
+        if (dev.gateway && !_inSubnet(dev.gateway, netId, mask)) {
+          errs.push((dev.label || dev.id) + ': gateway ' + dev.gateway + ' is out of subnet ' + netId + '/' + mask);
+        }
+      }
+    });
+
+    // Apply the configure step's correct answer symbolically and re-check
+    // the corrected device.
+    if (configureStep && configureStep.deviceId) {
+      var dev2 = networkModel.devices.filter(function (d) { return d.id === configureStep.deviceId; })[0];
+      if (!dev2) {
+        errs.push('fidelity: configure step deviceId "' + configureStep.deviceId + '" not found in network reference');
+      } else {
+        var correctedIp = _slFidelityResolveSlot(configureStep, 'ip') || dev2.ip;
+        var correctedMask = _slFidelityResolveSlot(configureStep, 'mask') || dev2.mask;
+        var correctedGw = _slFidelityResolveSlot(configureStep, 'gateway') || dev2.gateway;
+
+        if (netId && correctedMask) {
+          if (!_inSubnet(correctedIp, netId, correctedMask)) {
+            errs.push('corrected ' + (dev2.label || dev2.id) + ': IP ' + correctedIp + ' is still out of subnet ' + netId + '/' + correctedMask);
+          }
+          if (correctedGw && !_inSubnet(correctedGw, netId, correctedMask)) {
+            errs.push('corrected ' + (dev2.label || dev2.id) + ': gateway ' + correctedGw + ' is still out of subnet ' + netId + '/' + correctedMask);
+          }
+        }
+      }
+    }
+
+    return { ok: errs.length === 0, errors: errs };
+  }
+
   // --- scoring (Task 2) ---
 
   function _norm(v) {
@@ -2311,6 +2408,7 @@
 
   // --- exports (more added in later tasks) ---
   window.simLabValidateScenario = simLabValidateScenario;
+  window.simLabValidateNetworkFidelity = simLabValidateNetworkFidelity;
   window.simLabScoreScenario = simLabScoreScenario;
   window.simLabSubmitScenario = simLabSubmitScenario;
   window._simLab = window._simLab || {};

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -684,7 +684,98 @@
     }
     return _el('div', 'sl-timeline', rows.join(''));
   }
-  function _slRenderRefLayered(ref) { return _el('div', 'sl-ref-stub', 'layered'); }   // replaced in Task 8
+  function _slRenderRefLayered(ref) {
+    // Defense-in-depth nested-frames renderer (Task 8).
+    // Layout: concentric SVG rectangles — layers[0] = outermost frame, each
+    // subsequent layer inset INSET_X px left/right/bottom and INSET_TOP px top
+    // (room for the layer label), then the core innermost. viewBox scales with
+    // layer count: outer = CORE_W + 2*INSET_X*N wide, CORE_H + (INSET_X+INSET_TOP)*N tall.
+    var layers = Array.isArray(ref.layers) ? ref.layers : [];
+    var core   = ref.core || { label: 'Core', assets: [] };
+    var assets = Array.isArray(core.assets) ? core.assets : [];
+    var N = layers.length;
+
+    var INSET_X   = 46;   // left/right/bottom inset per level
+    var INSET_TOP = 52;   // top inset (label room) per level
+    var CORE_W    = 200;  // minimum core inner width
+    var CORE_H    = 120;  // minimum core inner height
+    var RX        = 14;   // corner radius for all frames
+    var DEV_W     = 90;   // device node width
+    var DEV_H     = 42;   // device node height
+    var DEV_GAP   = 12;   // gap between device nodes
+
+    // Outer frame dimensions grow outward from the core
+    var outerW = CORE_W + 2 * INSET_X * N;
+    var outerH = CORE_H + (INSET_X + INSET_TOP) * N;
+    // Add padding around the outer frame
+    var PAD = 8;
+    var VW  = outerW + PAD * 2;
+    var VH  = outerH + PAD * 2;
+
+    var parts = [];
+
+    // Render each layer frame, outer to inner (layers[0] = outer)
+    for (var i = 0; i < N; i++) {
+      var lyr  = layers[i];
+      var depth = i; // 0 = outermost
+      var lx = PAD + INSET_X * depth;
+      var ly = PAD + INSET_TOP * depth;
+      var lw = outerW - 2 * INSET_X * depth;
+      var lh = outerH - (INSET_X + INSET_TOP) * depth;
+      var isMissing = lyr.state === 'missing';
+      var frameCls = isMissing ? 'sl-misslayer' : 'sl-layer';
+      var labelText = _esc(lyr.label) + (lyr.control ? ' — ' + _esc(lyr.control) : '');
+      var missingTag = isMissing ? ' <tspan class="sl-misslayer-tag">missing</tspan>' : '';
+      parts.push(
+        '<rect class="' + frameCls + '" x="' + lx + '" y="' + ly +
+        '" width="' + lw + '" height="' + lh + '" rx="' + RX + '"/>' +
+        '<text class="sl-layer-lbl' + (isMissing ? ' sl-layer-lbl-miss' : '') + '" x="' + (lx + 14) + '" y="' + (ly + 22) + '">' +
+        labelText + missingTag + '</text>'
+      );
+    }
+
+    // Core frame — innermost rectangle
+    var coreX = PAD + INSET_X * N;
+    var coreY = PAD + INSET_TOP * N;
+    var coreW = CORE_W;
+    var coreH = CORE_H;
+    var anyExposed = assets.some(function (a) { return a.exposed; });
+    var coreCls = anyExposed ? 'sl-core-exposed' : 'sl-core';
+    var coreLabelCls = anyExposed ? 'sl-core-lbl sl-core-lbl-exp' : 'sl-core-lbl';
+    parts.push(
+      '<rect class="' + coreCls + '" x="' + coreX + '" y="' + coreY +
+      '" width="' + coreW + '" height="' + coreH + '" rx="' + RX + '"/>' +
+      '<text class="' + coreLabelCls + '" x="' + (coreX + 10) + '" y="' + (coreY + 16) + '">' +
+      _esc(core.label) + '</text>'
+    );
+
+    // Device nodes inside the core, laid out in a row centred horizontally
+    var totalDevW = assets.length * DEV_W + (assets.length - 1) * DEV_GAP;
+    var devStartX = coreX + Math.max(0, Math.floor((coreW - totalDevW) / 2));
+    var devY = coreY + coreH - DEV_H - 10;
+    for (var j = 0; j < assets.length; j++) {
+      var ast = assets[j];
+      var dx  = devStartX + j * (DEV_W + DEV_GAP);
+      var dy  = devY;
+      var expd = ast.exposed;
+      var devBoxCls  = expd ? 'sl-dev-box sl-dev-box-exp' : 'sl-dev-box';
+      var devNameCls = expd ? 'sl-dev-nm sl-dev-nm-exp'   : 'sl-dev-nm';
+      parts.push(
+        '<g class="sl-dev' + (expd ? ' exposed' : '') + '" transform="translate(' + dx + ',' + dy + ')">' +
+        '<rect class="' + devBoxCls + '" width="' + DEV_W + '" height="' + DEV_H + '" rx="7"/>' +
+        '<text class="' + devNameCls + '" x="' + Math.floor(DEV_W / 2) + '" y="' + Math.floor(DEV_H / 2 + 5) + '">' +
+        _esc(ast.label) + '</text>' +
+        '</g>'
+      );
+    }
+
+    var svgStr =
+      '<svg class="sl-layered-svg" viewBox="0 0 ' + VW + ' ' + VH + '" xmlns="http://www.w3.org/2000/svg">' +
+      parts.join('') +
+      '</svg>';
+
+    return _el('div', 'sl-layered', svgStr);
+  }
   function _slRenderReference(ref) {
     if (!ref || !ref.kind) return null;
     var panel = _el('div', 'sl-ref');

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -2,7 +2,7 @@
 (function () {
   'use strict';
 
-  var STEP_TYPES = ['order', 'categorize', 'match', 'analyze', 'fillin'];
+  var STEP_TYPES = ['order', 'categorize', 'match', 'analyze', 'fillin', 'configure'];
 
   var _SL_PBQ_CERTS = ['netplus', 'secplus', 'aplus-core1', 'aplus-core2'];
 
@@ -28,6 +28,16 @@
         return Array.isArray(p.fields) && p.fields.length >= 1 &&
                a && typeof a === 'object' &&
                p.fields.every(function (f) { return typeof f.id === 'string' && f.id && Array.isArray(a[f.id]) && a[f.id].length >= 1; });
+      case 'configure':
+        return Array.isArray(p.slots) && p.slots.length >= 1 &&
+               a.slots && typeof a.slots === 'object' && !Array.isArray(a.slots) &&
+               p.slots.every(function (sl) {
+                 return _isNonEmptyStr(sl.id) && _isNonEmptyStr(sl.label) &&
+                        Array.isArray(sl.options) && sl.options.length >= 2 &&
+                        sl.options.every(function (o) { return _isNonEmptyStr(o.id) && _isNonEmptyStr(o.text); }) &&
+                        _isNonEmptyStr(a.slots[sl.id]) &&
+                        sl.options.some(function (o) { return o.id === a.slots[sl.id]; });
+               });
       default: return false;
     }
   }

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -656,7 +656,34 @@
 
     return root;
   }
-  function _slRenderRefTimeline(ref) { return _el('div', 'sl-ref-stub', 'timeline'); } // replaced in Task 7
+  // Real timeline reference renderer (Task 7). Data-driven: ref.stages[] drives
+  // one .sl-stage row per entry. Faithful lift from mockups/incident-response-pbq-concept.html
+  // (.timeline / .stage / .rail / .dot / .line / .body / .when / .what / .sevtag).
+  // severity → sev-low|sev-med|sev-high|sev-crit on the stage (drives --sev token).
+  // The .sl-line connector is OMITTED on the last stage. ES5, read-only.
+  function _slRenderRefTimeline(ref) {
+    var stages = Array.isArray(ref.stages) ? ref.stages : [];
+    var rows = [];
+    for (var i = 0; i < stages.length; i++) {
+      var st = stages[i];
+      var sev = st.severity || 'low';
+      var sevCls = 'sev-' + sev;
+      var isLast = (i === stages.length - 1);
+
+      // rail: dot + optional connecting line
+      var railInner = '<span class="sl-dot"></span>' + (isLast ? '' : '<span class="sl-line"></span>');
+      var rail = '<div class="sl-rail">' + railInner + '</div>';
+
+      // body: optional time, label, severity tag
+      var whenHtml = st.time ? '<div class="sl-when">' + _esc(st.time) + '</div>' : '';
+      var whatHtml = '<div class="sl-what">' + _esc(st.label) + '</div>';
+      var tagHtml  = '<span class="sl-sevtag">' + _esc(sev) + '</span>';
+      var body = '<div class="sl-body">' + whenHtml + whatHtml + tagHtml + '</div>';
+
+      rows.push('<div class="sl-stage ' + sevCls + '">' + rail + body + '</div>');
+    }
+    return _el('div', 'sl-timeline', rows.join(''));
+  }
   function _slRenderRefLayered(ref) { return _el('div', 'sl-ref-stub', 'layered'); }   // replaced in Task 8
   function _slRenderReference(ref) {
     if (!ref || !ref.kind) return null;

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -68,6 +68,9 @@
       else if (ref.kind === 'timeline' && !Array.isArray(ref.stages)) errs.push('reference timeline: stages[] required');
       else if (ref.kind === 'layered' && !Array.isArray(ref.layers)) errs.push('reference layered: layers[] required');
     }
+    if (s.archetype !== undefined && ['diagram', 'incident', 'defense'].indexOf(s.archetype) === -1) {
+      errs.push('bad archetype');
+    }
     return { ok: errs.length === 0, errors: errs };
   }
 

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -937,6 +937,22 @@
       '<text class="sl-perim-sub" x="' + (PAD_X + 22) + '" y="' + (PERIM_TOP + 40) + '">' + perimSub + '</text>'
     );
 
+    // ── Perimeter device box (FW-1, WAF-1, ...) — data-driven, optional ──
+    // Faithful lift of mockups/defense-in-depth-secplus-concept.html ~line 194
+    // (`.fw` device box), anchored top-right inside the perimeter frame.
+    if (perimeter.device && perimeter.device.label) {
+      var fwW = 64, fwH = 30;
+      var fwX = VW - PAD_X - 22 - fwW;
+      var fwY = PERIM_TOP + 10;
+      parts.push(
+        '<g class="sl-fw" transform="translate(' + fwX + ',' + fwY + ')">' +
+        '<rect class="sl-fw-box" width="' + fwW + '" height="' + fwH + '" rx="8"/>' +
+        '<g class="sl-fw-glyph" transform="translate(8,8)"><path d="M2 1v12M7 1v12M0 4h13M0 9h13"/></g>' +
+        '<text class="sl-fw-nm" x="42" y="20">' + _esc(perimeter.device.label) + '</text>' +
+        '</g>'
+      );
+    }
+
     // ── Interior bands, top→bottom ──
     for (var i = 0; i < N; i++) {
       var b = bands[i];

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -67,6 +67,9 @@
       else if (ref.kind === 'network' && !Array.isArray(ref.devices)) errs.push('reference network: devices[] required');
       else if (ref.kind === 'timeline' && !Array.isArray(ref.stages)) errs.push('reference timeline: stages[] required');
       else if (ref.kind === 'layered' && !Array.isArray(ref.layers)) errs.push('reference layered: layers[] required');
+      if (ref.kind === 'layered' && ref.layout !== undefined && ['nested', 'stacked'].indexOf(ref.layout) === -1) {
+        errs.push('reference layered: bad layout');
+      }
     }
     if (s.archetype !== undefined && ['diagram', 'incident', 'defense'].indexOf(s.archetype) === -1) {
       errs.push('bad archetype');
@@ -876,12 +879,126 @@
 
     return _el('div', 'sl-layered', svgStr);
   }
+
+  // Defense-in-depth "stacked-bands" renderer — faithful lift of
+  // mockups/defense-in-depth-secplus-concept.html (~lines 188-209).
+  // Layout convention: layers[0] = outer PERIMETER frame (present/missing
+  // styling + name label + mono control sublabel); layers[1..] = a vertical
+  // stack of horizontal interior BANDS, top-to-bottom, each either a solid
+  // accent band (present) or a red-dashed band (missing) with a mono
+  // sublabel; core = the bottom band containing device boxes from
+  // core.assets[] (exposed → red device styling, else accent/safe).
+  function _slRenderRefLayeredStacked(ref) {
+    var layers = Array.isArray(ref.layers) ? ref.layers : [];
+    var perimeter = layers[0] || { label: 'Perimeter', state: 'present' };
+    var bands = layers.slice(1);
+    var core = ref.core || { label: 'Core', assets: [] };
+    var assets = Array.isArray(core.assets) ? core.assets : [];
+    var N = bands.length;
+
+    var VW = 560;
+    var PAD_X = 16;
+    var PERIM_TOP = 40;
+    var BAND_X = 52;
+    var BAND_W = VW - BAND_X * 2;
+    var BAND_H = 38;
+    var BAND_GAP = 10;
+    var BAND_TOP = PERIM_TOP + 60; // room for perimeter label + sublabel
+    var CORE_H_PER_ASSET = 78;
+    var CORE_TOP_GAP = 30; // room for core label above device row
+    var CORE_MARGIN_X = 68;
+    var RX_PERIM = 18;
+    var RX_BAND = 11;
+    var RX_CORE = 14;
+    var RX_DEV = 11;
+    var DEV_W = 118;
+    var DEV_H = 78;
+    var DEV_GAP = 24;
+
+    var bandsBottom = BAND_TOP + N * BAND_H + Math.max(0, N - 1) * BAND_GAP;
+    var coreTop = bandsBottom + 20;
+    var coreH = CORE_TOP_GAP + CORE_H_PER_ASSET;
+    var coreBottom = coreTop + coreH;
+    var perimBottom = coreBottom + 16;
+    var VH = perimBottom + PAD_X;
+
+    var parts = [];
+
+    // ── Perimeter frame ──
+    var perimMissing = perimeter.state === 'missing';
+    var perimFrameCls = perimMissing ? 'sl-perim-missing' : 'sl-perim';
+    var perimLblCls = perimMissing ? 'sl-perim-lbl sl-perim-lbl-miss' : 'sl-perim-lbl';
+    var perimStateTag = perimMissing ? 'missing' : 'present';
+    var perimSub = _esc(perimeter.control || '') + (perimeter.control ? ' · ' : '') + perimStateTag;
+    parts.push(
+      '<rect class="' + perimFrameCls + '" x="' + PAD_X + '" y="' + PERIM_TOP +
+      '" width="' + (VW - PAD_X * 2) + '" height="' + (perimBottom - PERIM_TOP) + '" rx="' + RX_PERIM + '"/>' +
+      '<text class="' + perimLblCls + '" x="' + (PAD_X + 22) + '" y="' + (PERIM_TOP + 24) + '">' + _esc(perimeter.label) + '</text>' +
+      '<text class="sl-perim-sub" x="' + (PAD_X + 22) + '" y="' + (PERIM_TOP + 40) + '">' + perimSub + '</text>'
+    );
+
+    // ── Interior bands, top→bottom ──
+    for (var i = 0; i < N; i++) {
+      var b = bands[i];
+      var isMissing = b.state === 'missing';
+      var bandCls = isMissing ? 'sl-band-missing' : 'sl-band';
+      var bandLblCls = isMissing ? 'sl-band-lbl sl-band-lbl-miss' : 'sl-band-lbl';
+      var by = BAND_TOP + i * (BAND_H + BAND_GAP);
+      var stateTag = isMissing ? 'missing' : 'present';
+      var subText = _esc(b.control || '') + (b.control ? ' — ' : '') + stateTag;
+      parts.push(
+        '<rect class="' + bandCls + '" x="' + BAND_X + '" y="' + by +
+        '" width="' + BAND_W + '" height="' + BAND_H + '" rx="' + RX_BAND + '"/>' +
+        '<text class="' + bandLblCls + '" x="' + (BAND_X + 20) + '" y="' + (by + BAND_H / 2 + 5) + '">' + _esc(b.label) + '</text>' +
+        '<text class="sl-band-sub" x="' + (BAND_X + 20 + (String(b.label || '').length * 8 + 16)) + '" y="' + (by + BAND_H / 2 + 5) + '">' + subText + '</text>'
+      );
+    }
+
+    // ── Exposed/safe core band with device boxes ──
+    var anyExposed = assets.some(function (a) { return a.exposed; });
+    var coreCls = anyExposed ? 'sl-core-exposed' : 'sl-core';
+    var coreLblCls = anyExposed ? 'sl-core-lbl sl-core-lbl-exp' : 'sl-core-lbl';
+    var coreW = VW - CORE_MARGIN_X * 2;
+    parts.push(
+      '<rect class="' + coreCls + '" x="' + CORE_MARGIN_X + '" y="' + coreTop +
+      '" width="' + coreW + '" height="' + coreH + '" rx="' + RX_CORE + '"/>' +
+      '<text class="' + coreLblCls + '" x="' + (CORE_MARGIN_X + 22) + '" y="' + (coreTop + 24) + '">' + _esc(core.label) + (anyExposed ? ' · exposed' : ' · safe') + '</text>'
+    );
+
+    var totalDevW = assets.length * DEV_W + Math.max(0, assets.length - 1) * DEV_GAP;
+    var devStartX = CORE_MARGIN_X + Math.max(0, Math.floor((coreW - totalDevW) / 2));
+    var devY = coreTop + CORE_TOP_GAP + 8;
+    for (var j = 0; j < assets.length; j++) {
+      var ast = assets[j];
+      var dx = devStartX + j * (DEV_W + DEV_GAP);
+      var expd = ast.exposed;
+      var devBoxCls = expd ? 'sl-dev-box sl-dev-box-exp' : 'sl-dev-box';
+      var devNameCls = expd ? 'sl-dev-nm sl-dev-nm-exp' : 'sl-dev-nm';
+      parts.push(
+        '<g class="sl-dev' + (expd ? ' exposed' : '') + '" transform="translate(' + dx + ',' + devY + ')">' +
+        '<rect class="' + devBoxCls + '" width="' + DEV_W + '" height="' + DEV_H + '" rx="' + RX_DEV + '"/>' +
+        '<text class="' + devNameCls + '" x="' + Math.floor(DEV_W / 2) + '" y="' + Math.floor(DEV_H / 2 + 5) + '">' +
+        _esc(ast.label) + '</text>' +
+        '</g>'
+      );
+    }
+
+    var svgStr =
+      '<svg class="sl-layered-svg" viewBox="0 0 ' + VW + ' ' + VH + '" xmlns="http://www.w3.org/2000/svg">' +
+      parts.join('') +
+      '</svg>';
+
+    return _el('div', 'sl-stacked', svgStr);
+  }
+
   function _slRenderReference(ref) {
     if (!ref || !ref.kind) return null;
     var panel = _el('div', 'sl-ref');
     if (ref.kind === 'network') panel.appendChild(_slRenderRefNetwork(ref));
     else if (ref.kind === 'timeline') panel.appendChild(_slRenderRefTimeline(ref));
-    else if (ref.kind === 'layered') panel.appendChild(_slRenderRefLayered(ref));
+    else if (ref.kind === 'layered') {
+      panel.appendChild(ref.layout === 'stacked' ? _slRenderRefLayeredStacked(ref) : _slRenderRefLayered(ref));
+    }
     return panel;
   }
 

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -469,6 +469,41 @@
     return root;
   }
 
+  // --- configure renderer ---
+  // Renders one native <select> per slot. Native selects are chosen deliberately:
+  // they use the platform wheel picker on iOS and are universally accessible
+  // without custom ARIA. CSS comes in Task 4; class names are locked here.
+  function _slRenderConfigure(step, onChange, initial) {
+    var resp = (initial && initial.slots && typeof initial.slots === 'object')
+      ? Object.assign({}, initial.slots)
+      : {};
+    var root = _el('div', 'sl-cfg');
+    root.appendChild(_el('p', 'sl-prompt', _esc(step.prompt)));
+    step.payload.slots.forEach(function (sl) {
+      var wrap = _el('div', 'sl-cfg-slot');
+      wrap.appendChild(_el('label', 'sl-cfg-label', _esc(sl.label)));
+      var sel = document.createElement('select');
+      sel.className = 'sl-cfg-select';
+      sel.setAttribute('data-slot', sl.id);
+      var ph = document.createElement('option');
+      ph.value = ''; ph.textContent = 'Choose…'; sel.appendChild(ph);
+      sl.options.forEach(function (o) {
+        var op = document.createElement('option');
+        op.value = o.id; op.textContent = o.text;
+        if (resp[sl.id] === o.id) { op.selected = true; }
+        sel.appendChild(op);
+      });
+      sel.addEventListener('change', function () {
+        if (sel.value) { resp[sl.id] = sel.value; } else { delete resp[sl.id]; }
+        onChange({ slots: Object.assign({}, resp) });
+      });
+      wrap.appendChild(sel);
+      root.appendChild(wrap);
+    });
+    onChange({ slots: Object.assign({}, resp) }); // report initial state
+    return root;
+  }
+
   // --- renderStep dispatcher ---
   // `initial` (optional) seeds the widget with a prior response so it re-hydrates
   // visually — used by exam free-nav to restore a saved round. Omitted in
@@ -480,6 +515,7 @@
       case 'match': return _slRenderMatch(step, onChange, initial);
       case 'analyze': return _slRenderAnalyze(step, onChange, initial);
       case 'fillin': return _slRenderFillin(step, onChange, initial);
+      case 'configure': return _slRenderConfigure(step, onChange, initial);
       default: return _el('div', 'sl-unknown', 'Unsupported step');
     }
   }

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -528,7 +528,134 @@
   }
 
   // --- reference asset renderers (Task 5 — stubs; replaced by Tasks 6-8) ---
-  function _slRenderRefNetwork(ref) { return _el('div', 'sl-ref-stub', 'network'); }   // replaced in Task 6
+
+  // Real network reference renderer (Task 6). Data-driven: the mockups supply
+  // VISUAL STYLE only; layout is computed from each device's small-int grid
+  // coords so it works for any scenario, not just the dev fixture. Read-only
+  // (no listeners). SVG is built as a string and mounted via
+  // _el('div','sl-net', svg) so it is inert and trivially assertable. The
+  // glyph map lives inside the fn so the unit is self-contained.
+  function _slRenderRefNetwork(ref) {
+    // Monoline device glyphs (lifted from mockups/diagram-pbq-concept.html;
+    // each is drawn in a ~16px box and centered on the node by the renderer).
+    // Stroke is currentColor via .sl-glyph so state overlays recolour it.
+    var _SL_NET_GLYPHS = {
+      router:   { d: 'M1 8h7m-3.5-3.5v7M10 4l5 4-5 4', w: 16, h: 16 },
+      'switch': { d: 'M5 3l-5 5 5 5M13 3l5 5-5 5',     w: 18, h: 16 },
+      server:   { d: 'M0 3h16v10H0zM0 8h16',           w: 16, h: 16 },
+      pc:       { d: 'M0 3h16v9H0zM5 16h6',            w: 16, h: 18 },
+      firewall: { d: 'M0 2h16v12H0zM0 6h16M0 10h16M5 2v4M11 2v4M3 6v4M8 6v4M13 6v4', w: 16, h: 16 },
+      box:      { d: 'M1 3h14v10H1z',                  w: 16, h: 16 }
+    };
+    var root = _el('div', 'sl-net-ref');
+    if (!ref || !Array.isArray(ref.devices)) { return root; }
+
+    var CELL_W = 150, CELL_H = 110, NODE_W = 128, NODE_H = 62, PAD = 24;
+    var ZONE_PAD = 20, ZONE_LABEL_PAD = 34;
+    var devices = ref.devices, links = Array.isArray(ref.links) ? ref.links : [];
+
+    // index by id + precompute geometry; track max extents for the viewBox
+    var byId = {}, geo = {}, maxRight = 0, maxBottom = 0, i;
+    for (i = 0; i < devices.length; i++) {
+      var d = devices[i];
+      var nx = PAD + (d.x || 0) * CELL_W;
+      var ny = PAD + (d.y || 0) * CELL_H;
+      geo[d.id] = { nx: nx, ny: ny, cx: nx + NODE_W / 2, cy: ny + NODE_H / 2 };
+      byId[d.id] = d;
+      if (nx + NODE_W > maxRight) maxRight = nx + NODE_W;
+      if (ny + NODE_H > maxBottom) maxBottom = ny + NODE_H;
+    }
+    var W = maxRight + PAD, H = maxBottom + PAD;
+
+    // zones: bounding box per distinct (truthy) zone — devices with a falsy
+    // zone (router/firewall/internet) sit outside any zone box.
+    var zoneOrder = [], zoneBox = {};
+    for (i = 0; i < devices.length; i++) {
+      var dv = devices[i];
+      if (!dv.zone) continue;
+      var zg = geo[dv.id];
+      if (!zoneBox[dv.zone]) {
+        zoneOrder.push(dv.zone);
+        zoneBox[dv.zone] = { x1: zg.nx, y1: zg.ny, x2: zg.nx + NODE_W, y2: zg.ny + NODE_H };
+      } else {
+        var zb = zoneBox[dv.zone];
+        if (zg.nx < zb.x1) zb.x1 = zg.nx;
+        if (zg.ny < zb.y1) zb.y1 = zg.ny;
+        if (zg.nx + NODE_W > zb.x2) zb.x2 = zg.nx + NODE_W;
+        if (zg.ny + NODE_H > zb.y2) zb.y2 = zg.ny + NODE_H;
+      }
+    }
+
+    var svg = [];
+    svg.push('<svg class="sl-net-svg" viewBox="0 0 ' + W + ' ' + H + '" role="img" ' +
+             'aria-label="Network diagram reference" preserveAspectRatio="xMidYMid meet">');
+    // arrow marker for attack links (lifted from incident-response mockup)
+    svg.push('<defs><marker id="sl-net-arrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">' +
+             '<path d="M0 0L6 3L0 6z" class="sl-net-arrowhead"/></marker></defs>');
+
+    // zones first (behind nodes)
+    for (i = 0; i < zoneOrder.length; i++) {
+      var zname = zoneOrder[i], box = zoneBox[zname];
+      var zx = box.x1 - ZONE_PAD, zy = box.y1 - ZONE_LABEL_PAD;
+      var zw = (box.x2 - box.x1) + ZONE_PAD * 2;
+      var zh = (box.y2 - box.y1) + ZONE_LABEL_PAD + ZONE_PAD;
+      svg.push('<rect class="sl-vlan-zone" x="' + zx + '" y="' + zy + '" width="' + zw +
+               '" height="' + zh + '" rx="16"/>');
+      svg.push('<text class="sl-zone-lbl" x="' + (zx + 14) + '" y="' + (zy + 20) + '">' +
+               _esc(String(zname).toUpperCase()) + '</text>');
+    }
+
+    // links (node-center to node-center)
+    for (i = 0; i < links.length; i++) {
+      var lk = links[i];
+      var a = geo[lk.from], b = geo[lk.to];
+      if (!a || !b) continue;
+      var attack = lk.kind === 'attack';
+      svg.push('<line class="sl-link' + (attack ? ' attack' : '') + '" x1="' + a.cx + '" y1="' + a.cy +
+               '" x2="' + b.cx + '" y2="' + b.cy + '"' +
+               (attack ? ' marker-end="url(#sl-net-arrow)"' : '') + '/>');
+    }
+
+    // nodes (centered-stack: rect + glyph-on-top + name/ip centered)
+    for (i = 0; i < devices.length; i++) {
+      var nd = devices[i], ng = geo[nd.id];
+      var stateCls = nd.state === 'compromised' ? ' compromised'
+                   : (nd.state === 'affected' ? ' affected' : '');
+      var gl = _SL_NET_GLYPHS[nd.type] || _SL_NET_GLYPHS.box;
+      var glX = ng.nx + (NODE_W - gl.w) / 2;
+      var cxText = ng.nx + NODE_W / 2;
+      svg.push('<g class="sl-node' + stateCls + '">');
+      svg.push('<rect class="sl-node-box" x="' + ng.nx + '" y="' + ng.ny + '" width="' + NODE_W +
+               '" height="' + NODE_H + '" rx="12"/>');
+      svg.push('<path class="sl-glyph" transform="translate(' + glX + ',' + (ng.ny + 9) + ')" d="' + gl.d + '"/>');
+      svg.push('<text class="sl-node-name" x="' + cxText + '" y="' + (ng.ny + 40) + '">' + _esc(nd.label) + '</text>');
+      if (nd.ip) {
+        svg.push('<text class="sl-node-ip" x="' + cxText + '" y="' + (ng.ny + 54) + '">' + _esc(nd.ip) + '</text>');
+      }
+      svg.push('</g>');
+    }
+
+    svg.push('</svg>');
+    root.appendChild(_el('div', 'sl-net', svg.join('')));
+
+    // optional read-only given panel + mono CLI block
+    var given = ref.given;
+    if (given) {
+      if (given.networkId || given.mask) {
+        var rows = '';
+        if (given.networkId) rows += '<div class="sl-net-row"><span class="k">Network ID</span><span class="v">' + _esc(given.networkId) + '</span></div>';
+        if (given.mask) rows += '<div class="sl-net-row"><span class="k">Subnet mask</span><span class="v">' + _esc(given.mask) + '</span></div>';
+        root.appendChild(_el('div', 'sl-net-given', rows));
+      }
+      if (Array.isArray(given.cli) && given.cli.length) {
+        var lines = [];
+        for (i = 0; i < given.cli.length; i++) lines.push(_esc(given.cli[i]));
+        root.appendChild(_el('div', 'sl-net-cli', lines.join('<br>')));
+      }
+    }
+
+    return root;
+  }
   function _slRenderRefTimeline(ref) { return _el('div', 'sl-ref-stub', 'timeline'); } // replaced in Task 7
   function _slRenderRefLayered(ref) { return _el('div', 'sl-ref-stub', 'layered'); }   // replaced in Task 8
   function _slRenderReference(ref) {

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -92,6 +92,15 @@
     return _arrEq(sa, sb);
   }
 
+  function _scoreConfigureSlots(step, resp) {
+    var ans = step.answer.slots, total = 0, correct = 0;
+    Object.keys(ans).forEach(function (slotId) {
+      total++;
+      if (resp && resp.slots && resp.slots[slotId] === ans[slotId]) correct++;
+    });
+    return { total: total, correct: correct };
+  }
+
   function _scoreStep(step, resp) {
     if (!resp) return false;
     switch (step.type) {
@@ -113,18 +122,27 @@
           var given = resp && resp[f.id];
           return _simLabNormalizeMatch(given, accept); // see _simLabNormalizeMatch above
         });
+      case 'configure':
+        var _sc = _scoreConfigureSlots(step, resp);
+        return _sc.total > 0 && _sc.correct === _sc.total;
       default: return false;
     }
   }
 
   function simLabScoreScenario(scn, responses) {
-    var perStep = {}, correct = 0;
+    var perStep = {}, correct = 0, total = 0;
     scn.steps.forEach(function (st) {
-      var ok = _scoreStep(st, responses ? responses[st.id] : null);
-      perStep[st.id] = ok;
-      if (ok) correct++;
+      var resp = responses ? responses[st.id] : null;
+      if (st.type === 'configure') {
+        var sc = _scoreConfigureSlots(st, resp);
+        perStep[st.id] = sc;            // { total, correct } breakdown for configure
+        correct += sc.correct; total += sc.total;
+      } else {
+        var ok = _scoreStep(st, resp);
+        perStep[st.id] = ok;            // boolean for existing types
+        if (ok) correct++; total++;
+      }
     });
-    var total = scn.steps.length;
     return { perStep: perStep, correct: correct, total: total, fraction: total ? correct / total : 0 };
   }
 

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -61,6 +61,13 @@
         if (!_validateStepPayload(st)) errs.push('step ' + i + ': bad payload/answer for ' + st.type);
       });
     }
+    if (s.assets && s.assets.reference) {
+      var ref = s.assets.reference, kinds = ['network', 'timeline', 'layered'];
+      if (kinds.indexOf(ref.kind) === -1) errs.push('reference: bad kind');
+      else if (ref.kind === 'network' && !Array.isArray(ref.devices)) errs.push('reference network: devices[] required');
+      else if (ref.kind === 'timeline' && !Array.isArray(ref.stages)) errs.push('reference timeline: stages[] required');
+      else if (ref.kind === 'layered' && !Array.isArray(ref.layers)) errs.push('reference layered: layers[] required');
+    }
     return { ok: errs.length === 0, errors: errs };
   }
 
@@ -520,6 +527,19 @@
     }
   }
 
+  // --- reference asset renderers (Task 5 — stubs; replaced by Tasks 6-8) ---
+  function _slRenderRefNetwork(ref) { return _el('div', 'sl-ref-stub', 'network'); }   // replaced in Task 6
+  function _slRenderRefTimeline(ref) { return _el('div', 'sl-ref-stub', 'timeline'); } // replaced in Task 7
+  function _slRenderRefLayered(ref) { return _el('div', 'sl-ref-stub', 'layered'); }   // replaced in Task 8
+  function _slRenderReference(ref) {
+    if (!ref || !ref.kind) return null;
+    var panel = _el('div', 'sl-ref');
+    if (ref.kind === 'network') panel.appendChild(_slRenderRefNetwork(ref));
+    else if (ref.kind === 'timeline') panel.appendChild(_slRenderRefTimeline(ref));
+    else if (ref.kind === 'layered') panel.appendChild(_slRenderRefLayered(ref));
+    return panel;
+  }
+
   // --- scenario orchestrator (Task 10) ---
   // opts.initial (optional): a per-step seed map { stepId: response } used by exam
   // free-nav to re-hydrate a previously-answered round. Practice/session mode omits
@@ -536,6 +556,10 @@
       var pre = _el('pre', 'sl-scn-logs');
       pre.textContent = scn.assets.logs.join('\n');
       wrap.appendChild(pre);
+    }
+    if (scn.assets && scn.assets.reference) {
+      var refPanel = _slRenderReference(scn.assets.reference);
+      if (refPanel) wrap.appendChild(refPanel);
     }
     scn.steps.forEach(function (st, i) {
       var stepWrap = _el('div', 'sl-step');

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.60.5">
+<link rel="stylesheet" href="dg-system.css?v=7.61.0">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.60.2">
+<link rel="stylesheet" href="dg-system.css?v=7.60.3">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.60.3">
+<link rel="stylesheet" href="dg-system.css?v=7.60.4">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/index.html
+++ b/index.html
@@ -772,7 +772,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.60.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.61.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.61.0">
+<link rel="stylesheet" href="dg-system.css?v=7.61.1">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.60.4">
+<link rel="stylesheet" href="dg-system.css?v=7.60.5">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.60.1">
+<link rel="stylesheet" href="dg-system.css?v=7.60.2">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.60.0">
+<link rel="stylesheet" href="dg-system.css?v=7.60.1">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/mockups/defense-in-depth-netplus-concept.html
+++ b/mockups/defense-in-depth-netplus-concept.html
@@ -1,0 +1,371 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Defense in Depth PBQ (Net+) · concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ── CertAnvil MOCKUP STARTER TOKEN BLOCK (verbatim) + --warn from BRAND.md §3 ── */
+:root, [data-theme="dark"] {
+  --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+  --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+  --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+  --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+  --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25); --warn: oklch(0.80 0.130 75);
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-theme="light"] {
+  --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+  --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+  --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+  --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+  --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25); --warn: oklch(0.62 0.14 70);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { background: var(--bg); color: var(--ink); font-family: Inter, system-ui, sans-serif; }
+body { min-height: 100dvh; padding: clamp(14px, 3vw, 32px); -webkit-font-smoothing: antialiased; }
+.wrap { max-width: 1180px; margin: 0 auto; }
+
+.topbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 22px; }
+.brand { display: flex; align-items: center; gap: 11px; }
+.brand svg { width: 30px; height: 30px; }
+.brand b { font-weight: 700; font-size: 15px; letter-spacing: -0.01em; }
+.brand .sub { color: var(--muted); font-size: 12px; font-weight: 600; }
+.theme-btn { font: inherit; font-size: 12px; font-weight: 600; color: var(--ink-soft); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 9px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease); }
+.theme-btn:active { transform: scale(0.97); }
+
+.eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.13em; text-transform: uppercase; color: var(--accent); }
+.scn-head { margin-bottom: 18px; }
+.scn-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: clamp(24px, 3.4vw, 33px);
+  letter-spacing: -0.02em; line-height: 1.05; margin: 7px 0 9px; }
+.scn-prose { color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; max-width: 70ch; }
+.metstrip { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.met { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 600; color: var(--ink-soft);
+  background: var(--surface); border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; }
+.met svg { width: 13px; height: 13px; stroke: var(--accent); }
+.met .timer { font-variant-numeric: tabular-nums; }
+
+.split { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
+@media (max-width: 880px) { .split { grid-template-columns: 1fr; } }
+
+.panel { background: var(--surface); border: 1px solid var(--border); border-radius: 18px; overflow: hidden;
+  box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 18px 40px -22px color-mix(in oklab, var(--ink) 20%, transparent); }
+.panel-head { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 13px 16px; border-bottom: 1px solid var(--border-soft); }
+.panel-head .lbl { font-size: 10.5px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+.panel-head .gap { font-size: 11px; font-weight: 700; color: var(--fail); }
+
+/* ── layered defense diagram (nested frames = layers around the core) ── */
+.diagram { padding: 12px; }
+.diagram svg { width: 100%; height: auto; display: block; }
+.layer { fill: none; stroke-width: 1.4; }
+.layer.l1 { stroke: color-mix(in oklab, var(--accent) 55%, var(--border)); }
+.layer.l2 { stroke: color-mix(in oklab, var(--accent) 38%, var(--border)); }
+.layer.fill1 { fill: color-mix(in oklab, var(--accent) 5%, transparent); }
+.layer.fill2 { fill: color-mix(in oklab, var(--accent) 7%, transparent); }
+.core-fill { fill: color-mix(in oklab, var(--accent) 11%, transparent); stroke: color-mix(in oklab, var(--accent) 40%, var(--border)); stroke-width: 1.4; }
+.lname { font: 800 10.5px Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; }
+.lname.on { fill: var(--accent); } .lname.mut { fill: var(--muted); }
+.lctrl { font: 600 10.5px ui-monospace, Menlo, monospace; fill: var(--ink-soft); }
+.gapmark { stroke: var(--fail); stroke-width: 1.6; stroke-dasharray: 5 5; fill: none; }
+.gaplbl { font: 800 10px Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; fill: var(--fail); }
+.dev .box { fill: var(--surface); stroke: var(--border); stroke-width: 1.2; }
+.dev .nm { font: 700 11px Inter, sans-serif; fill: var(--ink); text-anchor: middle; }
+.dev.exposed .box { stroke: var(--fail); stroke-width: 1.8; }
+.dev.exposed .nm { fill: var(--fail); }
+.dev .glyph { stroke: var(--accent); stroke-width: 1.7; fill: none; }
+.dev.exposed .glyph { stroke: var(--fail); }
+.expdot { fill: var(--fail); }
+.legend { display: flex; gap: 14px; flex-wrap: wrap; padding: 0 16px 14px; font-size: 11px; color: var(--muted); font-weight: 600; }
+.legend i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 6px; vertical-align: -1px; }
+.legend .ok i { background: color-mix(in oklab, var(--accent) 45%, var(--border)); }
+.legend .bad i { background: var(--fail); }
+
+/* ── answer rail (shared) ── */
+.rail { display: grid; gap: 14px; }
+.phase-tabs { display: flex; gap: 7px; }
+.ptab { flex: 1; text-align: center; font-size: 11.5px; font-weight: 700; padding: 9px; border-radius: 9px;
+  border: 1px solid var(--border); background: var(--surface); color: var(--muted);
+  transition: color .2s var(--ease), border-color .2s var(--ease), background-color .2s var(--ease); }
+.ptab.on { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 34%, var(--border)); background: color-mix(in oklab, var(--accent) 9%, transparent); }
+.ptab.done { color: var(--pass); border-color: color-mix(in oklab, var(--pass) 30%, var(--border)); }
+.ptab .n { font-variant-numeric: tabular-nums; opacity: .65; margin-right: 5px; }
+
+.qcard { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 16px;
+  transition: opacity .22s var(--ease), transform .22s var(--ease), filter .22s var(--ease); }
+.qcard.entering { opacity: 0; transform: translateY(8px); filter: blur(2px); }
+.qcard.leaving { opacity: 0; transform: translateY(-6px); filter: blur(2px); }
+.qcard .q { font-size: 14px; font-weight: 650; line-height: 1.4; margin-bottom: 13px; }
+.slot { display: grid; gap: 6px; margin-bottom: 13px; }
+.slot:last-of-type { margin-bottom: 0; }
+.slot label { font-size: 12px; font-weight: 700; color: var(--ink-soft); }
+.sel { position: relative; }
+.sel select { width: 100%; appearance: none; -webkit-appearance: none; font: inherit; font-size: 13.5px; font-weight: 600;
+  color: var(--ink); background: var(--surface-2); border: 1px solid var(--border); border-radius: 10px;
+  padding: 11px 38px 11px 13px; cursor: pointer; transition: border-color .18s var(--ease), box-shadow .18s var(--ease); }
+.sel select:focus { outline: none; border-color: color-mix(in oklab, var(--accent) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent); }
+.sel::after { content: ""; position: absolute; right: 14px; top: 50%; width: 8px; height: 8px; pointer-events: none;
+  border-right: 2px solid var(--muted); border-bottom: 2px solid var(--muted); transform: translateY(-65%) rotate(45deg); }
+.sel.correct select { border-color: color-mix(in oklab, var(--pass) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--pass) 15%, transparent); }
+.sel.wrong select { border-color: color-mix(in oklab, var(--fail) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--fail) 14%, transparent); }
+.verdict { font-size: 11.5px; font-weight: 600; line-height: 1.45; margin-top: 4px; display: none;
+  opacity: 0; transform: translateY(-3px); transition: opacity .25s var(--ease), transform .25s var(--ease); }
+.slot.graded.ok .verdict.ok { display: block; color: var(--pass); }
+.slot.graded.no .verdict.no { display: block; color: var(--fail); }
+.verdict.in { opacity: 1; transform: none; }
+.verdict b { font-family: ui-monospace, Menlo, monospace; font-weight: 700; }
+
+.actions { display: flex; gap: 10px; }
+.btn { font: inherit; font-size: 13.5px; font-weight: 700; border-radius: 11px; padding: 12px 18px; cursor: pointer;
+  transition: transform .15s var(--ease), filter .15s var(--ease); border: 1px solid transparent; }
+.btn:active { transform: scale(0.97); }
+.btn-primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent-deep); flex: 1; }
+.btn-ghost { background: transparent; color: var(--accent); border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); }
+@media (hover: hover) and (pointer: fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+.result { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 18px; text-align: center;
+  display: none; opacity: 0; transform: translateY(10px) scale(0.99); transition: opacity .38s var(--ease), transform .38s var(--ease); }
+.result.show { display: block; } .result.in { opacity: 1; transform: none; }
+.score-fig { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 62px; line-height: 1; letter-spacing: -0.03em;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; color: var(--ink);
+  opacity: 0; transform: scale(0.96); transition: opacity .5s var(--ease) .08s, transform .5s var(--ease) .08s; }
+.result.in .score-fig { opacity: 1; transform: none; }
+.score-cap { margin-top: 9px; font-size: 11.5px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; color: var(--muted); }
+.score-sub { margin-top: 12px; font-size: 13px; color: var(--ink-soft); line-height: 1.5; }
+.pro { margin-top: 18px; text-align: left; background: var(--accent); color: var(--on-accent); border-radius: 16px; padding: 18px 18px 16px; }
+.pro .pe { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; opacity: .82; }
+.pro h3 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.02em; line-height: 1.12; margin: 7px 0 8px; }
+.pro p { font-size: 12.5px; line-height: 1.5; opacity: .92; margin-bottom: 14px; }
+.btn-white { background: var(--on-accent); color: var(--accent); border: none; width: 100%; }
+.freestate { margin-top: 13px; font-size: 12px; color: var(--muted); font-weight: 600; }
+
+.reveal { opacity: 0; transform: translateY(14px); transition: opacity .5s var(--ease), transform .5s var(--ease); }
+.reveal.vis { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .reveal, .qcard, .verdict, .result, .score-fig { transition-property: opacity !important; transform: none !important; filter: none !important; }
+  .reveal { opacity: 1 !important; }
+  .btn:active, .theme-btn:active { transform: none; }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <div class="brand">
+      <svg viewBox="0 0 40 40" fill="none" aria-hidden="true">
+        <path d="M27 11.5a11 11 0 1 0 0 17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+        <path d="M13 28 27 12" stroke="var(--accent)" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+        <path d="M14 28.5a11 11 0 0 1 0-17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+      </svg>
+      <div><b>CertAnvil</b> &nbsp;<span class="sub">Sim Lab · Defense in Depth (Net+)</span></div>
+    </div>
+    <button class="theme-btn" id="themeBtn">Dark</button>
+  </div>
+
+  <div class="scn-head reveal" style="transition-delay:.04s">
+    <div class="eyebrow">Network+ · Objective 4.1 · Defense in depth</div>
+    <h1 class="scn-title">One firewall, one flat network</h1>
+    <p class="scn-prose">This office has a stateful firewall at the edge, and behind it everything sits on a single internal network, including the public-facing web server. The perimeter is solid, but there is only one real layer. Find the weakness, then add the layers that should be there.</p>
+    <div class="metstrip">
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/><path d="M12 7v5l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg><span class="timer" id="timer">00:51</span></span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>2 steps · partial credit</span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3l8 4v5c0 4.5-3.5 7.5-8 9-4.5-1.5-8-4.5-8-9V7l8-4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/></svg>Practice mode</span>
+    </div>
+  </div>
+
+  <div class="split">
+
+    <!-- LAYERED DEFENSE DIAGRAM (read-only reference) -->
+    <div class="panel reveal" style="transition-delay:.08s">
+      <div class="panel-head">
+        <span class="lbl">Defense layers · current state</span>
+        <span class="gap">1 layer protecting the core</span>
+      </div>
+      <div class="diagram">
+        <svg viewBox="0 0 560 400" role="img" aria-label="Defense in depth layers, current state">
+          <!-- Layer 1: perimeter (present) -->
+          <rect class="layer l1 fill1" x="18" y="40" width="524" height="344" rx="18"/>
+          <text class="lname on" x="40" y="64">Perimeter</text>
+          <text class="lctrl" x="40" y="80">stateful firewall · present</text>
+          <g class="dev" transform="translate(458,52)"><rect class="box" width="68" height="30" rx="8"/><g class="glyph" transform="translate(8,8)"><path d="M2 1v12M7 1v12M0 4h13M0 9h13"/></g><text class="nm" x="44" y="20">FW-1</text></g>
+
+          <!-- GAP where the DMZ layer should be -->
+          <rect class="gapmark" x="56" y="104" width="448" height="40" rx="12"/>
+          <text class="gaplbl" x="76" y="128">No screened subnet (DMZ) here</text>
+
+          <!-- Layer 2: internal LAN (flat) -->
+          <rect class="layer l2 fill2" x="56" y="160" width="448" height="208" rx="16"/>
+          <text class="lname mut" x="78" y="184">Internal LAN · one flat subnet</text>
+
+          <!-- core: servers + data -->
+          <rect class="core-fill" x="120" y="210" width="320" height="138" rx="14"/>
+          <text class="lname on" x="140" y="234">Servers + data</text>
+
+          <!-- file server (internal, fine) -->
+          <g class="dev" transform="translate(150,256)"><rect class="box" width="116" height="64" rx="11"/><g class="glyph" transform="translate(50,11)"><path d="M0 3h16v10H0zM0 8h16"/></g><text class="nm" x="58" y="46">FS-1 · file</text></g>
+          <!-- public web server (should be in a DMZ) -->
+          <g class="dev exposed" transform="translate(296,256)"><rect class="box" width="116" height="64" rx="11"/><circle class="expdot" cx="104" cy="12" r="5"/><g class="glyph" transform="translate(50,11)"><path d="M8 0a8 8 0 0 1 0 16M8 0a8 8 0 0 0 0 16M0 8h16M3 3h10M3 13h10"/></g><text class="nm" x="58" y="46">WEB-1 · public</text></g>
+        </svg>
+      </div>
+      <div class="legend">
+        <span class="ok"><i></i>layer present</span>
+        <span class="bad"><i></i>missing layer / exposed asset</span>
+      </div>
+    </div>
+
+    <!-- ANSWER RAIL -->
+    <div class="rail reveal" style="transition-delay:.12s">
+      <div class="phase-tabs">
+        <div class="ptab on" id="tab1"><span class="n">1</span>Diagnose</div>
+        <div class="ptab" id="tab2"><span class="n">2</span>Add layers</div>
+      </div>
+
+      <!-- PHASE 1: diagnose -->
+      <div class="qcard" id="phase1">
+        <div class="q">Why does this design fail defense in depth?</div>
+        <div class="slot" data-answer="d2">
+          <div class="sel"><select>
+            <option value="">Select the weakness…</option>
+            <option value="d1">The edge firewall is not powerful enough for the traffic</option>
+            <option value="d2">The public web server sits on the flat internal LAN with no DMZ</option>
+            <option value="d3">The internal LAN is using private IP addresses</option>
+            <option value="d4">There are too many devices on one switch</option>
+          </select></div>
+          <p class="verdict ok">Correct. Past the one firewall, everything is flat and the public server is right next to the data. One breach reaches it all. Defense in depth needs more than a single layer.</p>
+          <p class="verdict no">Look at how many layers stand between the internet and the data. A public server on the flat internal LAN means one control is all that protects everything.</p>
+        </div>
+      </div>
+
+      <!-- PHASE 2: add the layers -->
+      <div class="qcard" id="phase2" style="display:none">
+        <div class="q">Add the layers this network is missing.</div>
+        <div class="slot" data-answer="a1">
+          <label>Where should the public web server live?</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="a1">In a screened subnet (DMZ) between two firewalls</option>
+            <option value="a2">On the internal LAN with the file server</option>
+            <option value="a3">Directly on the edge firewall</option>
+          </select></div>
+          <p class="verdict ok">Right. A DMZ isolates the public server so a compromise does not land on the internal network.</p>
+          <p class="verdict no">Correct answer: <b>a screened subnet (DMZ)</b>, so a hit on the public server stays away from internal data.</p>
+        </div>
+        <div class="slot" data-answer="b1">
+          <label>How should the internal network be built?</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="b1">Segmented into VLANs by role</option>
+            <option value="b2">Kept as one flat subnet for simplicity</option>
+            <option value="b3">Bridged so every port can reach every device</option>
+          </select></div>
+          <p class="verdict ok">Right. Segmentation contains lateral movement, which is a layer of its own.</p>
+          <p class="verdict no">Correct answer: <b>VLAN segmentation</b>. A flat network lets one foothold reach everything.</p>
+        </div>
+        <div class="slot" data-answer="c1">
+          <label>Add a detection layer:</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="c1">IDS/IPS monitoring internal traffic</option>
+            <option value="c2">A second public IP address</option>
+            <option value="c3">A faster internet connection</option>
+          </select></div>
+          <p class="verdict ok">Right. Monitoring catches what the preventive layers miss.</p>
+          <p class="verdict no">Correct answer: <b>IDS/IPS</b>. Detection is the layer that sees an attacker who slips past the rest.</p>
+        </div>
+      </div>
+
+      <div class="actions" id="actions">
+        <button class="btn btn-primary" id="primary">Check answer</button>
+      </div>
+
+      <!-- RESULT -->
+      <div class="result" id="result">
+        <div class="score-fig" id="scoreFig">4/4</div>
+        <div class="score-cap" id="scoreCap">layers correct · 100%</div>
+        <p class="score-sub" id="scoreSub">Well layered. A DMZ for the public server, VLANs inside, and IDS/IPS watching. No single breach reaches the core now.</p>
+
+        <div class="pro">
+          <div class="pe">CertAnvil Pro</div>
+          <h3>Build defense in depth on sight.</h3>
+          <p>Layered design is a pattern you learn by repetition. Pro opens unlimited layered-defense PBQs across Net+ and Sec+, plus timed Exam mode and weak-spot tracking, so spotting a missing layer becomes automatic.</p>
+          <button class="btn btn-white" id="goPro">Go Pro</button>
+        </div>
+
+        <div class="freestate">That was today's free PBQ. The next one unlocks in 22h.</div>
+        <div class="actions" style="margin-top:12px;justify-content:center">
+          <button class="btn btn-ghost" id="again">Review this scenario</button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+const root = document.documentElement, tb = document.getElementById('themeBtn');
+tb.onclick = () => { const d = root.getAttribute('data-theme') === 'dark'; root.setAttribute('data-theme', d ? 'light' : 'dark'); tb.textContent = d ? 'Dark' : 'Light'; };
+requestAnimationFrame(() => document.querySelectorAll('.reveal').forEach(e => e.classList.add('vis')));
+
+let t = 51; const tEl = document.getElementById('timer');
+setInterval(() => { t++; tEl.textContent = String(Math.floor(t/60)).padStart(2,'0') + ':' + String(t%60).padStart(2,'0'); }, 1000);
+
+const primary = document.getElementById('primary');
+const p1 = document.getElementById('phase1'), p2 = document.getElementById('phase2');
+const tab1 = document.getElementById('tab1'), tab2 = document.getElementById('tab2');
+let stage = 'diagnose';
+let tally = { total: 0, correct: 0 };
+
+function gradeSlots(scope){
+  let total = 0, correct = 0;
+  scope.querySelectorAll('.slot').forEach(slot => {
+    total++;
+    const sel = slot.querySelector('select'), ok = sel.value === slot.dataset.answer;
+    if (ok) correct++;
+    slot.classList.add('graded', ok ? 'ok' : 'no');
+    slot.querySelector('.sel').classList.add(ok ? 'correct' : 'wrong');
+    sel.disabled = true;
+    const v = slot.querySelector(ok ? '.verdict.ok' : '.verdict.no');
+    requestAnimationFrame(() => requestAnimationFrame(() => v.classList.add('in')));
+  });
+  return { total, correct };
+}
+function swapPhase(outEl, inEl){
+  outEl.classList.add('leaving');
+  setTimeout(() => {
+    outEl.style.display = 'none'; outEl.classList.remove('leaving');
+    inEl.style.display = 'block'; inEl.classList.add('entering');
+    requestAnimationFrame(() => requestAnimationFrame(() => inEl.classList.remove('entering')));
+  }, 220);
+}
+primary.onclick = () => {
+  if (stage === 'diagnose') {
+    const r = gradeSlots(p1); tally.total += r.total; tally.correct += r.correct;
+    stage = 'diagnosed'; tab1.classList.add('done'); primary.textContent = 'Continue to layers';
+  } else if (stage === 'diagnosed') {
+    stage = 'layers'; tab1.classList.remove('on'); tab2.classList.add('on');
+    primary.textContent = 'Submit design'; swapPhase(p1, p2);
+  } else if (stage === 'layers') {
+    const r = gradeSlots(p2); tally.total += r.total; tally.correct += r.correct;
+    stage = 'done'; tab2.classList.add('done'); primary.textContent = 'See result';
+  } else {
+    document.getElementById('actions').style.display = 'none';
+    p2.classList.add('leaving');
+    const pct = Math.round(tally.correct / tally.total * 100);
+    document.getElementById('scoreFig').textContent = tally.correct + '/' + tally.total;
+    document.getElementById('scoreCap').textContent = 'layers correct · ' + pct + '%';
+    if (pct < 100) document.getElementById('scoreSub').textContent = 'Each layer is scored on its own, so you keep credit for every one you got right. Depth means no single control is the only thing standing.';
+    const res = document.getElementById('result');
+    res.classList.add('show');
+    requestAnimationFrame(() => requestAnimationFrame(() => res.classList.add('in')));
+  }
+};
+document.getElementById('again')?.addEventListener('click', () => location.reload());
+</script>
+</body>
+</html>

--- a/mockups/defense-in-depth-secplus-concept.html
+++ b/mockups/defense-in-depth-secplus-concept.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Defense in Depth PBQ (Sec+) · concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ── CertAnvil MOCKUP STARTER TOKEN BLOCK (verbatim) + --warn from BRAND.md §3 ── */
+:root, [data-theme="dark"] {
+  --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+  --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+  --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+  --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+  --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25); --warn: oklch(0.80 0.130 75);
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-theme="light"] {
+  --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+  --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+  --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+  --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+  --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25); --warn: oklch(0.62 0.14 70);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { background: var(--bg); color: var(--ink); font-family: Inter, system-ui, sans-serif; }
+body { min-height: 100dvh; padding: clamp(14px, 3vw, 32px); -webkit-font-smoothing: antialiased; }
+.wrap { max-width: 1180px; margin: 0 auto; }
+
+.topbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 22px; }
+.brand { display: flex; align-items: center; gap: 11px; }
+.brand svg { width: 30px; height: 30px; }
+.brand b { font-weight: 700; font-size: 15px; letter-spacing: -0.01em; }
+.brand .sub { color: var(--muted); font-size: 12px; font-weight: 600; }
+.theme-btn { font: inherit; font-size: 12px; font-weight: 600; color: var(--ink-soft); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 9px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease); }
+.theme-btn:active { transform: scale(0.97); }
+
+.eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.13em; text-transform: uppercase; color: var(--accent); }
+.scn-head { margin-bottom: 18px; }
+.scn-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: clamp(24px, 3.4vw, 33px);
+  letter-spacing: -0.02em; line-height: 1.05; margin: 7px 0 9px; }
+.scn-prose { color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; max-width: 70ch; }
+.metstrip { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.met { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 600; color: var(--ink-soft);
+  background: var(--surface); border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; }
+.met svg { width: 13px; height: 13px; stroke: var(--accent); }
+.met .timer { font-variant-numeric: tabular-nums; }
+
+.split { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
+@media (max-width: 880px) { .split { grid-template-columns: 1fr; } }
+
+.panel { background: var(--surface); border: 1px solid var(--border); border-radius: 18px; overflow: hidden;
+  box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 18px 40px -22px color-mix(in oklab, var(--ink) 20%, transparent); }
+.panel-head { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 13px 16px; border-bottom: 1px solid var(--border-soft); }
+.panel-head .lbl { font-size: 10.5px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+.panel-head .gap { font-size: 11px; font-weight: 700; color: var(--fail); }
+
+/* ── layered defense diagram (nested frames + missing inner layers) ── */
+.diagram { padding: 12px; }
+.diagram svg { width: 100%; height: auto; display: block; }
+.layer { fill: none; stroke-width: 1.4; }
+.layer.l1 { stroke: color-mix(in oklab, var(--accent) 55%, var(--border)); }
+.layer.fill1 { fill: color-mix(in oklab, var(--accent) 5%, transparent); }
+.lname { font: 800 10.5px Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; }
+.lname.on { fill: var(--accent); } .lname.bad { fill: var(--fail); }
+.lctrl { font: 600 10.5px ui-monospace, Menlo, monospace; fill: var(--ink-soft); }
+.misslayer { fill: color-mix(in oklab, var(--fail) 5%, transparent); stroke: var(--fail); stroke-width: 1.5; stroke-dasharray: 6 5; }
+.misslbl { font: 800 10.5px Inter, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; fill: var(--fail); }
+.misssub { font: 600 9.5px ui-monospace, Menlo, monospace; fill: color-mix(in oklab, var(--fail) 78%, var(--ink-soft)); }
+.core-exposed { fill: color-mix(in oklab, var(--fail) 9%, transparent); stroke: var(--fail); stroke-width: 1.7; }
+.dev .box { fill: var(--surface); stroke: var(--fail); stroke-width: 1.5; }
+.dev .nm { font: 700 10.5px Inter, sans-serif; fill: var(--fail); text-anchor: middle; }
+.dev .glyph { stroke: var(--fail); stroke-width: 1.7; fill: none; }
+.fw .box { fill: var(--surface); stroke: var(--border); stroke-width: 1.2; }
+.fw .nm { font: 700 11px Inter, sans-serif; fill: var(--ink); text-anchor: middle; }
+.fw .glyph { stroke: var(--accent); stroke-width: 1.7; fill: none; }
+.legend { display: flex; gap: 14px; flex-wrap: wrap; padding: 0 16px 14px; font-size: 11px; color: var(--muted); font-weight: 600; }
+.legend i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 6px; vertical-align: -1px; }
+.legend .ok i { background: color-mix(in oklab, var(--accent) 45%, var(--border)); }
+.legend .bad i { background: var(--fail); }
+
+/* ── answer rail (shared) ── */
+.rail { display: grid; gap: 14px; }
+.phase-tabs { display: flex; gap: 7px; }
+.ptab { flex: 1; text-align: center; font-size: 11.5px; font-weight: 700; padding: 9px; border-radius: 9px;
+  border: 1px solid var(--border); background: var(--surface); color: var(--muted);
+  transition: color .2s var(--ease), border-color .2s var(--ease), background-color .2s var(--ease); }
+.ptab.on { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 34%, var(--border)); background: color-mix(in oklab, var(--accent) 9%, transparent); }
+.ptab.done { color: var(--pass); border-color: color-mix(in oklab, var(--pass) 30%, var(--border)); }
+.ptab .n { font-variant-numeric: tabular-nums; opacity: .65; margin-right: 5px; }
+
+.qcard { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 16px;
+  transition: opacity .22s var(--ease), transform .22s var(--ease), filter .22s var(--ease); }
+.qcard.entering { opacity: 0; transform: translateY(8px); filter: blur(2px); }
+.qcard.leaving { opacity: 0; transform: translateY(-6px); filter: blur(2px); }
+.qcard .q { font-size: 14px; font-weight: 650; line-height: 1.4; margin-bottom: 13px; }
+.slot { display: grid; gap: 6px; margin-bottom: 13px; }
+.slot:last-of-type { margin-bottom: 0; }
+.slot label { font-size: 12px; font-weight: 700; color: var(--ink-soft); }
+.sel { position: relative; }
+.sel select { width: 100%; appearance: none; -webkit-appearance: none; font: inherit; font-size: 13.5px; font-weight: 600;
+  color: var(--ink); background: var(--surface-2); border: 1px solid var(--border); border-radius: 10px;
+  padding: 11px 38px 11px 13px; cursor: pointer; transition: border-color .18s var(--ease), box-shadow .18s var(--ease); }
+.sel select:focus { outline: none; border-color: color-mix(in oklab, var(--accent) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent); }
+.sel::after { content: ""; position: absolute; right: 14px; top: 50%; width: 8px; height: 8px; pointer-events: none;
+  border-right: 2px solid var(--muted); border-bottom: 2px solid var(--muted); transform: translateY(-65%) rotate(45deg); }
+.sel.correct select { border-color: color-mix(in oklab, var(--pass) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--pass) 15%, transparent); }
+.sel.wrong select { border-color: color-mix(in oklab, var(--fail) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--fail) 14%, transparent); }
+.verdict { font-size: 11.5px; font-weight: 600; line-height: 1.45; margin-top: 4px; display: none;
+  opacity: 0; transform: translateY(-3px); transition: opacity .25s var(--ease), transform .25s var(--ease); }
+.slot.graded.ok .verdict.ok { display: block; color: var(--pass); }
+.slot.graded.no .verdict.no { display: block; color: var(--fail); }
+.verdict.in { opacity: 1; transform: none; }
+.verdict b { font-family: ui-monospace, Menlo, monospace; font-weight: 700; }
+
+.actions { display: flex; gap: 10px; }
+.btn { font: inherit; font-size: 13.5px; font-weight: 700; border-radius: 11px; padding: 12px 18px; cursor: pointer;
+  transition: transform .15s var(--ease), filter .15s var(--ease); border: 1px solid transparent; }
+.btn:active { transform: scale(0.97); }
+.btn-primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent-deep); flex: 1; }
+.btn-ghost { background: transparent; color: var(--accent); border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); }
+@media (hover: hover) and (pointer: fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+.result { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 18px; text-align: center;
+  display: none; opacity: 0; transform: translateY(10px) scale(0.99); transition: opacity .38s var(--ease), transform .38s var(--ease); }
+.result.show { display: block; } .result.in { opacity: 1; transform: none; }
+.score-fig { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 62px; line-height: 1; letter-spacing: -0.03em;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; color: var(--ink);
+  opacity: 0; transform: scale(0.96); transition: opacity .5s var(--ease) .08s, transform .5s var(--ease) .08s; }
+.result.in .score-fig { opacity: 1; transform: none; }
+.score-cap { margin-top: 9px; font-size: 11.5px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; color: var(--muted); }
+.score-sub { margin-top: 12px; font-size: 13px; color: var(--ink-soft); line-height: 1.5; }
+.pro { margin-top: 18px; text-align: left; background: var(--accent); color: var(--on-accent); border-radius: 16px; padding: 18px 18px 16px; }
+.pro .pe { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; opacity: .82; }
+.pro h3 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.02em; line-height: 1.12; margin: 7px 0 8px; }
+.pro p { font-size: 12.5px; line-height: 1.5; opacity: .92; margin-bottom: 14px; }
+.btn-white { background: var(--on-accent); color: var(--accent); border: none; width: 100%; }
+.freestate { margin-top: 13px; font-size: 12px; color: var(--muted); font-weight: 600; }
+
+.reveal { opacity: 0; transform: translateY(14px); transition: opacity .5s var(--ease), transform .5s var(--ease); }
+.reveal.vis { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .reveal, .qcard, .verdict, .result, .score-fig { transition-property: opacity !important; transform: none !important; filter: none !important; }
+  .reveal { opacity: 1 !important; }
+  .btn:active, .theme-btn:active { transform: none; }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <div class="brand">
+      <svg viewBox="0 0 40 40" fill="none" aria-hidden="true">
+        <path d="M27 11.5a11 11 0 1 0 0 17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+        <path d="M13 28 27 12" stroke="var(--accent)" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+        <path d="M14 28.5a11 11 0 0 1 0-17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+      </svg>
+      <div><b>CertAnvil</b> &nbsp;<span class="sub">Sim Lab · Defense in Depth (Sec+)</span></div>
+    </div>
+    <button class="theme-btn" id="themeBtn">Dark</button>
+  </div>
+
+  <div class="scn-head reveal" style="transition-delay:.04s">
+    <div class="eyebrow">Security+ · Domain 3 · Security architecture</div>
+    <h1 class="scn-title">Strong wall, hollow inside</h1>
+    <p class="scn-prose">A security review of Northwind HQ. There is a capable next-gen firewall at the edge and almost nothing behind it: endpoints are unmanaged, the database stores records in clear text, and one shared admin account opens everything. A single phishing click puts an attacker next to the crown jewels. Name the flaw, then build the inner layers.</p>
+    <div class="metstrip">
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/><path d="M12 7v5l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg><span class="timer" id="timer">01:24</span></span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>2 steps · partial credit</span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3l8 4v5c0 4.5-3.5 7.5-8 9-4.5-1.5-8-4.5-8-9V7l8-4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/></svg>Practice mode</span>
+    </div>
+  </div>
+
+  <div class="split">
+
+    <!-- LAYERED DEFENSE DIAGRAM (read-only) -->
+    <div class="panel reveal" style="transition-delay:.08s">
+      <div class="panel-head">
+        <span class="lbl">Defense layers · current state</span>
+        <span class="gap">3 inner layers missing</span>
+      </div>
+      <div class="diagram">
+        <svg viewBox="0 0 560 432" role="img" aria-label="Defense in depth, strong perimeter with hollow interior">
+          <!-- perimeter (present) -->
+          <rect class="layer l1 fill1" x="16" y="40" width="528" height="376" rx="18"/>
+          <text class="lname on" x="38" y="64">Perimeter</text>
+          <text class="lctrl" x="38" y="80">next-gen firewall · present</text>
+          <g class="fw" transform="translate(462,50)"><rect class="box" width="64" height="30" rx="8"/><g class="glyph" transform="translate(8,8)"><path d="M2 1v12M7 1v12M0 4h13M0 9h13"/></g><text class="nm" x="42" y="20">FW-1</text></g>
+
+          <!-- missing inner layers -->
+          <rect class="misslayer" x="52" y="100" width="456" height="38" rx="11"/>
+          <text class="misslbl" x="72" y="118">Endpoint</text><text class="misssub" x="146" y="124">EDR / hardening — missing</text>
+          <rect class="misslayer" x="52" y="148" width="456" height="38" rx="11"/>
+          <text class="misslbl" x="72" y="166">Data</text><text class="misssub" x="118" y="172">encryption + DLP — missing</text>
+          <rect class="misslayer" x="52" y="196" width="456" height="38" rx="11"/>
+          <text class="misslbl" x="72" y="214">Identity</text><text class="misssub" x="132" y="220">MFA / least privilege — missing</text>
+
+          <!-- exposed core -->
+          <rect class="core-exposed" x="120" y="256" width="320" height="146" rx="14"/>
+          <text class="lname bad" x="142" y="280">Crown-jewel data · exposed</text>
+          <g class="dev" transform="translate(150,298)"><rect class="box" width="118" height="78" rx="11"/><g class="glyph" transform="translate(50,12)"><path d="M0 3c0-1.6 3.6-3 8-3s8 1.4 8 3v10c0 1.6-3.6 3-8 3s-8-1.4-8-3zM0 3c0 1.6 3.6 3 8 3s8-1.4 8-3"/></g><text class="nm" x="59" y="58">DB-1 · records</text></g>
+          <g class="dev" transform="translate(292,298)"><rect class="box" width="118" height="78" rx="11"/><g class="glyph" transform="translate(50,12)"><path d="M6 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6M9 8h7M14 8v3"/></g><text class="nm" x="59" y="58">DC-1 · identity</text></g>
+        </svg>
+      </div>
+      <div class="legend">
+        <span class="ok"><i></i>layer present</span>
+        <span class="bad"><i></i>missing layer / exposed asset</span>
+      </div>
+    </div>
+
+    <!-- ANSWER RAIL -->
+    <div class="rail reveal" style="transition-delay:.12s">
+      <div class="phase-tabs">
+        <div class="ptab on" id="tab1"><span class="n">1</span>Diagnose</div>
+        <div class="ptab" id="tab2"><span class="n">2</span>Build layers</div>
+      </div>
+
+      <!-- PHASE 1: diagnose -->
+      <div class="qcard" id="phase1">
+        <div class="q">What is the core flaw in this architecture?</div>
+        <div class="slot" data-answer="d2">
+          <div class="sel"><select>
+            <option value="">Select the flaw…</option>
+            <option value="d1">The firewall vendor is not on the approved list</option>
+            <option value="d2">It is a hard shell with a soft center: one perimeter, no inner controls</option>
+            <option value="d3">The network uses too many subnets</option>
+            <option value="d4">The database server is running on outdated hardware</option>
+          </select></div>
+          <p class="verdict ok">Correct. Everything rides on one control. Once the perimeter is bypassed, by phishing or an insider, nothing else slows the attacker before the data.</p>
+          <p class="verdict no">Look past the firewall. There are no endpoint, data, or identity controls, so a single bypass reaches the crown jewels unopposed.</p>
+        </div>
+      </div>
+
+      <!-- PHASE 2: build the inner layers -->
+      <div class="qcard" id="phase2" style="display:none">
+        <div class="q">Build the inner layers, and classify one control.</div>
+        <div class="slot" data-answer="a1">
+          <label>Endpoint layer:</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="a1">EDR plus host hardening</option>
+            <option value="a2">A louder antivirus pop-up</option>
+            <option value="a3">Local admin rights for every user</option>
+          </select></div>
+          <p class="verdict ok">Right. EDR and hardening give each host its own line of defense.</p>
+          <p class="verdict no">Correct answer: <b>EDR + host hardening</b>. Each endpoint should defend itself, not rely on the edge.</p>
+        </div>
+        <div class="slot" data-answer="b1">
+          <label>Data layer:</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="b1">Encryption at rest plus DLP</option>
+            <option value="b2">A nightly backup, nothing else</option>
+            <option value="b3">Public read access for convenience</option>
+          </select></div>
+          <p class="verdict ok">Right. Encryption protects the records if they are reached; DLP catches them leaving.</p>
+          <p class="verdict no">Correct answer: <b>encryption at rest + DLP</b>. Protect the data itself, not just the path to it.</p>
+        </div>
+        <div class="slot" data-answer="c1">
+          <label>Identity layer:</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="c1">MFA plus least privilege</option>
+            <option value="c2">One shared admin account</option>
+            <option value="c3">Longer passwords, no other change</option>
+          </select></div>
+          <p class="verdict ok">Right. MFA and least privilege shrink what a stolen credential can do.</p>
+          <p class="verdict no">Correct answer: <b>MFA + least privilege</b>. The shared admin account is a single key to everything.</p>
+        </div>
+        <div class="slot" data-answer="t1">
+          <label>MFA is best classified as which control type?</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="t1">Technical, preventive</option>
+            <option value="t2">Physical, detective</option>
+            <option value="t3">Managerial, corrective</option>
+            <option value="t4">Operational, compensating</option>
+          </select></div>
+          <p class="verdict ok">Right. MFA is enforced by technology (technical) and stops misuse before it happens (preventive).</p>
+          <p class="verdict no">Correct answer: <b>technical, preventive</b>. It is enforced by a system and acts before an event, not after.</p>
+        </div>
+      </div>
+
+      <div class="actions" id="actions">
+        <button class="btn btn-primary" id="primary">Check answer</button>
+      </div>
+
+      <!-- RESULT -->
+      <div class="result" id="result">
+        <div class="score-fig" id="scoreFig">5/5</div>
+        <div class="score-cap" id="scoreCap">correct · 100%</div>
+        <p class="score-sub" id="scoreSub">Real depth. Endpoint, data, and identity now each stand on their own, and you classified the control correctly. The soft center is gone.</p>
+
+        <div class="pro">
+          <div class="pe">CertAnvil Pro</div>
+          <h3>See the soft center instantly.</h3>
+          <p>Architecture questions reward a trained eye. Pro opens unlimited defense-in-depth PBQs across Net+ and Sec+, plus timed Exam mode and weak-spot tracking, so by exam day you spot the missing layer before you finish reading.</p>
+          <button class="btn btn-white" id="goPro">Go Pro</button>
+        </div>
+
+        <div class="freestate">That was today's free PBQ. The next one unlocks in 22h.</div>
+        <div class="actions" style="margin-top:12px;justify-content:center">
+          <button class="btn btn-ghost" id="again">Review this scenario</button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+const root = document.documentElement, tb = document.getElementById('themeBtn');
+tb.onclick = () => { const d = root.getAttribute('data-theme') === 'dark'; root.setAttribute('data-theme', d ? 'light' : 'dark'); tb.textContent = d ? 'Dark' : 'Light'; };
+requestAnimationFrame(() => document.querySelectorAll('.reveal').forEach(e => e.classList.add('vis')));
+
+let t = 84; const tEl = document.getElementById('timer');
+setInterval(() => { t++; tEl.textContent = String(Math.floor(t/60)).padStart(2,'0') + ':' + String(t%60).padStart(2,'0'); }, 1000);
+
+const primary = document.getElementById('primary');
+const p1 = document.getElementById('phase1'), p2 = document.getElementById('phase2');
+const tab1 = document.getElementById('tab1'), tab2 = document.getElementById('tab2');
+let stage = 'diagnose';
+let tally = { total: 0, correct: 0 };
+
+function gradeSlots(scope){
+  let total = 0, correct = 0;
+  scope.querySelectorAll('.slot').forEach(slot => {
+    total++;
+    const sel = slot.querySelector('select'), ok = sel.value === slot.dataset.answer;
+    if (ok) correct++;
+    slot.classList.add('graded', ok ? 'ok' : 'no');
+    slot.querySelector('.sel').classList.add(ok ? 'correct' : 'wrong');
+    sel.disabled = true;
+    const v = slot.querySelector(ok ? '.verdict.ok' : '.verdict.no');
+    requestAnimationFrame(() => requestAnimationFrame(() => v.classList.add('in')));
+  });
+  return { total, correct };
+}
+function swapPhase(outEl, inEl){
+  outEl.classList.add('leaving');
+  setTimeout(() => {
+    outEl.style.display = 'none'; outEl.classList.remove('leaving');
+    inEl.style.display = 'block'; inEl.classList.add('entering');
+    requestAnimationFrame(() => requestAnimationFrame(() => inEl.classList.remove('entering')));
+  }, 220);
+}
+primary.onclick = () => {
+  if (stage === 'diagnose') {
+    const r = gradeSlots(p1); tally.total += r.total; tally.correct += r.correct;
+    stage = 'diagnosed'; tab1.classList.add('done'); primary.textContent = 'Continue to layers';
+  } else if (stage === 'diagnosed') {
+    stage = 'layers'; tab1.classList.remove('on'); tab2.classList.add('on');
+    primary.textContent = 'Submit design'; swapPhase(p1, p2);
+  } else if (stage === 'layers') {
+    const r = gradeSlots(p2); tally.total += r.total; tally.correct += r.correct;
+    stage = 'done'; tab2.classList.add('done'); primary.textContent = 'See result';
+  } else {
+    document.getElementById('actions').style.display = 'none';
+    p2.classList.add('leaving');
+    const pct = Math.round(tally.correct / tally.total * 100);
+    document.getElementById('scoreFig').textContent = tally.correct + '/' + tally.total;
+    document.getElementById('scoreCap').textContent = 'correct · ' + pct + '%';
+    if (pct < 100) document.getElementById('scoreSub').textContent = 'Each layer is scored on its own, so you keep credit for every one you got right. Depth means no single control is the only thing standing.';
+    const res = document.getElementById('result');
+    res.classList.add('show');
+    requestAnimationFrame(() => requestAnimationFrame(() => res.classList.add('in')));
+  }
+};
+document.getElementById('again')?.addEventListener('click', () => location.reload());
+</script>
+</body>
+</html>

--- a/mockups/diagram-pbq-concept.html
+++ b/mockups/diagram-pbq-concept.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Diagram PBQ · concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ── CertAnvil MOCKUP STARTER TOKEN BLOCK (verbatim from brand/mockup-starter-tokens.css) ── */
+:root, [data-theme="dark"] {
+  --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+  --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+  --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+  --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+  --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25);
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-theme="light"] {
+  --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+  --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+  --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+  --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+  --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { background: var(--bg); color: var(--ink); font-family: Inter, system-ui, sans-serif; }
+body { min-height: 100dvh; padding: clamp(14px, 3vw, 32px); -webkit-font-smoothing: antialiased; }
+.wrap { max-width: 1180px; margin: 0 auto; }
+
+/* top chrome */
+.topbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 22px; }
+.brand { display: flex; align-items: center; gap: 11px; }
+.brand svg { width: 30px; height: 30px; }
+.brand b { font-weight: 700; font-size: 15px; letter-spacing: -0.01em; }
+.brand .sub { color: var(--muted); font-size: 12px; font-weight: 600; }
+.theme-btn { font: inherit; font-size: 12px; font-weight: 600; color: var(--ink-soft); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 9px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease); }
+.theme-btn:active { transform: scale(0.97); }
+
+/* scenario header */
+.eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.13em; text-transform: uppercase; color: var(--accent); }
+.scn-head { margin-bottom: 18px; }
+.scn-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: clamp(24px, 3.4vw, 33px);
+  letter-spacing: -0.02em; line-height: 1.05; margin: 7px 0 9px; }
+.scn-prose { color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; max-width: 70ch; }
+.metstrip { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.met { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 600; color: var(--ink-soft);
+  background: var(--surface); border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; }
+.met svg { width: 13px; height: 13px; stroke: var(--accent); }
+.met .timer { font-variant-numeric: tabular-nums; }
+
+/* the decoupled split */
+.split { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
+@media (max-width: 860px) { .split { grid-template-columns: 1fr; } }
+
+/* diagram panel (read-only reference) */
+.panel { background: var(--surface); border: 1px solid var(--border); border-radius: 18px; overflow: hidden;
+  box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 18px 40px -22px color-mix(in oklab, var(--ink) 20%, transparent); }
+.panel-head { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 13px 16px; border-bottom: 1px solid var(--border-soft); }
+.panel-head .lbl { font-size: 10.5px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+.zoomhint { font-size: 11px; color: var(--muted); font-weight: 600; }
+.diagram { padding: 8px; }
+.diagram svg { width: 100%; height: auto; display: block; touch-action: pan-x pan-y pinch-zoom; }
+
+/* diagram primitives */
+.vlan-zone { fill: color-mix(in oklab, var(--accent) 7%, transparent); stroke: color-mix(in oklab, var(--accent) 26%, var(--border)); stroke-width: 1; }
+.vlan-zone.guest { fill: color-mix(in oklab, var(--muted) 9%, transparent); stroke: color-mix(in oklab, var(--muted) 30%, var(--border)); }
+.zone-lbl { font: 800 10.5px Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; fill: var(--muted); }
+.link { stroke: color-mix(in oklab, var(--ink) 34%, transparent); stroke-width: 1.6; fill: none; }
+.node rect { fill: var(--surface-2); stroke: var(--border); stroke-width: 1.2; }
+.node.flag rect.box { stroke: var(--fail); stroke-width: 1.8; }
+.node .name { font: 700 13px Inter, sans-serif; fill: var(--ink); text-anchor: middle; }
+.node .ip { font: 600 11px ui-monospace, Menlo, monospace; fill: var(--ink-soft); text-anchor: middle; }
+.node .glyph { stroke: var(--accent); stroke-width: 1.8; fill: none; }
+.node.flag .glyph { stroke: var(--fail); }
+.flag-dot { fill: var(--fail); }
+.halo { fill: none; stroke: var(--fail); stroke-width: 2; opacity: 0; transform-box: fill-box; transform-origin: center; }
+
+/* read-only given reference */
+.given { margin: 2px 8px 10px; border-top: 1px solid var(--border-soft); padding-top: 11px; display: grid; gap: 9px; }
+.given .row { display: flex; align-items: baseline; gap: 10px; font-size: 12.5px; }
+.given .k { color: var(--muted); font-weight: 700; min-width: 86px; }
+.given .v { font-family: ui-monospace, Menlo, monospace; color: var(--ink); font-size: 12px; }
+.cli { margin: 0 8px 8px; background: color-mix(in oklab, var(--ink) 5%, var(--surface)); border: 1px solid var(--border-soft);
+  border-radius: 11px; padding: 11px 13px; font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; line-height: 1.6; color: var(--ink-soft); }
+.cli .c { color: var(--accent-deep); }
+
+/* answer rail */
+.rail { display: grid; gap: 14px; }
+.phase-tabs { display: flex; gap: 7px; }
+.ptab { flex: 1; text-align: center; font-size: 11.5px; font-weight: 700; padding: 9px; border-radius: 9px;
+  border: 1px solid var(--border); background: var(--surface); color: var(--muted);
+  transition: color .2s var(--ease), border-color .2s var(--ease), background-color .2s var(--ease); }
+.ptab.on { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 34%, var(--border)); background: color-mix(in oklab, var(--accent) 9%, transparent); }
+.ptab.done { color: var(--pass); border-color: color-mix(in oklab, var(--pass) 30%, var(--border)); }
+.ptab .n { font-variant-numeric: tabular-nums; opacity: .65; margin-right: 5px; }
+
+.qcard { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 16px;
+  transition: opacity .22s var(--ease), transform .22s var(--ease), filter .22s var(--ease); }
+.qcard.entering { opacity: 0; transform: translateY(8px); filter: blur(2px); }
+.qcard.leaving { opacity: 0; transform: translateY(-6px); filter: blur(2px); }
+.qcard .q { font-size: 14px; font-weight: 650; line-height: 1.4; margin-bottom: 13px; }
+.slot { display: grid; gap: 6px; margin-bottom: 13px; }
+.slot:last-of-type { margin-bottom: 0; }
+.slot label { font-size: 12px; font-weight: 700; color: var(--ink-soft); display: flex; align-items: center; gap: 7px; }
+.slot label .pin { color: var(--accent); cursor: pointer; font-size: 11px; font-weight: 700; transition: transform .15s var(--ease); }
+.slot label .pin:active { transform: scale(0.95); }
+.sel { position: relative; }
+.sel select { width: 100%; appearance: none; -webkit-appearance: none; font: inherit; font-size: 13.5px; font-weight: 600;
+  color: var(--ink); background: var(--surface-2); border: 1px solid var(--border); border-radius: 10px;
+  padding: 11px 38px 11px 13px; cursor: pointer; transition: border-color .18s var(--ease), box-shadow .18s var(--ease); }
+.sel select:focus { outline: none; border-color: color-mix(in oklab, var(--accent) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent); }
+.sel::after { content: ""; position: absolute; right: 14px; top: 50%; width: 8px; height: 8px; pointer-events: none;
+  border-right: 2px solid var(--muted); border-bottom: 2px solid var(--muted); transform: translateY(-65%) rotate(45deg); }
+.sel.correct select { border-color: color-mix(in oklab, var(--pass) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--pass) 15%, transparent); }
+.sel.wrong select { border-color: color-mix(in oklab, var(--fail) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--fail) 14%, transparent); }
+.verdict { font-size: 11.5px; font-weight: 600; line-height: 1.45; margin-top: 4px; display: none;
+  opacity: 0; transform: translateY(-3px); transition: opacity .25s var(--ease), transform .25s var(--ease); }
+.slot.graded.ok .verdict.ok { display: block; color: var(--pass); }
+.slot.graded.no .verdict.no { display: block; color: var(--fail); }
+.verdict.in { opacity: 1; transform: none; }
+.verdict b { font-family: ui-monospace, Menlo, monospace; font-weight: 700; }
+
+/* primary action */
+.actions { display: flex; gap: 10px; }
+.btn { font: inherit; font-size: 13.5px; font-weight: 700; border-radius: 11px; padding: 12px 18px; cursor: pointer;
+  transition: transform .15s var(--ease), filter .15s var(--ease); border: 1px solid transparent; }
+.btn:active { transform: scale(0.97); }
+.btn-primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent-deep); flex: 1; }
+.btn-ghost { background: transparent; color: var(--accent); border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); }
+@media (hover: hover) and (pointer: fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+/* result */
+.result { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 18px; text-align: center;
+  display: none; opacity: 0; transform: translateY(10px) scale(0.99); transition: opacity .38s var(--ease), transform .38s var(--ease); }
+.result.show { display: block; }
+.result.in { opacity: 1; transform: none; }
+.score-fig { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 62px; line-height: 1; letter-spacing: -0.03em;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; color: var(--ink);
+  opacity: 0; transform: scale(0.96); transition: opacity .5s var(--ease) .08s, transform .5s var(--ease) .08s; }
+.result.in .score-fig { opacity: 1; transform: none; }
+.score-cap { margin-top: 9px; font-size: 11.5px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; color: var(--muted); }
+.score-sub { margin-top: 12px; font-size: 13px; color: var(--ink-soft); line-height: 1.5; }
+
+/* Pro gate (fires at peak-end, after the free daily PBQ) */
+.pro { margin-top: 18px; text-align: left; background: var(--accent); color: var(--on-accent); border-radius: 16px; padding: 18px 18px 16px; }
+.pro .pe { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; opacity: .82; }
+.pro h3 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.02em; line-height: 1.12; margin: 7px 0 8px; }
+.pro p { font-size: 12.5px; line-height: 1.5; opacity: .92; margin-bottom: 14px; }
+.btn-white { background: var(--on-accent); color: var(--accent); border: none; width: 100%; }
+.freestate { margin-top: 13px; font-size: 12px; color: var(--muted); font-weight: 600; }
+
+/* reveal (matches dg-system .reveal entrance) */
+.reveal { opacity: 0; transform: translateY(14px); transition: opacity .5s var(--ease), transform .5s var(--ease); }
+.reveal.vis { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .reveal, .qcard, .verdict, .result, .score-fig { transition-property: opacity !important; transform: none !important; filter: none !important; }
+  .reveal { opacity: 1 !important; }
+  .btn:active, .theme-btn:active, .pin:active { transform: none; }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <div class="brand">
+      <svg viewBox="0 0 40 40" fill="none" aria-hidden="true">
+        <path d="M27 11.5a11 11 0 1 0 0 17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+        <path d="M13 28 27 12" stroke="var(--accent)" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+        <path d="M14 28.5a11 11 0 0 1 0-17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+      </svg>
+      <div><b>CertAnvil</b> &nbsp;<span class="sub">Sim Lab · Diagram PBQ</span></div>
+    </div>
+    <button class="theme-btn" id="themeBtn">Dark</button>
+  </div>
+
+  <div class="scn-head reveal" style="transition-delay:.04s">
+    <div class="eyebrow">Network+ · Objective 2.1 · VLANs &amp; addressing</div>
+    <h1 class="scn-title">The Mercer &amp; Hale branch office</h1>
+    <p class="scn-prose">Two VLANs serve this office: Staff (VLAN 10) and Guest (VLAN 20). A user on the Staff network reports they cannot reach the internal file server or the internet, while everyone else is fine. Inspect the diagram and the device configs, then fix it.</p>
+    <div class="metstrip">
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/><path d="M12 7v5l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg><span class="timer" id="timer">00:42</span></span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>2 steps · partial credit</span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3l8 4v5c0 4.5-3.5 7.5-8 9-4.5-1.5-8-4.5-8-9V7l8-4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/></svg>Practice mode</span>
+    </div>
+  </div>
+
+  <div class="split">
+
+    <!-- DIAGRAM: read-only reference -->
+    <div class="panel reveal" style="transition-delay:.08s">
+      <div class="panel-head">
+        <span class="lbl">Network diagram · reference</span>
+        <span class="zoomhint">pinch / scroll to zoom</span>
+      </div>
+      <div class="diagram">
+        <svg viewBox="0 0 800 500" role="img" aria-label="Office network diagram">
+          <!-- VLAN zones (wide gap between them) -->
+          <rect class="vlan-zone" x="28" y="100" width="344" height="372" rx="16"/>
+          <text class="zone-lbl" x="48" y="130">VLAN 10 · Staff · 192.168.10.0/24</text>
+          <rect class="vlan-zone guest" x="428" y="100" width="344" height="372" rx="16"/>
+          <text class="zone-lbl" x="448" y="130">VLAN 20 · Guest · 192.168.20.0/24</text>
+
+          <!-- links -->
+          <path class="link" d="M400 98 L200 176"/>
+          <path class="link" d="M400 98 L600 176"/>
+          <path class="link" d="M200 238 L116 360"/>
+          <path class="link" d="M200 238 L284 360"/>
+          <path class="link" d="M600 238 L600 360"/>
+
+          <!-- router (gateway), centered above both zones -->
+          <g class="node" transform="translate(324,36)">
+            <rect class="box" width="152" height="62" rx="12"/>
+            <g class="glyph" transform="translate(67,11)"><path d="M1 8h7m-3.5-3.5v7M10 4l5 4-5 4"/></g>
+            <text class="name" x="76" y="42">RTR-1</text>
+            <text class="ip" x="76" y="56">gw .10.1 / .20.1</text>
+          </g>
+
+          <!-- switch staff -->
+          <g class="node" transform="translate(136,176)">
+            <rect class="box" width="128" height="62" rx="12"/>
+            <g class="glyph" transform="translate(55,11)"><path d="M5 3l-5 5 5 5M13 3l5 5-5 5"/></g>
+            <text class="name" x="64" y="42">SW-A</text>
+            <text class="ip" x="64" y="56">access v10</text>
+          </g>
+          <!-- switch guest -->
+          <g class="node" transform="translate(536,176)">
+            <rect class="box" width="128" height="62" rx="12"/>
+            <g class="glyph" transform="translate(55,11)"><path d="M5 3l-5 5 5 5M13 3l5 5-5 5"/></g>
+            <text class="name" x="64" y="42">SW-B</text>
+            <text class="ip" x="64" y="56">access v20</text>
+          </g>
+
+          <!-- file server (staff) -->
+          <g class="node" transform="translate(52,360)">
+            <rect class="box" width="128" height="62" rx="12"/>
+            <g class="glyph" transform="translate(56,11)"><path d="M0 3h16v10H0zM0 8h16"/></g>
+            <text class="name" x="64" y="42">FS-1</text>
+            <text class="ip" x="64" y="56">.10.20</text>
+          </g>
+          <!-- the flagged PC (staff zone, wrong subnet) -->
+          <g class="node flag" id="flagNode" transform="translate(220,360)">
+            <rect class="halo" x="-7" y="-7" width="142" height="76" rx="15"/>
+            <rect class="box" width="128" height="62" rx="12"/>
+            <circle class="flag-dot" cx="116" cy="11" r="5"/>
+            <g class="glyph" transform="translate(56,11)"><path d="M0 3h16v9H0zM5 16h6"/></g>
+            <text class="name" x="64" y="42">PC-2</text>
+            <text class="ip" x="64" y="56">.20.45 ?</text>
+          </g>
+          <!-- guest PC -->
+          <g class="node" transform="translate(536,360)">
+            <rect class="box" width="128" height="62" rx="12"/>
+            <g class="glyph" transform="translate(56,11)"><path d="M0 3h16v9H0zM5 16h6"/></g>
+            <text class="name" x="64" y="42">PC-7</text>
+            <text class="ip" x="64" y="56">.20.31</text>
+          </g>
+        </svg>
+      </div>
+
+      <div class="given">
+        <div class="row"><span class="k">Network ID</span><span class="v">192.168.10.0</span></div>
+        <div class="row"><span class="k">Subnet mask</span><span class="v">255.255.255.0  (/24)</span></div>
+        <div class="row"><span class="k">Staff gateway</span><span class="v">192.168.10.1</span></div>
+      </div>
+      <div class="cli"><span class="c">PC-2&gt;</span> ipconfig<br>&nbsp;&nbsp;IPv4 Address . . : 192.168.<b>20</b>.45<br>&nbsp;&nbsp;Subnet Mask . . : 255.255.255.0<br>&nbsp;&nbsp;Default Gateway : 192.168.<b>20</b>.1<br><span class="c">PC-2&gt;</span> ping 192.168.10.20<br>&nbsp;&nbsp;Request timed out.</div>
+    </div>
+
+    <!-- ANSWER RAIL -->
+    <div class="rail reveal" style="transition-delay:.12s">
+      <div class="phase-tabs">
+        <div class="ptab on" id="tab1"><span class="n">1</span>Diagnose</div>
+        <div class="ptab" id="tab2"><span class="n">2</span>Reconfigure</div>
+      </div>
+
+      <!-- PHASE 1: diagnose -->
+      <div class="qcard" id="phase1">
+        <div class="q">What is wrong with this network?</div>
+        <div class="slot" data-answer="d2">
+          <div class="sel">
+            <select id="dx">
+              <option value="">Select the problem…</option>
+              <option value="d1">The Staff and Guest VLANs are using the same subnet</option>
+              <option value="d2">PC-2 is assigned an IP from the Guest subnet, not its own VLAN</option>
+              <option value="d3">The subnet mask on PC-2 is too small for the host count</option>
+              <option value="d4">RTR-1 is missing a route between the two VLANs</option>
+            </select>
+          </div>
+          <p class="verdict ok">Correct. PC-2 sits in VLAN 10 but holds a 192.168.20.x address and .20.1 gateway, so it is stranded on the Guest subnet.</p>
+          <p class="verdict no">Not quite. Compare PC-2's <b>192.168.20.45</b> against its VLAN 10 subnet <b>192.168.10.0/24</b>.</p>
+        </div>
+      </div>
+
+      <!-- PHASE 2: reconfigure -->
+      <div class="qcard" id="phase2" style="display:none">
+        <div class="q">Fix <b>PC-2</b>'s configuration.</div>
+        <div class="slot" data-answer="a2">
+          <label>IP address <span class="pin" data-pin="PC-2">locate</span></label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="a1">192.168.20.45</option>
+            <option value="a2">192.168.10.45</option>
+            <option value="a3">10.0.10.45</option>
+          </select></div>
+          <p class="verdict ok">Right. A VLAN 10 host needs a 192.168.10.x address.</p>
+          <p class="verdict no">Correct answer: <b>192.168.10.45</b> (inside the VLAN 10 subnet).</p>
+        </div>
+        <div class="slot" data-answer="b1">
+          <label>Subnet mask</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="b1">255.255.255.0</option>
+            <option value="b2">255.255.255.192</option>
+            <option value="b3">255.255.0.0</option>
+          </select></div>
+          <p class="verdict ok">Right. /24 matches the documented subnet.</p>
+          <p class="verdict no">Correct answer: <b>255.255.255.0</b> (the /24 in the given config).</p>
+        </div>
+        <div class="slot" data-answer="c1">
+          <label>Default gateway</label>
+          <div class="sel"><select>
+            <option value="">Choose…</option>
+            <option value="c1">192.168.10.1</option>
+            <option value="c2">192.168.20.1</option>
+            <option value="c3">192.168.1.1</option>
+          </select></div>
+          <p class="verdict ok">Right. The Staff gateway is 192.168.10.1.</p>
+          <p class="verdict no">Correct answer: <b>192.168.10.1</b> (the VLAN 10 gateway).</p>
+        </div>
+      </div>
+
+      <div class="actions" id="actions">
+        <button class="btn btn-primary" id="primary">Check answer</button>
+      </div>
+
+      <!-- RESULT -->
+      <div class="result" id="result">
+        <div class="score-fig" id="scoreFig">4/4</div>
+        <div class="score-cap" id="scoreCap">slots correct · 100%</div>
+        <p class="score-sub" id="scoreSub">Clean fix. You found the host on the wrong subnet and moved it back into VLAN 10.</p>
+
+        <div class="pro">
+          <div class="pe">CertAnvil Pro</div>
+          <h3>Make PBQs muscle memory.</h3>
+          <p>You just worked a live network end to end. Pro opens unlimited PBQs across every cert, plus timed Exam mode and weak-spot tracking, so the most-feared part of the test becomes the part you have drilled most.</p>
+          <button class="btn btn-white" id="goPro">Go Pro</button>
+        </div>
+
+        <div class="freestate" id="freestate">That was today's free PBQ. The next one unlocks in 22h.</div>
+        <div class="actions" style="margin-top:12px;justify-content:center">
+          <button class="btn btn-ghost" id="again">Review this scenario</button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+const root = document.documentElement, tb = document.getElementById('themeBtn');
+tb.onclick = () => { const d = root.getAttribute('data-theme') === 'dark'; root.setAttribute('data-theme', d ? 'light' : 'dark'); tb.textContent = d ? 'Dark' : 'Light'; };
+
+requestAnimationFrame(() => document.querySelectorAll('.reveal').forEach(e => e.classList.add('vis')));
+
+let t = 42; const tEl = document.getElementById('timer');
+setInterval(() => { t++; tEl.textContent = String(Math.floor(t/60)).padStart(2,'0') + ':' + String(t%60).padStart(2,'0'); }, 1000);
+
+const primary = document.getElementById('primary');
+const p1 = document.getElementById('phase1'), p2 = document.getElementById('phase2');
+const tab1 = document.getElementById('tab1'), tab2 = document.getElementById('tab2');
+let stage = 'diagnose';            // diagnose -> diagnosed -> reconfigure -> done
+let tally = { total: 0, correct: 0 };
+
+// grade a phase's slots, ease the verdicts in
+function gradeSlots(scope){
+  let total = 0, correct = 0;
+  scope.querySelectorAll('.slot').forEach(slot => {
+    total++;
+    const sel = slot.querySelector('select'), got = sel.value, want = slot.dataset.answer;
+    const wrap = slot.querySelector('.sel');
+    const ok = got === want;
+    if (ok) correct++;
+    slot.classList.add('graded', ok ? 'ok' : 'no');
+    wrap.classList.add(ok ? 'correct' : 'wrong');
+    sel.disabled = true;
+    const v = slot.querySelector(ok ? '.verdict.ok' : '.verdict.no');
+    requestAnimationFrame(() => requestAnimationFrame(() => v.classList.add('in')));  // ease in after paint
+  });
+  return { total, correct };
+}
+
+// crossfade phase cards (blur-masked, brand ease)
+function swapPhase(outEl, inEl, after){
+  outEl.classList.add('leaving');
+  setTimeout(() => {
+    outEl.style.display = 'none'; outEl.classList.remove('leaving');
+    inEl.style.display = 'block'; inEl.classList.add('entering');
+    requestAnimationFrame(() => requestAnimationFrame(() => { inEl.classList.remove('entering'); after && after(); }));
+  }, 220);
+}
+
+primary.onclick = () => {
+  if (stage === 'diagnose') {
+    const r = gradeSlots(p1); tally.total += r.total; tally.correct += r.correct;
+    stage = 'diagnosed';
+    tab1.classList.add('done');
+    primary.textContent = 'Continue to reconfigure';
+  } else if (stage === 'diagnosed') {
+    stage = 'reconfigure';
+    tab1.classList.remove('on'); tab2.classList.add('on');
+    primary.textContent = 'Submit fix';
+    swapPhase(p1, p2);
+  } else if (stage === 'reconfigure') {
+    const r = gradeSlots(p2); tally.total += r.total; tally.correct += r.correct;
+    stage = 'done';
+    tab2.classList.add('done');
+    primary.textContent = 'See result';
+  } else {
+    document.getElementById('actions').style.display = 'none';
+    p2.classList.add('leaving');
+    const pct = Math.round(tally.correct / tally.total * 100);
+    document.getElementById('scoreFig').textContent = tally.correct + '/' + tally.total;
+    document.getElementById('scoreCap').textContent = 'slots correct · ' + pct + '%';
+    if (pct < 100) document.getElementById('scoreSub').textContent = 'Each slot is scored on its own, so you keep credit for every one you got right.';
+    const res = document.getElementById('result');
+    res.classList.add('show');
+    requestAnimationFrame(() => requestAnimationFrame(() => res.classList.add('in')));
+  }
+};
+
+// "locate on diagram": transform+opacity halo pulse (GPU)
+document.querySelectorAll('[data-pin]').forEach(p => p.onclick = () => {
+  const halo = document.querySelector('#flagNode .halo');
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    halo.animate([{ opacity: 0 }, { opacity: .9 }, { opacity: 0 }], { duration: 600 });
+    return;
+  }
+  halo.animate(
+    [ { opacity: 0, transform: 'scale(0.96)' }, { opacity: .9, transform: 'scale(1.04)' }, { opacity: 0, transform: 'scale(1.12)' } ],
+    { duration: 720, easing: 'cubic-bezier(0.16,1,0.3,1)' }
+  );
+});
+
+document.getElementById('again')?.addEventListener('click', () => location.reload());
+document.getElementById('next')?.addEventListener('click', () => location.reload());
+</script>
+</body>
+</html>

--- a/mockups/incident-response-pbq-concept.html
+++ b/mockups/incident-response-pbq-concept.html
@@ -1,0 +1,470 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Incident Response PBQ · concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ── CertAnvil MOCKUP STARTER TOKEN BLOCK (verbatim) + --warn from BRAND.md §3 ── */
+:root, [data-theme="dark"] {
+  --bg: oklch(0.17 0.008 275); --surface: oklch(0.205 0.009 275); --surface-2: oklch(0.23 0.009 275);
+  --ink: oklch(0.96 0.006 275); --ink-soft: oklch(0.80 0.012 275); --muted: oklch(0.725 0.013 275);
+  --border: oklch(0.32 0.011 275); --border-soft: oklch(0.255 0.010 275);
+  --accent: oklch(0.80 0.155 64); --accent-deep: oklch(0.86 0.135 64); --on-accent: oklch(0.18 0.020 275);
+  --pass: oklch(0.74 0.150 152); --fail: oklch(0.66 0.17 25); --warn: oklch(0.80 0.130 75);
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-theme="light"] {
+  --bg: oklch(0.975 0.007 85); --surface: oklch(0.992 0.004 85); --surface-2: oklch(0.965 0.010 84);
+  --ink: oklch(0.22 0.015 280); --ink-soft: oklch(0.36 0.014 280); --muted: oklch(0.50 0.013 280);
+  --border: oklch(0.86 0.008 85); --border-soft: oklch(0.91 0.006 85);
+  --accent: oklch(0.50 0.155 55); --accent-deep: oklch(0.42 0.150 52); --on-accent: oklch(0.985 0.010 85);
+  --pass: oklch(0.50 0.15 150); --fail: oklch(0.52 0.19 25); --warn: oklch(0.62 0.14 70);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { background: var(--bg); color: var(--ink); font-family: Inter, system-ui, sans-serif; }
+body { min-height: 100dvh; padding: clamp(14px, 3vw, 32px); -webkit-font-smoothing: antialiased; }
+.wrap { max-width: 1180px; margin: 0 auto; }
+
+.topbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 22px; }
+.brand { display: flex; align-items: center; gap: 11px; }
+.brand svg { width: 30px; height: 30px; }
+.brand b { font-weight: 700; font-size: 15px; letter-spacing: -0.01em; }
+.brand .sub { color: var(--muted); font-size: 12px; font-weight: 600; }
+.theme-btn { font: inherit; font-size: 12px; font-weight: 600; color: var(--ink-soft); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 9px; padding: 8px 13px; cursor: pointer; transition: transform .15s var(--ease); }
+.theme-btn:active { transform: scale(0.97); }
+
+.eyebrow { font-size: 10.5px; font-weight: 800; letter-spacing: 0.13em; text-transform: uppercase; color: var(--accent); }
+.scn-head { margin-bottom: 18px; }
+.scn-title { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: clamp(24px, 3.4vw, 33px);
+  letter-spacing: -0.02em; line-height: 1.05; margin: 7px 0 9px; }
+.scn-prose { color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; max-width: 70ch; }
+.metstrip { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.met { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 600; color: var(--ink-soft);
+  background: var(--surface); border: 1px solid var(--border); border-radius: 999px; padding: 6px 12px; }
+.met svg { width: 13px; height: 13px; stroke: var(--accent); }
+.met .timer { font-variant-numeric: tabular-nums; }
+
+.split { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
+@media (max-width: 880px) { .split { grid-template-columns: 1fr; } }
+
+.panel { background: var(--surface); border: 1px solid var(--border); border-radius: 18px; overflow: hidden;
+  box-shadow: 0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent), 0 18px 40px -22px color-mix(in oklab, var(--ink) 20%, transparent); }
+.panel-head { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 13px 16px; border-bottom: 1px solid var(--border-soft); }
+.panel-head .lbl { font-size: 10.5px; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+.panel-head .sev { font-size: 11px; font-weight: 700; color: var(--fail); }
+
+/* ── attack timeline (the signature IR visual) ── */
+.timeline { padding: 16px 16px 6px; display: grid; gap: 0; }
+.stage { display: grid; grid-template-columns: 22px 1fr; gap: 12px; }
+.stage .rail { display: flex; flex-direction: column; align-items: center; }
+.stage .dot { width: 13px; height: 13px; border-radius: 999px; margin-top: 3px; flex: none;
+  background: var(--sev); box-shadow: 0 0 0 4px color-mix(in oklab, var(--sev) 18%, transparent); }
+.stage .line { width: 2px; flex: 1; min-height: 16px; background: color-mix(in oklab, var(--ink) 14%, transparent); margin: 4px 0; }
+.stage:last-child .line { display: none; }
+.stage .body { padding-bottom: 14px; }
+.stage .when { font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--muted); font-weight: 600; }
+.stage .what { font-size: 13.5px; font-weight: 650; margin-top: 2px; }
+.stage .sevtag { display: inline-block; margin-top: 6px; font-size: 10px; font-weight: 800; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--sev); background: color-mix(in oklab, var(--sev) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--sev) 30%, var(--border)); border-radius: 999px; padding: 2px 8px; }
+.sev-low { --sev: var(--muted); } .sev-med { --sev: var(--warn); }
+.sev-high { --sev: color-mix(in oklab, var(--fail) 80%, var(--warn)); } .sev-crit { --sev: var(--fail); }
+
+/* ── network under attack ── */
+.diagram { padding: 6px 8px 8px; border-top: 1px solid var(--border-soft); }
+.diagram svg { width: 100%; height: auto; display: block; }
+.zone-lbl { font: 800 10.5px Inter, sans-serif; letter-spacing: 0.1em; text-transform: uppercase; fill: var(--muted); }
+.boundary { fill: none; stroke: color-mix(in oklab, var(--ink) 16%, var(--border)); stroke-width: 1; stroke-dasharray: 4 4; }
+.node .box { fill: var(--surface-2); stroke: var(--border); stroke-width: 1.2; }
+.node .name { font: 700 12.5px Inter, sans-serif; fill: var(--ink); text-anchor: middle; }
+.node .ip { font: 600 10px ui-monospace, Menlo, monospace; fill: var(--ink-soft); text-anchor: middle; }
+.node .glyph { stroke: var(--accent); stroke-width: 1.8; fill: none; }
+.node.compromised .box { stroke: var(--fail); stroke-width: 2; }
+.node.compromised .name { fill: var(--fail); } .node.compromised .glyph { stroke: var(--fail); }
+.node.affected .box { stroke: var(--warn); stroke-width: 1.8; }
+.node.affected .name { fill: var(--warn); } .node.affected .glyph { stroke: var(--warn); }
+.state-dot.crit { fill: var(--fail); } .state-dot.warn { fill: var(--warn); }
+.link { stroke: color-mix(in oklab, var(--ink) 30%, transparent); stroke-width: 1.6; fill: none; }
+.link.attack { stroke: var(--fail); stroke-width: 2.2; fill: none; stroke-dasharray: 5 6; marker-end: url(#arrow); }
+@media (prefers-reduced-motion: no-preference) { .link.attack { animation: flow 1s linear infinite; } }
+@keyframes flow { to { stroke-dashoffset: -22; } }
+.atk-cap { font: 700 9.5px Inter, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; fill: var(--fail); }
+
+/* ── answer rail (shared with Diagram PBQ) ── */
+.rail { display: grid; gap: 14px; }
+.phase-tabs { display: flex; gap: 7px; }
+.ptab { flex: 1; text-align: center; font-size: 11.5px; font-weight: 700; padding: 9px; border-radius: 9px;
+  border: 1px solid var(--border); background: var(--surface); color: var(--muted);
+  transition: color .2s var(--ease), border-color .2s var(--ease), background-color .2s var(--ease); }
+.ptab.on { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 34%, var(--border)); background: color-mix(in oklab, var(--accent) 9%, transparent); }
+.ptab.done { color: var(--pass); border-color: color-mix(in oklab, var(--pass) 30%, var(--border)); }
+.ptab .n { font-variant-numeric: tabular-nums; opacity: .65; margin-right: 5px; }
+
+.qcard { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 16px;
+  transition: opacity .22s var(--ease), transform .22s var(--ease), filter .22s var(--ease); }
+.qcard.entering { opacity: 0; transform: translateY(8px); filter: blur(2px); }
+.qcard.leaving { opacity: 0; transform: translateY(-6px); filter: blur(2px); }
+.qcard .q { font-size: 14px; font-weight: 650; line-height: 1.4; margin-bottom: 13px; }
+.slot { display: grid; gap: 6px; margin-bottom: 13px; }
+.slot:last-of-type { margin-bottom: 0; }
+.slot label { font-size: 12px; font-weight: 700; color: var(--ink-soft); }
+.sel { position: relative; }
+.sel select { width: 100%; appearance: none; -webkit-appearance: none; font: inherit; font-size: 13.5px; font-weight: 600;
+  color: var(--ink); background: var(--surface-2); border: 1px solid var(--border); border-radius: 10px;
+  padding: 11px 38px 11px 13px; cursor: pointer; transition: border-color .18s var(--ease), box-shadow .18s var(--ease); }
+.sel select:focus { outline: none; border-color: color-mix(in oklab, var(--accent) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent); }
+.sel::after { content: ""; position: absolute; right: 14px; top: 50%; width: 8px; height: 8px; pointer-events: none;
+  border-right: 2px solid var(--muted); border-bottom: 2px solid var(--muted); transform: translateY(-65%) rotate(45deg); }
+.sel.correct select { border-color: color-mix(in oklab, var(--pass) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--pass) 15%, transparent); }
+.sel.wrong select { border-color: color-mix(in oklab, var(--fail) 60%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--fail) 14%, transparent); }
+.verdict { font-size: 11.5px; font-weight: 600; line-height: 1.45; margin-top: 4px; display: none;
+  opacity: 0; transform: translateY(-3px); transition: opacity .25s var(--ease), transform .25s var(--ease); }
+.slot.graded.ok .verdict.ok { display: block; color: var(--pass); }
+.slot.graded.no .verdict.no { display: block; color: var(--fail); }
+.verdict.in { opacity: 1; transform: none; }
+.verdict b { font-family: ui-monospace, Menlo, monospace; font-weight: 700; }
+
+/* ── order interaction (sequence the response) ── */
+.order { display: grid; gap: 9px; }
+.orow { display: grid; grid-template-columns: 26px 1fr auto; align-items: center; gap: 11px;
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: 11px; padding: 11px 12px;
+  transition: border-color .18s var(--ease), box-shadow .18s var(--ease), transform .2s var(--ease); }
+.orow .pos { font-family: ui-monospace, Menlo, monospace; font-weight: 700; font-size: 13px; color: var(--accent); text-align: center; }
+.orow .txt { font-size: 13px; font-weight: 600; line-height: 1.35; }
+.orow .ctrl { display: flex; flex-direction: column; gap: 3px; }
+.orow .ctrl button { width: 26px; height: 20px; border: 1px solid var(--border); background: var(--surface); border-radius: 6px;
+  color: var(--ink-soft); cursor: pointer; display: grid; place-items: center; transition: transform .15s var(--ease); }
+.orow .ctrl button:active { transform: scale(0.92); }
+.orow .ctrl button:disabled { opacity: .35; cursor: default; }
+.orow .ctrl button svg { width: 10px; height: 10px; stroke: currentColor; fill: none; stroke-width: 2.4; }
+.order.graded .orow.ok { border-color: color-mix(in oklab, var(--pass) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--pass) 13%, transparent); }
+.order.graded .orow.no { border-color: color-mix(in oklab, var(--fail) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--fail) 12%, transparent); }
+.order.graded .orow .pos { color: inherit; }
+.order.graded .orow.ok .pos { color: var(--pass); } .order.graded .orow.no .pos { color: var(--fail); }
+
+.actions { display: flex; gap: 10px; }
+.btn { font: inherit; font-size: 13.5px; font-weight: 700; border-radius: 11px; padding: 12px 18px; cursor: pointer;
+  transition: transform .15s var(--ease), filter .15s var(--ease); border: 1px solid transparent; }
+.btn:active { transform: scale(0.97); }
+.btn-primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent-deep); flex: 1; }
+.btn-ghost { background: transparent; color: var(--accent); border-color: color-mix(in oklab, var(--accent) 30%, var(--border)); }
+@media (hover: hover) and (pointer: fine) { .btn-primary:hover { filter: brightness(1.05); } }
+
+.result { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 18px; text-align: center;
+  display: none; opacity: 0; transform: translateY(10px) scale(0.99); transition: opacity .38s var(--ease), transform .38s var(--ease); }
+.result.show { display: block; } .result.in { opacity: 1; transform: none; }
+.score-fig { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 62px; line-height: 1; letter-spacing: -0.03em;
+  font-variant-numeric: lining-nums tabular-nums; font-feature-settings: "lnum","tnum"; color: var(--ink);
+  opacity: 0; transform: scale(0.96); transition: opacity .5s var(--ease) .08s, transform .5s var(--ease) .08s; }
+.result.in .score-fig { opacity: 1; transform: none; }
+.score-cap { margin-top: 9px; font-size: 11.5px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; color: var(--muted); }
+.score-sub { margin-top: 12px; font-size: 13px; color: var(--ink-soft); line-height: 1.5; }
+.pro { margin-top: 18px; text-align: left; background: var(--accent); color: var(--on-accent); border-radius: 16px; padding: 18px 18px 16px; }
+.pro .pe { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; opacity: .82; }
+.pro h3 { font-family: Fraunces, Georgia, serif; font-weight: 600; font-size: 21px; letter-spacing: -0.02em; line-height: 1.12; margin: 7px 0 8px; }
+.pro p { font-size: 12.5px; line-height: 1.5; opacity: .92; margin-bottom: 14px; }
+.btn-white { background: var(--on-accent); color: var(--accent); border: none; width: 100%; }
+.freestate { margin-top: 13px; font-size: 12px; color: var(--muted); font-weight: 600; }
+
+.reveal { opacity: 0; transform: translateY(14px); transition: opacity .5s var(--ease), transform .5s var(--ease); }
+.reveal.vis { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .reveal, .qcard, .verdict, .result, .score-fig, .orow { transition-property: opacity !important; transform: none !important; filter: none !important; }
+  .reveal { opacity: 1 !important; }
+  .btn:active, .theme-btn:active { transform: none; }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <div class="brand">
+      <svg viewBox="0 0 40 40" fill="none" aria-hidden="true">
+        <path d="M27 11.5a11 11 0 1 0 0 17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+        <path d="M13 28 27 12" stroke="var(--accent)" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+        <path d="M14 28.5a11 11 0 0 1 0-17" stroke="var(--accent)" stroke-width="7" stroke-linecap="round"/>
+      </svg>
+      <div><b>CertAnvil</b> &nbsp;<span class="sub">Sim Lab · Incident Response PBQ</span></div>
+    </div>
+    <button class="theme-btn" id="themeBtn">Dark</button>
+  </div>
+
+  <div class="scn-head reveal" style="transition-delay:.04s">
+    <div class="eyebrow">Security+ · Objective 4.8 · Incident response</div>
+    <h1 class="scn-title">Northwind Trading · 10:11 alert</h1>
+    <p class="scn-prose">Your EDR fired a critical alert. A finance workstation ran an unknown executable minutes after a user opened an email attachment, then reached the file server. Read the timeline and the evidence, work out what happened, then sequence the response.</p>
+    <div class="metstrip">
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/><path d="M12 7v5l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg><span class="timer" id="timer">01:08</span></span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>2 steps · partial credit</span>
+      <span class="met"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3l8 4v5c0 4.5-3.5 7.5-8 9-4.5-1.5-8-4.5-8-9V7l8-4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/></svg>Practice mode</span>
+    </div>
+  </div>
+
+  <div class="split">
+
+    <!-- VISUAL REFERENCE: attack timeline + network under attack -->
+    <div class="panel reveal" style="transition-delay:.08s">
+      <div class="panel-head">
+        <span class="lbl">Attack timeline</span>
+        <span class="sev">Severity: critical</span>
+      </div>
+      <div class="timeline">
+        <div class="stage sev-med">
+          <div class="rail"><span class="dot"></span><span class="line"></span></div>
+          <div class="body"><div class="when">09:14</div><div class="what">User on WKS-04 opened the attachment "Invoice_4471.xlsm" and enabled macros.</div><span class="sevtag">Initial access</span></div>
+        </div>
+        <div class="stage sev-high">
+          <div class="rail"><span class="dot"></span><span class="line"></span></div>
+          <div class="body"><div class="when">09:21</div><div class="what">WKS-04 ran an unsigned executable; EDR flagged a known dropper hash.</div><span class="sevtag">Execution</span></div>
+        </div>
+        <div class="stage sev-high">
+          <div class="rail"><span class="dot"></span><span class="line"></span></div>
+          <div class="body"><div class="when">09:48</div><div class="what">WKS-04 opened SMB sessions to SRV-FILE using a finance account.</div><span class="sevtag">Lateral movement</span></div>
+        </div>
+        <div class="stage sev-crit">
+          <div class="rail"><span class="dot"></span></div>
+          <div class="body"><div class="when">10:05</div><div class="what">SRV-FILE began bulk file writes, then a large outbound transfer to an external host (185.x.x.x).</div><span class="sevtag">Impact · exfiltration</span></div>
+        </div>
+      </div>
+
+      <div class="diagram">
+        <svg viewBox="0 0 560 196" role="img" aria-label="Network under attack">
+          <text class="zone-lbl" x="20" y="22">Internal · 10.20.0.0/24</text>
+          <rect class="boundary" x="430" y="44" width="118" height="108" rx="12"/>
+          <text class="zone-lbl" x="448" y="36" fill="var(--fail)">External</text>
+
+          <!-- benign links -->
+          <path class="link" d="M120 96 H210"/>
+          <path class="link" d="M120 96 V150 H120"/>
+          <!-- attack path -->
+          <path class="link attack" d="M120 96 H210"/>
+          <path class="link attack" d="M318 96 H430"/>
+          <text class="atk-cap" x="150" y="84">lateral</text>
+          <text class="atk-cap" x="346" y="84">exfil</text>
+
+          <!-- WKS-04 compromised -->
+          <g class="node compromised" transform="translate(24,72)">
+            <rect class="box" width="96" height="48" rx="11"/>
+            <circle class="state-dot crit" cx="84" cy="10" r="5"/>
+            <g class="glyph" transform="translate(40,9)"><path d="M0 3h16v9H0zM5 16h6"/></g>
+            <text class="name" x="48" y="33">WKS-04</text>
+          </g>
+          <!-- SRV-FILE affected -->
+          <g class="node affected" transform="translate(222,72)">
+            <rect class="box" width="96" height="48" rx="11"/>
+            <circle class="state-dot warn" cx="84" cy="10" r="5"/>
+            <g class="glyph" transform="translate(40,9)"><path d="M0 3h16v10H0zM0 8h16"/></g>
+            <text class="name" x="48" y="33">SRV-FILE</text>
+          </g>
+          <!-- FW-1 gateway -->
+          <g class="node" transform="translate(360,72)">
+            <rect class="box" width="70" height="48" rx="11"/>
+            <g class="glyph" transform="translate(27,9)"><path d="M2 2v12M8 2v12M0 6h16M0 10h16"/></g>
+            <text class="name" x="35" y="33">FW-1</text>
+          </g>
+          <!-- external host -->
+          <g class="node" transform="translate(454,72)">
+            <rect class="box" width="74" height="48" rx="11"/>
+            <g class="glyph" transform="translate(28,9)"><path d="M8 1a6 6 0 0 1 0 12M8 1a6 6 0 0 0 0 12M2 7h12"/></g>
+            <text class="name" x="37" y="33">attacker</text>
+          </g>
+          <!-- WKS-09 clean -->
+          <g class="node" transform="translate(24,138)">
+            <rect class="box" width="96" height="44" rx="11"/>
+            <g class="glyph" transform="translate(40,8)"><path d="M0 3h16v9H0zM5 16h6"/></g>
+            <text class="name" x="48" y="31">WKS-09</text>
+          </g>
+
+          <defs>
+            <marker id="arrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">
+              <path d="M0 0L6 3L0 6z" fill="var(--fail)"/>
+            </marker>
+          </defs>
+        </svg>
+      </div>
+
+      <div class="cli" style="margin:0 8px 8px;background:color-mix(in oklab, var(--ink) 5%, var(--surface));border:1px solid var(--border-soft);border-radius:11px;padding:11px 13px;font-family:ui-monospace,Menlo,monospace;font-size:11px;line-height:1.6;color:var(--ink-soft)">
+        <span style="color:var(--accent-deep)">EDR&gt;</span> alert 09:21 host=WKS-04 sig=Dropper.Win.Agent action=blocked? <b>no</b><br>
+        <span style="color:var(--accent-deep)">EDR&gt;</span> 09:48 WKS-04 -&gt; SRV-FILE smb session user=fin\\jhale<br>
+        <span style="color:var(--accent-deep)">EDR&gt;</span> 10:05 SRV-FILE -&gt; 185.x.x.x bytes_out=<b>2.4GB</b>
+      </div>
+    </div>
+
+    <!-- ANSWER RAIL -->
+    <div class="rail reveal" style="transition-delay:.12s">
+      <div class="phase-tabs">
+        <div class="ptab on" id="tab1"><span class="n">1</span>Triage</div>
+        <div class="ptab" id="tab2"><span class="n">2</span>Respond</div>
+      </div>
+
+      <!-- PHASE 1: triage (configure) -->
+      <div class="qcard" id="phase1">
+        <div class="q">Triage the incident.</div>
+        <div class="slot" data-answer="t1">
+          <label>What kind of incident is this?</label>
+          <div class="sel"><select>
+            <option value="">Classify…</option>
+            <option value="t1">Phishing-delivered ransomware</option>
+            <option value="t2">Distributed denial of service</option>
+            <option value="t3">Insider data theft</option>
+            <option value="t4">Web application compromise</option>
+          </select></div>
+          <p class="verdict ok">Correct. A macro-enabled attachment ran a dropper, then files were encrypted and exfiltrated. That is ransomware, and the exfiltration makes it double extortion.</p>
+          <p class="verdict no">Re-read the timeline: a macro attachment, a dropper, bulk file writes, then a 2.4GB outbound transfer.</p>
+        </div>
+        <div class="slot" data-answer="e1">
+          <label>Where did the attack enter?</label>
+          <div class="sel"><select>
+            <option value="">Pick the entry point…</option>
+            <option value="e1">WKS-04 (the finance workstation)</option>
+            <option value="e2">SRV-FILE</option>
+            <option value="e3">FW-1</option>
+            <option value="e4">WKS-09</option>
+          </select></div>
+          <p class="verdict ok">Right. WKS-04 opened the attachment and ran the dropper first. It is patient zero.</p>
+          <p class="verdict no">Correct answer: <b>WKS-04</b>. It opened the attachment at 09:14, before anything else moved.</p>
+        </div>
+      </div>
+
+      <!-- PHASE 2: respond (order) -->
+      <div class="qcard" id="phase2" style="display:none">
+        <div class="q">Put the response in the right order, then submit.</div>
+        <div class="order" id="orderList">
+          <div class="orow" data-correct="0"><span class="pos">1</span><span class="txt">Restore SRV-FILE from a known-clean backup</span><span class="ctrl"><button class="up" aria-label="Move up"><svg viewBox="0 0 12 12"><path d="M2 8l4-4 4 4"/></svg></button><button class="down" aria-label="Move down"><svg viewBox="0 0 12 12"><path d="M2 4l4 4 4-4"/></svg></button></span></div>
+          <div class="orow" data-correct="1"><span class="pos">2</span><span class="txt">Isolate WKS-04 and SRV-FILE from the network</span><span class="ctrl"><button class="up"><svg viewBox="0 0 12 12"><path d="M2 8l4-4 4 4"/></svg></button><button class="down"><svg viewBox="0 0 12 12"><path d="M2 4l4 4 4-4"/></svg></button></span></div>
+          <div class="orow" data-correct="2"><span class="pos">3</span><span class="txt">Document the timeline and tighten email controls</span><span class="ctrl"><button class="up"><svg viewBox="0 0 12 12"><path d="M2 8l4-4 4 4"/></svg></button><button class="down"><svg viewBox="0 0 12 12"><path d="M2 4l4 4 4-4"/></svg></button></span></div>
+          <div class="orow" data-correct="3"><span class="pos">4</span><span class="txt">Remove the malware and reset the finance credentials</span><span class="ctrl"><button class="up"><svg viewBox="0 0 12 12"><path d="M2 8l4-4 4 4"/></svg></button><button class="down"><svg viewBox="0 0 12 12"><path d="M2 4l4 4 4-4"/></svg></button></span></div>
+        </div>
+        <p style="font-size:11.5px;color:var(--muted);margin-top:10px;font-weight:600">Order them: contain, eradicate, recover, then learn.</p>
+      </div>
+
+      <div class="actions" id="actions">
+        <button class="btn btn-primary" id="primary">Check triage</button>
+      </div>
+
+      <!-- RESULT -->
+      <div class="result" id="result">
+        <div class="score-fig" id="scoreFig">6/6</div>
+        <div class="score-cap" id="scoreCap">steps correct · 100%</div>
+        <p class="score-sub" id="scoreSub">Textbook. You named the incident, found patient zero, and ran containment before eradication and recovery.</p>
+
+        <div class="pro">
+          <div class="pe">CertAnvil Pro</div>
+          <h3>Run the playbook until it's reflex.</h3>
+          <p>Incident response is muscle memory under pressure. Pro opens unlimited IR scenarios plus timed Exam mode and weak-spot tracking, so on test day the order of operations is already automatic.</p>
+          <button class="btn btn-white" id="goPro">Go Pro</button>
+        </div>
+
+        <div class="freestate">That was today's free PBQ. The next one unlocks in 22h.</div>
+        <div class="actions" style="margin-top:12px;justify-content:center">
+          <button class="btn btn-ghost" id="again">Review this scenario</button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+const root = document.documentElement, tb = document.getElementById('themeBtn');
+tb.onclick = () => { const d = root.getAttribute('data-theme') === 'dark'; root.setAttribute('data-theme', d ? 'light' : 'dark'); tb.textContent = d ? 'Dark' : 'Light'; };
+requestAnimationFrame(() => document.querySelectorAll('.reveal').forEach(e => e.classList.add('vis')));
+
+let t = 68; const tEl = document.getElementById('timer');
+setInterval(() => { t++; tEl.textContent = String(Math.floor(t/60)).padStart(2,'0') + ':' + String(t%60).padStart(2,'0'); }, 1000);
+
+const primary = document.getElementById('primary');
+const p1 = document.getElementById('phase1'), p2 = document.getElementById('phase2');
+const tab1 = document.getElementById('tab1'), tab2 = document.getElementById('tab2');
+const orderList = document.getElementById('orderList');
+let stage = 'triage';
+let tally = { total: 0, correct: 0 };
+
+function gradeSlots(scope){
+  let total = 0, correct = 0;
+  scope.querySelectorAll('.slot').forEach(slot => {
+    total++;
+    const sel = slot.querySelector('select'), ok = sel.value === slot.dataset.answer;
+    if (ok) correct++;
+    slot.classList.add('graded', ok ? 'ok' : 'no');
+    slot.querySelector('.sel').classList.add(ok ? 'correct' : 'wrong');
+    sel.disabled = true;
+    const v = slot.querySelector(ok ? '.verdict.ok' : '.verdict.no');
+    requestAnimationFrame(() => requestAnimationFrame(() => v.classList.add('in')));
+  });
+  return { total, correct };
+}
+
+// order interaction: up/down reorder + renumber
+function renumber(){
+  [...orderList.children].forEach((row, i) => {
+    row.querySelector('.pos').textContent = i + 1;
+    row.querySelector('.up').disabled = i === 0;
+    row.querySelector('.down').disabled = i === orderList.children.length - 1;
+  });
+}
+orderList.addEventListener('click', e => {
+  const btn = e.target.closest('button'); if (!btn || stage !== 'respond') return;
+  const row = btn.closest('.orow');
+  if (btn.classList.contains('up') && row.previousElementSibling) orderList.insertBefore(row, row.previousElementSibling);
+  if (btn.classList.contains('down') && row.nextElementSibling) orderList.insertBefore(row.nextElementSibling, row);
+  renumber();
+});
+function gradeOrder(){
+  let total = 0, correct = 0;
+  orderList.classList.add('graded');
+  [...orderList.children].forEach((row, i) => {
+    total++;
+    const ok = Number(row.dataset.correct) === i;
+    if (ok) correct++;
+    row.classList.add(ok ? 'ok' : 'no');
+    row.querySelectorAll('button').forEach(b => b.disabled = true);
+  });
+  return { total, correct };
+}
+
+function swapPhase(outEl, inEl, after){
+  outEl.classList.add('leaving');
+  setTimeout(() => {
+    outEl.style.display = 'none'; outEl.classList.remove('leaving');
+    inEl.style.display = 'block'; inEl.classList.add('entering');
+    requestAnimationFrame(() => requestAnimationFrame(() => { inEl.classList.remove('entering'); after && after(); }));
+  }, 220);
+}
+
+primary.onclick = () => {
+  if (stage === 'triage') {
+    const r = gradeSlots(p1); tally.total += r.total; tally.correct += r.correct;
+    stage = 'triaged'; tab1.classList.add('done'); primary.textContent = 'Continue to response';
+  } else if (stage === 'triaged') {
+    stage = 'respond'; tab1.classList.remove('on'); tab2.classList.add('on');
+    primary.textContent = 'Submit response';
+    swapPhase(p1, p2, renumber);
+  } else if (stage === 'respond') {
+    const r = gradeOrder(); tally.total += r.total; tally.correct += r.correct;
+    stage = 'done'; tab2.classList.add('done'); primary.textContent = 'See result';
+  } else {
+    document.getElementById('actions').style.display = 'none';
+    p2.classList.add('leaving');
+    const pct = Math.round(tally.correct / tally.total * 100);
+    document.getElementById('scoreFig').textContent = tally.correct + '/' + tally.total;
+    document.getElementById('scoreCap').textContent = 'steps correct · ' + pct + '%';
+    if (pct < 100) document.getElementById('scoreSub').textContent = 'Each step is scored on its own, so you keep credit for every one you got right. Order matters: contain before you eradicate.';
+    const res = document.getElementById('result');
+    res.classList.add('show');
+    requestAnimationFrame(() => requestAnimationFrame(() => res.classList.add('in')));
+  }
+};
+
+document.getElementById('again')?.addEventListener('click', () => location.reload());
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certanvil",
-  "version": "7.60.0",
+  "version": "7.61.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.60.0
+   Network+ AI Quiz — styles.css  v7.61.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.60.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.60.0';
+// Service Worker v7.61.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.61.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20924,6 +20924,25 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
     test('reference validation: valid layered reference passes',
       simLabValidateScenario(_scnLy).ok === true);
 
+    // ── Task 10: optional scenario.archetype tag ──
+    // 7. Absent archetype still passes (backward compat — all existing scenarios).
+    var _scnNoArch = _baseScn();
+    test('archetype validation: absent archetype still passes',
+      simLabValidateScenario(_scnNoArch).ok === true);
+
+    // 8. Known archetype passes.
+    var _scnGoodArch = _baseScn();
+    _scnGoodArch.archetype = 'incident';
+    test('archetype validation: known archetype passes',
+      simLabValidateScenario(_scnGoodArch).ok === true);
+
+    // 9. Unknown archetype rejected.
+    var _scnBadArch = _baseScn();
+    _scnBadArch.archetype = 'not-a-real-archetype';
+    var _badArchResult = simLabValidateScenario(_scnBadArch);
+    test('archetype validation: unknown archetype rejected',
+      _badArchResult.ok === false && _badArchResult.errors.some(function (e) { return /archetype/i.test(e); }));
+
     // ── Mount test — vm-sandbox + DOM shim ──
     var elBody            = grab('_el');
     var escBody           = grabLine('_esc');

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -22139,6 +22139,86 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// The 20 consensus-approved Sec+ Incident Response scenarios now live for real
+// in features/sim-lab-seed-secplus.js (window.SIM_LAB_SEED_SECPLUS). This
+// proves every one of them is real, production-ready content: each passes the
+// same pure validator that gates the dev fixture (simLabValidateScenario),
+// extracted from features/sim-lab.js by the same brace-matching approach as
+// .superpowers/sdd/validate-drafts.js (no reimplementation of validator
+// logic). Not a fixture — this is the real bank. Incident scenarios use
+// timeline/network-under-attack refs without a deviceId configure step, so
+// simLabValidateNetworkFidelity does not apply here (mirrors Task 12's
+// diagram-bank test, minus the fidelity check).
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: Sec+ Incident Response seed-bank validation (Task 13) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── Extract the REAL pure validator from features/sim-lab.js, exactly
+    // as .superpowers/sdd/validate-drafts.js does ──
+    var isNonEmptyStrBody   = grab('_isNonEmptyStr');
+    var validatePayloadBody = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody) {
+      test('Sec+ Incident bank: validator helper extraction succeeded', false);
+      results.errors.push('could not extract validator helpers for Task 13 bank test; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+
+    // ── Load the real seed bank: eval features/sim-lab-seed-secplus.js in a
+    // sandbox with `var window = {}` so window.SIM_LAB_SEED_SECPLUS populates ──
+    var seedSrc = read('features/sim-lab-seed-secplus.js');
+    var seedCtx = {};
+    vm.createContext(seedCtx);
+    vm.runInContext('var window = {};\n' + seedSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_SECPLUS;', seedCtx);
+    var seedBank = seedCtx.__seed;
+
+    test('Sec+ Incident bank: window.SIM_LAB_SEED_SECPLUS loaded as an array',
+      Array.isArray(seedBank));
+    if (!Array.isArray(seedBank)) {
+      results.errors.push('could not load window.SIM_LAB_SEED_SECPLUS from features/sim-lab-seed-secplus.js');
+      return;
+    }
+
+    var incidentScenarios = seedBank.filter(function (s) { return s && s.archetype === 'incident'; });
+    test('Sec+ Incident bank: at least 20 incident-archetype scenarios present',
+      incidentScenarios.length >= 20);
+
+    var allValidateOk = true;
+    incidentScenarios.forEach(function (s) {
+      var vr = simLabValidateScenario(s);
+      if (!vr || vr.ok !== true) {
+        allValidateOk = false;
+        results.errors.push('Sec+ Incident bank: ' + (s && s.id) + ' failed simLabValidateScenario: ' + JSON.stringify(vr && vr.errors));
+      }
+    });
+
+    test('Sec+ Incident bank: every incident scenario passes simLabValidateScenario',
+      allValidateOk);
+
+  } catch (err) {
+    test('Sec+ Incident bank: vm smoke test (threw)', false);
+    results.errors.push('Sec+ Incident bank smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20653,6 +20653,172 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── v7.63.x: Sim Lab — configure step renderer (Task 3) ──
+// Structural + behavioral smoke using a minimal DOM shim (same pattern as
+// _renderDiagnosticQuestion). Verifies _slRenderConfigure exists, is wired
+// into simLabRenderStep('configure'), renders one <select> per slot, and
+// calls onChange with the correct response shape on user interaction.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: configure step renderer ──\x1b[0m');
+  try {
+    // js is app.js + dedented feature files (2 spaces stripped per line),
+    // so closing braces are \n} not \n  } — match Task 1/2 grab pattern exactly.
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // Structural: function exists and simLabRenderStep routes to it
+    test('configure renderer: _slRenderConfigure defined',
+      /function _slRenderConfigure\(/.test(js));
+    test('configure renderer: simLabRenderStep routes configure type',
+      /case 'configure'\s*:\s*return _slRenderConfigure\(/.test(js));
+    test('configure renderer: uses .sl-cfg root class',
+      js.includes("'sl-cfg'") || js.includes('"sl-cfg"'));
+    test('configure renderer: uses native <select> element',
+      /createElement\(\s*['"]select['"]\s*\)/.test(js) && js.includes('sl-cfg-select'));
+
+    // Behavioral smoke: extract renderer + helpers into a vm with a DOM shim.
+    // _el/_esc/_slAttr are one-liners so we grab them by line rather than by
+    // brace-depth (the multi-line grab regex overshoots on inline functions).
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var elBody         = grab('_el');       // multi-line: use brace-depth grab
+    var escBody        = grabLine('_esc');  // one-liner: use single-line grab
+    var slAttrBody     = grabLine('_slAttr'); // one-liner: use single-line grab
+    var renderCfgBody  = grab('_slRenderConfigure');
+    var renderStepBody = grab('simLabRenderStep');
+
+    if (!elBody || !escBody || !slAttrBody || !renderCfgBody || !renderStepBody) {
+      test('configure renderer: vm extraction succeeded', false);
+      results.errors.push('could not extract configure renderer helpers; check function names/indenting');
+      return;
+    }
+
+    var vm  = require('vm');
+    // Minimal DOM shim — enough for _el, _esc, createElement('select'), addEventListener, dispatchEvent
+    var makeEl = function (tag) {
+      var attrs = {}, listeners = {}, children = [], cls = '', inner = '', val = '';
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; },
+        set className(v) { cls = v; },
+        get innerHTML() { return inner; },
+        set innerHTML(v) { inner = v; },
+        get value() { return val; },
+        set value(v) { val = v; },
+        selected: false,
+        textContent: '',
+        style: {},
+        _children: children,
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return attrs[k] || null; },
+        appendChild: function (c) { children.push(c); return c; },
+        querySelector: function (sel) {
+          // Simple: find first child matching tag or class
+          for (var i = 0; i < children.length; i++) {
+            var c = children[i];
+            if (!c || !c.tagName) continue;
+            if (sel.toLowerCase() === c.tagName.toLowerCase()) return c;
+            if (c._children) {
+              for (var j = 0; j < c._children.length; j++) {
+                var gc = c._children[j];
+                if (gc && gc.tagName && sel.toLowerCase() === gc.tagName.toLowerCase()) return gc;
+              }
+            }
+          }
+          return null;
+        },
+        querySelectorAll: function (sel) {
+          var hits = [];
+          var search = function (node) {
+            if (!node || !node._children) return;
+            node._children.forEach(function (c) {
+              if (!c || !c.tagName) return;
+              var tag = sel.replace(/^\..*/, '').toUpperCase();
+              if (c.tagName === (tag || c.tagName)) hits.push(c);
+              search(c);
+            });
+          };
+          search(el);
+          return hits;
+        },
+        addEventListener: function (ev, fn) { listeners[ev] = (listeners[ev] || []); listeners[ev].push(fn); },
+        dispatchEvent: function (evObj) {
+          var fns = listeners[evObj.type] || [];
+          fns.forEach(function (fn) { fn(evObj); });
+        },
+        closest: function () { return null; },
+        remove: function () {}
+      };
+      return el;
+    };
+
+    var docShim = {
+      createElement: function (tag) { return makeEl(tag); },
+      createTextNode: function (t) { return { textContent: t, tagName: '#text' }; }
+    };
+    var windowShim = { CSS: null };
+
+    var ctx = { document: docShim, window: windowShim, Object: Object, Array: Array, String: String };
+    vm.createContext(ctx);
+    vm.runInContext(elBody, ctx);
+    vm.runInContext(escBody, ctx);
+    vm.runInContext(slAttrBody, ctx);
+    vm.runInContext(renderCfgBody, ctx);
+    vm.runInContext(renderStepBody, ctx);
+
+    var cfgStep = {
+      id: 's1', type: 'configure', prompt: 'Set the IP mode', explanation: 'e', points: 1,
+      payload: { slots: [
+        { id: 'ip', label: 'IP Mode', options: [{ id: 'a', text: 'Static' }, { id: 'b', text: 'DHCP' }] }
+      ]},
+      answer: { slots: { ip: 'a' } }
+    };
+
+    var captured = null;
+    ctx.cfgStep = cfgStep;
+    ctx.capturedRef = function (r) { captured = r; };
+    vm.runInContext('globalThis.__node = simLabRenderStep(cfgStep, capturedRef);', ctx);
+    var node = ctx.__node;
+
+    // 1. Root element has sl-cfg class
+    test('configure renderer: root has sl-cfg class',
+      node && node.className === 'sl-cfg');
+
+    // 2. One select rendered per slot
+    var selects = (node && node.querySelectorAll('select')) || [];
+    test('configure renderer: renders one select per slot',
+      selects.length === 1);
+
+    // 3. onChange called on mount with empty slots (no pre-selection)
+    test('configure renderer: reports initial state on mount',
+      captured !== null && captured.slots !== undefined);
+
+    // 4. Firing the select's change event updates the response
+    var sel = selects[0];
+    if (sel) {
+      sel.value = 'b';
+      sel.dispatchEvent({ type: 'change' });
+    }
+    test('configure renderer: onChange reports selection after change',
+      captured && captured.slots && captured.slots.ip === 'b');
+
+    // 5. Re-hydration: initial pre-selects the right option
+    var captured2 = null;
+    ctx.capturedRef2 = function (r) { captured2 = r; };
+    vm.runInContext('globalThis.__node2 = simLabRenderStep(cfgStep, capturedRef2, { slots: { ip: "a" } });', ctx);
+    test('configure renderer: re-hydrates from initial response',
+      captured2 && captured2.slots && captured2.slots.ip === 'a');
+
+  } catch (err) {
+    test('configure renderer: vm smoke test (threw)', false);
+    results.errors.push('configure renderer vm smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21405,6 +21405,209 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Sim Lab: layered defense-in-depth reference renderer (Task 8) ──
+// Renderer builds an SVG string mounted via _el('div','sl-layered',svgStr).
+// Same vm-sandbox + DOM-shim pattern as Tasks 6 & 7. Read-only.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: layered defense-in-depth reference renderer (Task 8) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      // De-indented feature source: function closes at \n} (0 spaces, same as Task 6/7)
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // Structural: stub is gone, real markup builder landed
+    test('layered renderer: stub replaced (no sl-ref-stub layered branch)',
+      !/_slRenderRefLayered\(ref\)\s*\{\s*return _el\('div', 'sl-ref-stub', 'layered'\)/.test(js));
+    test('layered renderer: builds an sl-layered element',
+      /sl-layered/.test(js));
+    test('layered renderer: builds sl-layer elements',
+      /sl-layer/.test(js));
+    test('layered renderer: builds sl-misslayer elements',
+      /sl-misslayer/.test(js));
+    test('layered renderer: builds sl-core element',
+      /sl-core/.test(js));
+    test('layered renderer: builds sl-dev elements',
+      /sl-dev/.test(js));
+
+    // ── DEV FIXTURE A — Net+ DID scenario ──
+    // Derived from defense-in-depth-netplus-concept.html:
+    // perimeter present, DMZ/VLAN layer missing, exposed asset in core.
+    var _netFix = {
+      kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter',  control: 'Firewall / IDS', state: 'present' },
+        { id: 'dmz',       label: 'DMZ',         control: 'Proxy / WAF',   state: 'missing' }
+      ],
+      core: {
+        label: 'Internal LAN',
+        assets: [
+          { id: 'web1', label: 'WEB-1', exposed: true },
+          { id: 'db1',  label: 'DB-1',  exposed: false }
+        ]
+      }
+    };
+
+    // ── DEV FIXTURE B — Sec+ DID scenario ──
+    // Derived from defense-in-depth-secplus-concept.html:
+    // perimeter present, 3 inner layers missing, 2 exposed core assets.
+    var _secFix = {
+      kind: 'layered',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter',  state: 'present' },
+        { id: 'endpoint',  label: 'Endpoint',   control: 'EDR / hardening',        state: 'missing' },
+        { id: 'data',      label: 'Data',        control: 'encryption + DLP',       state: 'missing' },
+        { id: 'identity',  label: 'Identity',    control: 'MFA / least privilege',  state: 'missing' }
+      ],
+      core: {
+        label: 'Crown-jewel data',
+        assets: [
+          { id: 'hr',  label: 'HR DB',   exposed: true },
+          { id: 'fin', label: 'FIN SRV', exposed: true }
+        ]
+      }
+    };
+
+    var refLyrBody = grab('_slRenderRefLayered');
+    var elBody     = grab('_el');
+    var escBody    = grabLine('_esc');
+
+    if (!refLyrBody || !elBody || !escBody) {
+      test('layered renderer: vm extraction succeeded', false);
+      results.errors.push('could not extract _slRenderRefLayered / helpers; check names/indenting');
+      return;
+    }
+
+    // Minimal DOM shim (same pattern as Tasks 6 & 7)
+    var htmlEscLyr = function (s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    };
+    var makeElLyr = function (tag) {
+      var attrs = {}, children = [], cls = '', inner = '';
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; },
+        set className(v) { cls = v; },
+        get innerHTML() { return inner; },
+        set innerHTML(v) { inner = v; children = []; },
+        get textContent() { return ''; },
+        set textContent(v) { inner = htmlEscLyr(v); },
+        style: {},
+        get _children() { return children; },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return attrs[k] || null; },
+        appendChild: function (c) { children.push(c); return c; }
+      };
+      return el;
+    };
+    var docShimLyr = { createElement: function (tag) { return makeElLyr(tag); } };
+
+    var lCtx = { document: docShimLyr, window: { CSS: null }, Object: Object, Array: Array, String: String, Math: Math };
+    vm.createContext(lCtx);
+    vm.runInContext(elBody, lCtx);
+    vm.runInContext(escBody, lCtx);
+    vm.runInContext(refLyrBody, lCtx);
+
+    // ── Fixture A (Net+) assertions ──
+    lCtx.fixA = _netFix;
+    var rootA = vm.runInContext('_slRenderRefLayered(fixA);', lCtx);
+
+    test('layered renderer A: returns an sl-layered root',
+      rootA && rootA.className === 'sl-layered');
+
+    var svgA = rootA ? rootA.innerHTML : '';
+
+    // SVG present with viewBox
+    test('layered renderer A: SVG emitted with viewBox',
+      /viewBox="0 0 \d+ \d+"/.test(svgA));
+
+    // One frame rect per layer (2 layers)
+    var layerRectsA = (svgA.match(/class="sl-layer"/g) || []).length;
+    var missRectsA  = (svgA.match(/class="sl-misslayer"/g) || []).length;
+    test('layered renderer A: present layer gets sl-layer rect (1)',  layerRectsA === 1);
+    test('layered renderer A: missing layer gets sl-misslayer rect (1)', missRectsA === 1);
+
+    // Core present
+    test('layered renderer A: core rect rendered',
+      /sl-core/.test(svgA));
+
+    // Exposed asset gets exposed class
+    test('layered renderer A: exposed asset gets exposed class on <g>',
+      /class="sl-dev exposed"/.test(svgA));
+
+    // Labels present and escaped
+    test('layered renderer A: perimeter label rendered',  /Perimeter/.test(svgA));
+    test('layered renderer A: DMZ label rendered',        /DMZ/.test(svgA));
+    test('layered renderer A: core label rendered',       /Internal LAN/.test(svgA));
+    test('layered renderer A: asset label WEB-1 rendered', /WEB-1/.test(svgA));
+
+    // missing tag shown on the missing layer label
+    test('layered renderer A: missing marker on DMZ label',
+      /sl-misslayer-tag/.test(svgA));
+
+    // ── Fixture B (Sec+) assertions — proves data-driven, not hardcoded ──
+    lCtx.fixB = _secFix;
+    var rootB = vm.runInContext('_slRenderRefLayered(fixB);', lCtx);
+
+    test('layered renderer B: returns an sl-layered root',
+      rootB && rootB.className === 'sl-layered');
+
+    var svgB = rootB ? rootB.innerHTML : '';
+
+    // 1 present + 3 missing layers
+    var layerRectsB = (svgB.match(/class="sl-layer"/g) || []).length;
+    var missRectsB  = (svgB.match(/class="sl-misslayer"/g) || []).length;
+    test('layered renderer B: 1 present layer rect',       layerRectsB === 1);
+    test('layered renderer B: 3 missing layer rects',      missRectsB === 3);
+
+    // Core is exposed (both assets exposed → core-exposed class)
+    test('layered renderer B: core-exposed class rendered', /sl-core-exposed/.test(svgB));
+
+    // Both exposed assets get exposed class
+    var expDevsB = (svgB.match(/class="sl-dev exposed"/g) || []).length;
+    test('layered renderer B: 2 exposed asset nodes', expDevsB === 2);
+
+    // Labels from Sec+ fixture
+    test('layered renderer B: Identity label rendered', /Identity/.test(svgB));
+    test('layered renderer B: Crown-jewel data label rendered', /Crown-jewel data/.test(svgB));
+    test('layered renderer B: FIN SRV asset label rendered', /FIN SRV/.test(svgB));
+
+    // viewBox is larger for Sec+ (4 layers) than Net+ (2 layers) — proves scaling
+    var vbA = svgA.match(/viewBox="0 0 (\d+) (\d+)"/);
+    var vbB = svgB.match(/viewBox="0 0 (\d+) (\d+)"/);
+    test('layered renderer: Sec+ (4 layers) viewBox wider than Net+ (2 layers)',
+      vbA && vbB && parseInt(vbB[1], 10) > parseInt(vbA[1], 10));
+    test('layered renderer: Sec+ (4 layers) viewBox taller than Net+ (2 layers)',
+      vbA && vbB && parseInt(vbB[2], 10) > parseInt(vbA[2], 10));
+
+    // XSS: label escaping
+    var xssFix = {
+      kind: 'layered',
+      layers: [{ id: 'x', label: '<script>alert(1)</script>', state: 'present' }],
+      core: { label: '<b>core</b>', assets: [{ id: 'a', label: '<img>', exposed: false }] }
+    };
+    lCtx.xssFix = xssFix;
+    var rootX = vm.runInContext('_slRenderRefLayered(xssFix);', lCtx);
+    var svgX  = rootX ? rootX.innerHTML : '';
+    test('layered renderer: layer label XSS-escaped',
+      !/<script>/.test(svgX) && /&lt;script&gt;/.test(svgX));
+    test('layered renderer: core label XSS-escaped',
+      !/<b>/.test(svgX) && /&lt;b&gt;/.test(svgX));
+
+  } catch (err) {
+    test('layered renderer: vm smoke test (threw)', false);
+    results.errors.push('layered renderer smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21876,6 +21876,42 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
     test('stacked renderer: exposed device gets exposed class',
       /class="sl-dev exposed"/.test(svgSt));
 
+    // ── Perimeter device box (FW-1, WAF-1, ...) — optional, data-driven ──
+    // _stackedFix's perimeter layer has no `device` field, so no .sl-fw
+    // should render (backward-compatible default).
+    test('stacked renderer: no perimeter device configured => no .sl-fw rendered',
+      !/class="sl-fw"/.test(svgSt));
+
+    var _stackedFwFix = {
+      kind: 'layered',
+      layout: 'stacked',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Next-gen firewall', state: 'present', device: { label: 'FW-1' } }
+      ],
+      core: { label: 'Core', assets: [] }
+    };
+    sCtx.fixStackedFw = _stackedFwFix;
+    var rootStFw = vm.runInContext('_slRenderRefLayeredStacked(fixStackedFw);', sCtx);
+    var svgStFw = rootStFw ? rootStFw.innerHTML : '';
+    test('stacked renderer: perimeter device configured => .sl-fw rendered',
+      /class="sl-fw"/.test(svgStFw));
+    test('stacked renderer: .sl-fw contains the escaped device label (FW-1)',
+      /class="sl-fw"[\s\S]*?FW-1/.test(svgStFw));
+
+    var _stackedFwXssFix = {
+      kind: 'layered',
+      layout: 'stacked',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', state: 'present', device: { label: '<script>alert(1)</script>' } }
+      ],
+      core: { label: 'Core', assets: [] }
+    };
+    sCtx.fixStackedFwXss = _stackedFwXssFix;
+    var rootStFwX = vm.runInContext('_slRenderRefLayeredStacked(fixStackedFwXss);', sCtx);
+    var svgStFwX = rootStFwX ? rootStFwX.innerHTML : '';
+    test('stacked renderer: .sl-fw device label is XSS-escaped',
+      !/<script>/.test(svgStFwX) && /&lt;script&gt;/.test(svgStFwX));
+
     // ── Safe-core fixture: no assets exposed => sl-core (not sl-core-exposed) ──
     var _safeCoreFix = {
       kind: 'layered', layout: 'stacked',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21077,6 +21077,110 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Task 9: subnetting/CIDR fidelity validator ──
+// Pure-logic check: given a `network` reference model + a `configure` step,
+// confirm the flagged device is out-of-subnet and the step's correct answer
+// re-homes it in-subnet. No DOM — extract via vm same as other Sim Lab tests.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: network fidelity validator (Task 9) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+    function assert(cond, msg) { test(msg, !!cond); }
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    var ipToIntBody = grab('_ipToInt');
+    var maskToIntBody = grab('_maskToInt');
+    var inSubnetBody = grab('_inSubnet');
+    var resolveSlotBody = grab('_slFidelityResolveSlot');
+    var fidelityBody = grab('simLabValidateNetworkFidelity');
+
+    if (!ipToIntBody || !maskToIntBody || !inSubnetBody || !resolveSlotBody || !fidelityBody) {
+      test('fidelity: vm extraction succeeded', false);
+      results.errors.push('could not extract fidelity validator helpers; check names/indenting');
+      return;
+    }
+
+    var fCtx = {};
+    vm.createContext(fCtx);
+    vm.runInContext(ipToIntBody, fCtx);
+    vm.runInContext(maskToIntBody, fCtx);
+    vm.runInContext(inSubnetBody, fCtx);
+    vm.runInContext(resolveSlotBody, fCtx);
+    vm.runInContext(fidelityBody, fCtx);
+    vm.runInContext('globalThis.__ipToInt = _ipToInt; globalThis.__maskToInt = _maskToInt; ' +
+      'globalThis.__inSubnet = _inSubnet; globalThis.__fidelity = simLabValidateNetworkFidelity;', fCtx);
+    var _ipToInt = fCtx.__ipToInt;
+    var _maskToInt = fCtx.__maskToInt;
+    var _inSubnet = fCtx.__inSubnet;
+    var simLabValidateNetworkFidelity = fCtx.__fidelity;
+
+    // ── helpers ──
+    assert(_ipToInt('192.168.10.1') === (((192 << 24) | (168 << 16) | (10 << 8) | 1) >>> 0), 'ipToInt');
+    assert(_inSubnet('192.168.10.45', '192.168.10.0', '255.255.255.0') === true, 'inSubnet true');
+    assert(_inSubnet('192.168.20.45', '192.168.10.0', '255.255.255.0') === false, 'inSubnet false');
+
+    // ── Task-9 dev fixture ──
+    // Net+ diagram: VLAN 10 (192.168.10.0/24) with PC-1 correctly homed and
+    // PC-2 mis-configured with an out-of-subnet IP (192.168.20.45). The
+    // configure step's correct answer re-homes PC-2 into .10.x with an
+    // in-subnet gateway.
+    //
+    // Slot -> field convention (kept minimal for this validator):
+    //   - The configure step carries a `deviceId` naming which device it
+    //     corrects.
+    //   - Slot ids are literally 'ip' / 'mask' / 'gateway'; each slot's
+    //     correct option (per step.answer.slots[slotId]) is resolved to its
+    //     option `text`, which is the corrected value for that field.
+    var fxNetworkRef = function () {
+      return {
+        kind: 'network',
+        devices: [
+          { id: 'pc1', label: 'PC-1', type: 'pc', zone: 'v10', ip: '192.168.10.10', mask: '255.255.255.0', gateway: '192.168.10.1', x: 10, y: 10 },
+          { id: 'pc2', label: 'PC-2', type: 'pc', zone: 'v10', ip: '192.168.20.45', mask: '255.255.255.0', gateway: '192.168.10.1', x: 40, y: 10 },
+          { id: 'gw1', label: 'Gateway', type: 'router', zone: 'v10', ip: '192.168.10.1', mask: '255.255.255.0', gateway: '192.168.10.1', x: 70, y: 10 }
+        ],
+        links: [{ from: 'pc1', to: 'gw1' }, { from: 'pc2', to: 'gw1' }],
+        given: { networkId: '192.168.10.0', mask: '255.255.255.0' }
+      };
+    };
+    var fxConfigureStep = function () {
+      return {
+        id: 'fix1', type: 'configure', prompt: 'Correct PC-2’s IP configuration',
+        explanation: 'PC-2 was on 192.168.20.0/24 — the wrong VLAN for this zone.', points: 1,
+        deviceId: 'pc2',
+        payload: {
+          slots: [
+            { id: 'ip', label: 'IP Address', options: [{ id: 'ip_bad', text: '192.168.20.45' }, { id: 'ip_good', text: '192.168.10.45' }] },
+            { id: 'mask', label: 'Subnet Mask', options: [{ id: 'm_good', text: '255.255.255.0' }, { id: 'm_bad', text: '255.255.0.0' }] },
+            { id: 'gateway', label: 'Gateway', options: [{ id: 'gw_good', text: '192.168.10.1' }, { id: 'gw_bad', text: '192.168.20.1' }] }
+          ]
+        },
+        answer: { slots: { ip: 'ip_good', mask: 'm_good', gateway: 'gw_good' } }
+      };
+    };
+
+    var _fx = { ref: fxNetworkRef(), step: fxConfigureStep() };
+    var _fxResult = simLabValidateNetworkFidelity(_fx.ref, _fx.step);
+    assert(_fxResult && _fxResult.ok === true, 'Net+ fixture is fidelity-sound');
+
+    // ── Negative case: "correct" answer is itself out-of-subnet ──
+    var _badFx = { ref: fxNetworkRef(), step: fxConfigureStep() };
+    // corrected IP still lands in the wrong subnet (192.168.30.x, not 192.168.10.x)
+    _badFx.step.payload.slots[0].options[1].text = '192.168.30.45';
+    var _badResult = simLabValidateNetworkFidelity(_badFx.ref, _badFx.step);
+    assert(_badResult && _badResult.ok === false, 'rejects a "correct" answer that is itself out-of-subnet');
+    assert(_badResult && Array.isArray(_badResult.errors) && _badResult.errors.length > 0, 'negative case reports errors');
+
+  } catch (err) {
+    test('fidelity validator: vm smoke test (threw)', false);
+    results.errors.push('fidelity validator smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Sim Lab: network reference renderer (Task 6) ──
 // The renderer builds SVG as a STRING mounted via _el('div','sl-net', svg), so
 // assertions run against that string (read from the .sl-net child's innerHTML),

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20529,6 +20529,67 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
     /reduce/.test(wireBody));
 })();
 
+// ── v7.61.x: Sim Lab — configure step type validation (Task 1) ──
+// Behavioral smoke: extract simLabValidateScenario + its helpers into a vm
+// sandbox and prove the configure step contract is enforced correctly.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: configure step type validation ──\x1b[0m');
+  try {
+    // Pull the three helpers out of the (already-dedented) features source.
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var isNonEmptyStrBody = grab('_isNonEmptyStr');
+    var validatePayloadBody = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    // Also need STEP_TYPES — grab the array declaration from the dedented source.
+    var stepTypesDecl = (js.match(/var STEP_TYPES = \[[^\]]*\];/) || [''])[0];
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody || !stepTypesDecl) {
+      test('configure: extraction of sim-lab validation helpers', false);
+      results.errors.push('could not extract sim-lab helpers from js; check dedenting');
+      return;
+    }
+
+    var ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(stepTypesDecl, ctx);
+    vm.runInContext(isNonEmptyStrBody, ctx);
+    vm.runInContext(validatePayloadBody, ctx);
+    vm.runInContext(validateScenarioBody, ctx);
+    vm.runInContext('globalThis.__slValidate = simLabValidateScenario;', ctx);
+    var slValidate = ctx.__slValidate;
+
+    // Canonical valid configure scenario.
+    var cfgStep = {
+      id: 's1', type: 'configure', prompt: 'p', explanation: 'e', points: 1,
+      payload: { slots: [{ id: 'ip', label: 'IP', options: [{ id: 'a', text: 'A' }, { id: 'b', text: 'B' }] }] },
+      answer: { slots: { ip: 'a' } }
+    };
+    var cfgScn = { id: 'c1', cert: 'netplus', scenario: 'prose', estMinutes: 3, steps: [cfgStep] };
+
+    test('configure: valid scenario passes',
+      slValidate(cfgScn).ok === true);
+
+    // answer references an option id that does not exist in the slot.
+    var bad1 = JSON.parse(JSON.stringify(cfgScn));
+    bad1.steps[0].answer.slots.ip = 'zzz';
+    test('configure: rejects unknown option id in answer',
+      slValidate(bad1).ok === false);
+
+    // slot has only 1 option (minimum is 2).
+    var bad2 = JSON.parse(JSON.stringify(cfgScn));
+    bad2.steps[0].payload.slots[0].options.pop();
+    test('configure: rejects slot with fewer than 2 options',
+      slValidate(bad2).ok === false);
+
+  } catch (err) {
+    test('configure: vm smoke test (threw)', false);
+    results.errors.push('configure vm smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21731,6 +21731,311 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Task 11 (PBQ archetypes plan): end-to-end diagram PBQ vertical slice ──
+// Proves reference + configure steps compose through the EXISTING Practice
+// mount path — no new mode code. Mounts a Net+ "diagram" archetype scenario
+// (network reference with one out-of-subnet device + a diagnose configure
+// step + a reconfigure configure×3 step) via _slMountScenario, drives the
+// rendered <select> elements exactly like a real user (Task 3 pattern),
+// then scores the captured responses via simLabScoreScenario (Task 2).
+// Same vm-sandbox + DOM shim as the Task 5 mount test — no shim expansion.
+//
+// *** DEV FIXTURE ONLY — NOT real content. Do not add to any seed bank. ***
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: end-to-end diagram PBQ vertical slice (Task 11) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── Task-11 DEV FIXTURE — Net+ diagram PBQ ──
+    // VLAN 10 (192.168.10.0/24). PC-2 is deliberately mis-configured with an
+    // out-of-subnet IP/mask/gateway (VLAN 20 values). Step 1 (diagnose) asks
+    // which device is misconfigured; step 2 (reconfigure) asks for the
+    // correct IP/mask/gateway to re-home it. Mirrors the Task 9 fixture
+    // shape/convention (deviceId + ip/mask/gateway slot ids) so it also
+    // passes simLabValidateNetworkFidelity.
+    var fx11NetworkRef = function () {
+      return {
+        kind: 'network',
+        devices: [
+          { id: 'pc1', label: 'PC-1', type: 'pc', zone: 'v10', ip: '192.168.10.10', mask: '255.255.255.0', gateway: '192.168.10.1', x: 10, y: 10 },
+          { id: 'pc2', label: 'PC-2', type: 'pc', zone: 'v10', ip: '192.168.20.45', mask: '255.255.255.0', gateway: '192.168.20.1', x: 40, y: 10 },
+          { id: 'gw1', label: 'Gateway', type: 'router', zone: 'v10', ip: '192.168.10.1', mask: '255.255.255.0', gateway: '192.168.10.1', x: 70, y: 10 }
+        ],
+        links: [{ from: 'pc1', to: 'gw1' }, { from: 'pc2', to: 'gw1' }],
+        given: { networkId: '192.168.10.0', mask: '255.255.255.0' }
+      };
+    };
+
+    var fx11DiagnoseStep = function () {
+      return {
+        id: 'diag1', type: 'configure', prompt: 'Which device is misconfigured?', explanation: 'PC-2 is on the wrong VLAN (192.168.20.0/24 instead of .10.0/24).', points: 1,
+        payload: {
+          slots: [
+            { id: 'device', label: 'Misconfigured device', options: [{ id: 'd_pc1', text: 'PC-1' }, { id: 'd_pc2', text: 'PC-2' }, { id: 'd_gw1', text: 'Gateway' }] }
+          ]
+        },
+        answer: { slots: { device: 'd_pc2' } }
+      };
+    };
+
+    var fx11ReconfigureStep = function () {
+      return {
+        id: 'fix1', type: 'configure', prompt: 'Correct PC-2’s IP configuration', explanation: 'PC-2 was on 192.168.20.0/24 — the wrong VLAN for this zone.', points: 1,
+        deviceId: 'pc2',
+        payload: {
+          slots: [
+            { id: 'ip', label: 'IP Address', options: [{ id: 'ip_bad', text: '192.168.20.45' }, { id: 'ip_good', text: '192.168.10.45' }] },
+            { id: 'mask', label: 'Subnet Mask', options: [{ id: 'm_good', text: '255.255.255.0' }, { id: 'm_bad', text: '255.255.0.0' }] },
+            { id: 'gateway', label: 'Gateway', options: [{ id: 'gw_good', text: '192.168.10.1' }, { id: 'gw_bad', text: '192.168.20.1' }] }
+          ]
+        },
+        answer: { slots: { ip: 'ip_good', mask: 'm_good', gateway: 'gw_good' } }
+      };
+    };
+
+    var fx11Scenario = function () {
+      return {
+        id: 'e2e-diagram-1', cert: 'netplus', archetype: 'diagram',
+        scenario: 'A help desk ticket reports PC-2 cannot reach the file server. Diagnose and correct the misconfiguration.',
+        estMinutes: 4,
+        assets: { reference: fx11NetworkRef() },
+        steps: [fx11DiagnoseStep(), fx11ReconfigureStep()]
+      };
+    };
+
+    // ── Sanity: fixture is well-formed per the existing Task 1/9 validators ──
+    var isNonEmptyStrBody   = grabLine('_isNonEmptyStr') || grab('_isNonEmptyStr');
+    var validatePayloadBody = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    var ipToIntBody      = grab('_ipToInt');
+    var maskToIntBody    = grab('_maskToInt');
+    var inSubnetBody     = grab('_inSubnet');
+    var resolveSlotBody  = grab('_slFidelityResolveSlot');
+    var fidelityBody     = grab('simLabValidateNetworkFidelity');
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody ||
+        !ipToIntBody || !maskToIntBody || !inSubnetBody || !resolveSlotBody || !fidelityBody) {
+      test('e2e diagram: validator helper extraction succeeded', false);
+      results.errors.push('could not extract validator helpers for Task 11 e2e test; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext(ipToIntBody, vCtx);
+    vm.runInContext(maskToIntBody, vCtx);
+    vm.runInContext(inSubnetBody, vCtx);
+    vm.runInContext(resolveSlotBody, vCtx);
+    vm.runInContext(fidelityBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario; globalThis.__fidelity = simLabValidateNetworkFidelity;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+    var simLabValidateNetworkFidelity = vCtx.__fidelity;
+
+    var _fxScn = fx11Scenario();
+    var _fxValidate = simLabValidateScenario(_fxScn);
+    test('e2e diagram fixture: passes simLabValidateScenario',
+      _fxValidate && _fxValidate.ok === true);
+    if (!_fxValidate || !_fxValidate.ok) {
+      results.errors.push('Task 11 fixture failed simLabValidateScenario: ' + JSON.stringify(_fxValidate && _fxValidate.errors));
+    }
+
+    var _fxFidelity = simLabValidateNetworkFidelity(fx11NetworkRef(), fx11ReconfigureStep());
+    test('e2e diagram fixture: passes simLabValidateNetworkFidelity',
+      _fxFidelity && _fxFidelity.ok === true);
+    if (!_fxFidelity || !_fxFidelity.ok) {
+      results.errors.push('Task 11 fixture failed simLabValidateNetworkFidelity: ' + JSON.stringify(_fxFidelity && _fxFidelity.errors));
+    }
+
+    // ── Mount via the EXISTING Practice path: _slMountScenario ──
+    // Same DOM shim as the Task 5 mount test (getter-backed _children so it
+    // tracks live children after innerHTML resets), plus addEventListener/
+    // dispatchEvent for the configure renderer's <select> elements (Task 3).
+    var elBody         = grab('_el');
+    var escBody        = grabLine('_esc');
+    var slAttrBody     = grabLine('_slAttr');
+    var renderCfgBody  = grab('_slRenderConfigure');
+    var renderStepBody = grab('simLabRenderStep');
+    var refNetBody     = grab('_slRenderRefNetwork');
+    var refTimeBody    = grab('_slRenderRefTimeline');
+    var refLayBody     = grab('_slRenderRefLayered');
+    var refDispBody    = grab('_slRenderReference');
+    var mountBody      = grab('_slMountScenario');
+    var scoreSlotsBody    = grab('_scoreConfigureSlots');
+    var scoreStepBody     = grab('_scoreStep');
+    var scoreScenarioBody = grab('simLabScoreScenario');
+    var normBody          = grab('_norm');
+    var normalizeMatchBody = grab('_simLabNormalizeMatch');
+    var arrEqBody         = grab('_arrEq');
+    var setEqBody         = grab('_setEq');
+
+    if (!elBody || !escBody || !mountBody || !refDispBody || !refNetBody ||
+        !renderCfgBody || !renderStepBody || !scoreScenarioBody || !scoreSlotsBody || !scoreStepBody) {
+      test('e2e diagram: mount/score vm extraction succeeded', false);
+      results.errors.push('could not extract _slMountScenario/score helpers for Task 11 e2e test; check names/indenting');
+      return;
+    }
+
+    var makeEl = function (tag) {
+      var attrs = {}, listeners = {}, children = [], cls = '', inner = '', val = '';
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; },
+        set className(v) { cls = v; },
+        get innerHTML() { return inner; },
+        set innerHTML(v) { inner = v; children = []; },
+        get value() { return val; },
+        set value(v) { val = v; },
+        selected: false,
+        textContent: '',
+        style: {},
+        get _children() { return children; },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return attrs[k] || null; },
+        appendChild: function (c) { children.push(c); return c; },
+        querySelector: function (sel) {
+          for (var i = 0; i < children.length; i++) {
+            var c = children[i];
+            if (!c || !c.tagName) continue;
+            if (sel.toLowerCase() === c.tagName.toLowerCase()) return c;
+            if (c._children) {
+              for (var j = 0; j < c._children.length; j++) {
+                var gc = c._children[j];
+                if (gc && gc.tagName && sel.toLowerCase() === gc.tagName.toLowerCase()) return gc;
+              }
+            }
+          }
+          return null;
+        },
+        querySelectorAll: function (sel) {
+          var hits = [];
+          var search = function (node) {
+            if (!node || !node._children) return;
+            node._children.forEach(function (c) {
+              if (!c || !c.tagName) return;
+              var tag = sel.replace(/^\..*/, '').toUpperCase();
+              if (c.tagName === (tag || c.tagName)) hits.push(c);
+              search(c);
+            });
+          };
+          search(el);
+          return hits;
+        },
+        addEventListener: function (ev, fn) { listeners[ev] = (listeners[ev] || []); listeners[ev].push(fn); },
+        dispatchEvent: function (evObj) { var fns = listeners[evObj.type] || []; fns.forEach(function (fn) { fn(evObj); }); },
+        closest: function () { return null; },
+        remove: function () {}
+      };
+      return el;
+    };
+
+    var docShim = {
+      createElement: function (tag) { return makeEl(tag); },
+      createTextNode: function (t) { return { textContent: t, tagName: '#text' }; }
+    };
+    var windowShim = { CSS: null };
+
+    var mCtx = { document: docShim, window: windowShim, Object: Object, Array: Array, String: String, JSON: JSON };
+    vm.createContext(mCtx);
+    vm.runInContext(elBody, mCtx);
+    vm.runInContext(escBody, mCtx);
+    vm.runInContext(slAttrBody, mCtx);
+    vm.runInContext(renderCfgBody, mCtx);
+    vm.runInContext(renderStepBody, mCtx);
+    vm.runInContext(refNetBody, mCtx);
+    if (refTimeBody) vm.runInContext(refTimeBody, mCtx);
+    if (refLayBody) vm.runInContext(refLayBody, mCtx);
+    vm.runInContext(refDispBody, mCtx);
+    vm.runInContext(mountBody, mCtx);
+    vm.runInContext(normBody, mCtx);
+    vm.runInContext(normalizeMatchBody, mCtx);
+    vm.runInContext(arrEqBody, mCtx);
+    vm.runInContext(setEqBody, mCtx);
+    vm.runInContext(scoreSlotsBody, mCtx);
+    vm.runInContext(scoreStepBody, mCtx);
+    vm.runInContext(scoreScenarioBody, mCtx);
+
+    var host = makeEl('div');
+    mCtx.host = host;
+    mCtx.e2eScn = fx11Scenario();
+    var e2eResult = null;
+    mCtx.e2eOnSubmit = function (r) { e2eResult = r; };
+    vm.runInContext('globalThis.__e2eOpts = { onSubmit: e2eOnSubmit }; _slMountScenario(host, e2eScn, __e2eOpts);', mCtx);
+
+    // wrap._children layout: [sl-scn-prose, sl-ref, ...sl-step wraps, submit]
+    var wrap = host._children[0];
+    var refPanelFound = wrap && wrap._children.some(function (c) { return c && c.className === 'sl-ref'; });
+    test('e2e diagram: mounted DOM contains a .sl-ref reference panel',
+      refPanelFound === true);
+
+    var allSelects = (wrap && wrap.querySelectorAll('select')) || [];
+    // 1 slot (diagnose) + 3 slots (reconfigure) = 4 selects total
+    test('e2e diagram: mounted DOM contains the configure <select> elements',
+      allSelects.length === 4);
+
+    // Drive every select to its correct option (Task 3 pattern: set .value,
+    // dispatch a 'change' event) so the captured responses are all correct.
+    var correctBySlot = { device: 'd_pc2', ip: 'ip_good', mask: 'm_good', gateway: 'gw_good' };
+    allSelects.forEach(function (sel) {
+      var slotId = sel.getAttribute('data-slot');
+      var correctVal = correctBySlot[slotId];
+      if (correctVal) {
+        sel.value = correctVal;
+        sel.dispatchEvent({ type: 'change' });
+      }
+    });
+
+    // Submit via the same window.__slActiveSubmit path _slMountScenario wires
+    // up (mirrors the real "Submit answers" button's data-action handler).
+    vm.runInContext('window.__slActiveSubmit();', mCtx);
+
+    test('e2e diagram: simLabScoreScenario reports correct === total after correct answers',
+      e2eResult && e2eResult.correct === e2eResult.total && e2eResult.total === 4);
+
+    // Negative control: an all-wrong pass must NOT score correct === total,
+    // proving the assertion above isn't vacuously true.
+    var host2 = makeEl('div');
+    mCtx.host2 = host2;
+    mCtx.e2eScn2 = fx11Scenario();
+    var e2eResult2 = null;
+    mCtx.e2eOnSubmit2 = function (r) { e2eResult2 = r; };
+    vm.runInContext('globalThis.__e2eOpts2 = { onSubmit: e2eOnSubmit2 }; _slMountScenario(host2, e2eScn2, __e2eOpts2);', mCtx);
+    var wrap2 = host2._children[0];
+    var allSelects2 = (wrap2 && wrap2.querySelectorAll('select')) || [];
+    var wrongBySlot = { device: 'd_pc1', ip: 'ip_bad', mask: 'm_bad', gateway: 'gw_bad' };
+    allSelects2.forEach(function (sel) {
+      var slotId = sel.getAttribute('data-slot');
+      var wrongVal = wrongBySlot[slotId];
+      if (wrongVal) {
+        sel.value = wrongVal;
+        sel.dispatchEvent({ type: 'change' });
+      }
+    });
+    vm.runInContext('window.__slActiveSubmit();', mCtx);
+    test('e2e diagram: negative control (wrong answers) does not score correct === total',
+      !(e2eResult2 && e2eResult2.correct === e2eResult2.total));
+
+  } catch (err) {
+    test('e2e diagram vertical slice: vm smoke test (threw)', false);
+    results.errors.push('e2e diagram vertical slice smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21259,6 +21259,152 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Sim Lab: timeline reference renderer (Task 7) ──
+// The renderer builds HTML as a STRING mounted via _el('div','sl-timeline', str),
+// so assertions run against innerHTML strings. Same vm-sandbox + DOM-shim pattern
+// as the Task 6 network renderer. Read-only: no listeners.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: timeline reference renderer (Task 7) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // Structural: stub is gone, real markup builder landed
+    test('tl renderer: stub replaced (no sl-ref-stub timeline branch)',
+      !/_slRenderRefTimeline\(ref\)\s*\{\s*return _el\('div', 'sl-ref-stub', 'timeline'\)/.test(js));
+    test('tl renderer: builds an sl-timeline element',
+      /sl-timeline/.test(js));
+    test('tl renderer: builds sl-stage elements',
+      /sl-stage/.test(js));
+    test('tl renderer: builds sl-dot elements',
+      /sl-dot/.test(js));
+    test('tl renderer: builds sl-sevtag elements',
+      /sl-sevtag/.test(js));
+
+    // ── DEV FIXTURE — IR scenario (4 stages, mixed severities, derived from
+    // mockups/incident-response-pbq-concept.html). LABELED dev fixture: Task 7.
+    var _tlFix = {
+      kind: 'timeline',
+      stages: [
+        { id: 's1', icon: '!', label: 'User on WKS-04 opened the attachment "Invoice_4471.xlsm" and enabled macros.', time: '09:14', severity: 'med' },
+        { id: 's2', icon: '!', label: 'WKS-04 ran an unsigned executable; EDR flagged a known dropper hash.', time: '09:21', severity: 'high' },
+        { id: 's3', icon: '!', label: 'WKS-04 opened SMB sessions to SRV-FILE using a finance account.', time: '09:48', severity: 'high' },
+        { id: 's4', icon: '!', label: 'SRV-FILE began bulk file writes, then a large outbound transfer to an external host (185.x.x.x).', time: '10:05', severity: 'crit' }
+      ]
+    };
+
+    var refTlBody = grab('_slRenderRefTimeline');
+    var elBody    = grab('_el');
+    var escBody   = grabLine('_esc');
+
+    if (!refTlBody || !elBody || !escBody) {
+      test('tl renderer: vm extraction succeeded', false);
+      results.errors.push('could not extract _slRenderRefTimeline / helpers; check names/indenting');
+      return;
+    }
+
+    // Minimal DOM shim — identical to Task 6 network renderer pattern.
+    // _el needs createElement + className/innerHTML/appendChild.
+    // _esc() does `d.textContent = s; return d.innerHTML;` so the textContent
+    // setter must populate innerHTML with HTML-escaped text for escaping to work.
+    var htmlEscTl = function (s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    };
+    var makeElTl = function (tag) {
+      var attrs = {}, children = [], cls = '', inner = '';
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; },
+        set className(v) { cls = v; },
+        get innerHTML() { return inner; },
+        set innerHTML(v) { inner = v; children = []; },
+        get textContent() { return ''; },
+        set textContent(v) { inner = htmlEscTl(v); },
+        style: {},
+        get _children() { return children; },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return attrs[k] || null; },
+        appendChild: function (c) { children.push(c); return c; }
+      };
+      return el;
+    };
+    var docShimTl = { createElement: function (tag) { return makeElTl(tag); } };
+
+    var tCtx = { document: docShimTl, window: { CSS: null }, Object: Object, Array: Array, String: String };
+    vm.createContext(tCtx);
+    vm.runInContext(elBody, tCtx);
+    vm.runInContext(escBody, tCtx);
+    vm.runInContext(refTlBody, tCtx);
+    tCtx.fix = _tlFix;
+    var rootEl = vm.runInContext('_slRenderRefTimeline(fix);', tCtx);
+
+    // Root is an sl-timeline container. The renderer uses _el('div','sl-timeline',markupStr)
+    // which sets innerHTML to the markup string — stages live in innerHTML, not _children.
+    test('tl renderer: returns an sl-timeline root', rootEl && rootEl.className === 'sl-timeline');
+
+    var markup = rootEl ? rootEl.innerHTML : '';
+
+    // Count stage divs by matching the class attribute opener
+    var stageCount = (markup.match(/class="sl-stage /g) || []).length;
+    test('tl renderer: one .sl-stage per stage entry (4)', stageCount === 4);
+
+    // Each severity class appears at the right index
+    // The stages are emitted in order; check the markup has each sev class
+    test('tl renderer: sev-med class present (stage 1)', /sev-med/.test(markup));
+    test('tl renderer: sev-high class present (stages 2+3)', /sev-high/.test(markup));
+    test('tl renderer: sev-crit class present (stage 4)', /sev-crit/.test(markup));
+
+    // Last stage has no .sl-line.  Split on </div> boundaries to isolate the last stage.
+    // The last stage div (sev-crit) appears last in markup; verify sl-line is absent in it.
+    var lastStagePart = markup.slice(markup.lastIndexOf('sev-crit'));
+    test('tl renderer: last stage has no .sl-line', !/sl-line/.test(lastStagePart));
+
+    // Earlier stages DO have an sl-line — first stage (sev-med) contains sl-line
+    var firstStagePart = markup.slice(markup.indexOf('sev-med'));
+    test('tl renderer: non-last stage has .sl-line', /sl-line/.test(firstStagePart));
+
+    // Labels escaped and present
+    test('tl renderer: labels present (SMB sessions text found)', /SMB sessions/.test(markup));
+    test('tl renderer: labels present (185\.x\.x\.x text found)', /185\.x\.x\.x/.test(markup));
+
+    // Time values present
+    test('tl renderer: time values rendered (09:14 present)', /09:14/.test(markup));
+    test('tl renderer: time values rendered (10:05 present)', /10:05/.test(markup));
+
+    // sevtag elements present
+    test('tl renderer: sevtag elements present in markup', /sl-sevtag/.test(markup));
+
+    // Stage with no time field — graceful render (no crash, no sl-when element)
+    var _tlNoTime = {
+      kind: 'timeline',
+      stages: [
+        { id: 'x1', icon: '!', label: 'Alert fired.', severity: 'low' },
+        { id: 'x2', icon: '!', label: 'Analyst investigated.', severity: 'high' }
+      ]
+    };
+    tCtx.fix2 = _tlNoTime;
+    var rootEl2 = vm.runInContext('_slRenderRefTimeline(fix2);', tCtx);
+    var markup2 = rootEl2 ? rootEl2.innerHTML : '';
+    var stageCount2 = (markup2.match(/class="sl-stage /g) || []).length;
+    test('tl renderer: renders without time field (2 stages)', stageCount2 === 2);
+    test('tl renderer: first stage of no-time fix gets sev-low', /sev-low/.test(markup2));
+    test('tl renderer: no sl-when rendered when time is absent', !/sl-when/.test(markup2));
+
+  } catch (err) {
+    test('tl renderer: vm smoke test (threw)', false);
+    results.errors.push('timeline renderer smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20924,6 +20924,25 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
     test('reference validation: valid layered reference passes',
       simLabValidateScenario(_scnLy).ok === true);
 
+    // 6b. layout:'stacked' layered scenario validates (stacked-bands layout)
+    var _scnStacked = _baseScn();
+    _scnStacked.assets = { reference: { kind: 'layered', layout: 'stacked', layers: [{ id: 'l1', label: 'Perimeter', state: 'present' }], core: { label: 'Core', assets: [] } } };
+    test('reference validation: layout:"stacked" layered reference passes',
+      simLabValidateScenario(_scnStacked).ok === true);
+
+    // 6c. layout:'nested' is also explicitly valid (not just absent)
+    var _scnNested = _baseScn();
+    _scnNested.assets = { reference: { kind: 'layered', layout: 'nested', layers: [{ id: 'l1', label: 'Perimeter', state: 'present' }], core: { label: 'Core', assets: [] } } };
+    test('reference validation: layout:"nested" layered reference passes',
+      simLabValidateScenario(_scnNested).ok === true);
+
+    // 6d. Invalid layout value rejected
+    var _scnBadLayout = _baseScn();
+    _scnBadLayout.assets = { reference: { kind: 'layered', layout: 'sideways', layers: [{ id: 'l1', label: 'Perimeter', state: 'present' }], core: { label: 'Core', assets: [] } } };
+    var _badLayoutResult = simLabValidateScenario(_scnBadLayout);
+    test('reference validation: invalid layout value rejected',
+      _badLayoutResult.ok === false && _badLayoutResult.errors.some(function (e) { return /layout/i.test(e); }));
+
     // ── Task 10: optional scenario.archetype tag ──
     // 7. Absent archetype still passes (backward compat — all existing scenarios).
     var _scnNoArch = _baseScn();
@@ -21728,6 +21747,204 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   } catch (err) {
     test('layered renderer: vm smoke test (threw)', false);
     results.errors.push('layered renderer smoke test threw: ' + err.message);
+  }
+})();
+
+// ── Sim Lab: layered defense-in-depth "stacked-bands" reference renderer ──
+// Faithful lift of mockups/defense-in-depth-secplus-concept.html: a
+// perimeter frame + a vertical stack of interior bands + an exposed-core
+// band. Data-driven via ref.layout — 'stacked' routes here, absent/other
+// (e.g. 'nested') keeps routing to the existing nested renderer (Task 8).
+// Same vm-sandbox + DOM-shim pattern as Task 8. Read-only.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: layered defense-in-depth stacked-bands renderer ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    test('stacked renderer: _slRenderRefLayeredStacked defined',
+      /function _slRenderRefLayeredStacked\(/.test(js));
+
+    // ── DEV FIXTURE — Sec+ DID scenario, stacked layout ──
+    // layers[0] = perimeter (present), layers[1..] = 3 interior bands
+    // (2 missing, 1 present — proves present/missing both render), core has
+    // 2 assets, 1 exposed.
+    var _stackedFix = {
+      kind: 'layered',
+      layout: 'stacked',
+      layers: [
+        { id: 'perimeter', label: 'Perimeter', control: 'Next-gen firewall', state: 'present' },
+        { id: 'endpoint',  label: 'Endpoint',  control: 'EDR / hardening',       state: 'missing' },
+        { id: 'data',      label: 'Data',      control: 'encryption + DLP',      state: 'present' },
+        { id: 'identity',  label: 'Identity',  control: 'MFA / least privilege', state: 'missing' }
+      ],
+      core: {
+        label: 'Crown-jewel data',
+        assets: [
+          { id: 'db1', label: 'DB-1', exposed: true },
+          { id: 'dc1', label: 'DC-1', exposed: false }
+        ]
+      }
+    };
+
+    var refStackedBody = grab('_slRenderRefLayeredStacked');
+    var elBody          = grab('_el');
+    var escBody         = grabLine('_esc');
+
+    if (!refStackedBody || !elBody || !escBody) {
+      test('stacked renderer: vm extraction succeeded', false);
+      results.errors.push('could not extract _slRenderRefLayeredStacked / helpers; check names/indenting');
+      return;
+    }
+
+    var htmlEscSt = function (s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    };
+    var makeElSt = function (tag) {
+      var attrs = {}, children = [], cls = '', inner = '';
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; },
+        set className(v) { cls = v; },
+        get innerHTML() { return inner; },
+        set innerHTML(v) { inner = v; children = []; },
+        get textContent() { return ''; },
+        set textContent(v) { inner = htmlEscSt(v); },
+        style: {},
+        get _children() { return children; },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return attrs[k] || null; },
+        appendChild: function (c) { children.push(c); return c; }
+      };
+      return el;
+    };
+    var docShimSt = { createElement: function (tag) { return makeElSt(tag); } };
+
+    var sCtx = { document: docShimSt, window: { CSS: null }, Object: Object, Array: Array, String: String, Math: Math };
+    vm.createContext(sCtx);
+    vm.runInContext(elBody, sCtx);
+    vm.runInContext(escBody, sCtx);
+    vm.runInContext(refStackedBody, sCtx);
+
+    sCtx.fixStacked = _stackedFix;
+    var rootSt = vm.runInContext('_slRenderRefLayeredStacked(fixStacked);', sCtx);
+
+    test('stacked renderer: returns an sl-stacked root',
+      rootSt && rootSt.className === 'sl-stacked');
+
+    var svgSt = rootSt ? rootSt.innerHTML : '';
+
+    test('stacked renderer: SVG emitted with viewBox',
+      /viewBox="0 0 \d+ \d+"/.test(svgSt));
+
+    // Perimeter frame present
+    test('stacked renderer: perimeter frame rendered (sl-perim)',
+      /class="sl-perim"/.test(svgSt));
+    test('stacked renderer: perimeter label rendered',
+      /Perimeter/.test(svgSt));
+
+    // One band per interior layer (3 bands: endpoint missing, data present, identity missing)
+    var bandRects = (svgSt.match(/class="sl-band"/g) || []).length;
+    var missBandRects = (svgSt.match(/class="sl-band-missing"/g) || []).length;
+    test('stacked renderer: 1 present interior band (sl-band)', bandRects === 1);
+    test('stacked renderer: 2 missing interior bands (sl-band-missing)', missBandRects === 2);
+    test('stacked renderer: total interior bands === layers.length - 1',
+      (bandRects + missBandRects) === (_stackedFix.layers.length - 1));
+
+    // Band labels rendered
+    test('stacked renderer: Endpoint band label rendered', /Endpoint/.test(svgSt));
+    test('stacked renderer: Data band label rendered', /Data/.test(svgSt));
+    test('stacked renderer: Identity band label rendered', /Identity/.test(svgSt));
+
+    // Exposed core (one asset exposed => core-exposed class)
+    test('stacked renderer: exposed-core class rendered (sl-core-exposed)',
+      /sl-core-exposed/.test(svgSt));
+    test('stacked renderer: core label rendered', /Crown-jewel data/.test(svgSt));
+
+    // Device boxes for core assets, exposed one flagged
+    test('stacked renderer: DB-1 device box rendered', /DB-1/.test(svgSt));
+    test('stacked renderer: DC-1 device box rendered', /DC-1/.test(svgSt));
+    test('stacked renderer: exposed device gets exposed class',
+      /class="sl-dev exposed"/.test(svgSt));
+
+    // ── Safe-core fixture: no assets exposed => sl-core (not sl-core-exposed) ──
+    var _safeCoreFix = {
+      kind: 'layered', layout: 'stacked',
+      layers: [{ id: 'perimeter', label: 'Perimeter', state: 'present' }],
+      core: { label: 'Safe core', assets: [{ id: 'a1', label: 'SRV-1', exposed: false }] }
+    };
+    sCtx.fixSafe = _safeCoreFix;
+    var rootSafe = vm.runInContext('_slRenderRefLayeredStacked(fixSafe);', sCtx);
+    var svgSafe = rootSafe ? rootSafe.innerHTML : '';
+    test('stacked renderer: safe core (no exposed assets) gets sl-core, not sl-core-exposed',
+      /class="sl-core"/.test(svgSafe) && !/sl-core-exposed/.test(svgSafe));
+
+    // XSS: label escaping
+    var xssStFix = {
+      kind: 'layered', layout: 'stacked',
+      layers: [
+        { id: 'x', label: '<script>alert(1)</script>', state: 'present' },
+        { id: 'y', label: '<i>band</i>', state: 'missing' }
+      ],
+      core: { label: '<b>core</b>', assets: [{ id: 'a', label: '<img>', exposed: false }] }
+    };
+    sCtx.xssStFix = xssStFix;
+    var rootStX = vm.runInContext('_slRenderRefLayeredStacked(xssStFix);', sCtx);
+    var svgStX  = rootStX ? rootStX.innerHTML : '';
+    test('stacked renderer: perimeter label XSS-escaped',
+      !/<script>/.test(svgStX) && /&lt;script&gt;/.test(svgStX));
+    test('stacked renderer: band label XSS-escaped',
+      !/<i>band<\/i>/.test(svgStX) && /&lt;i&gt;band&lt;\/i&gt;/.test(svgStX));
+    test('stacked renderer: core label XSS-escaped',
+      !/<b>core<\/b>/.test(svgStX) && /&lt;b&gt;core&lt;\/b&gt;/.test(svgStX));
+
+    // ── Regression: layered ref WITHOUT layout still routes to nested renderer ──
+    var refNestedBody = grab('_slRenderRefLayered');
+    var refDispBody    = grab('_slRenderReference');
+    if (!refNestedBody || !refDispBody) {
+      test('stacked renderer: dispatch regression vm extraction succeeded', false);
+      results.errors.push('could not extract _slRenderRefLayered / _slRenderReference for dispatch regression check');
+    } else {
+      var dCtx = { document: docShimSt, window: { CSS: null }, Object: Object, Array: Array, String: String, Math: Math };
+      vm.createContext(dCtx);
+      vm.runInContext(elBody, dCtx);
+      vm.runInContext(escBody, dCtx);
+      vm.runInContext(refNestedBody, dCtx);
+      vm.runInContext(refStackedBody, dCtx);
+      vm.runInContext(grab('_slRenderRefNetwork'), dCtx);
+      vm.runInContext(grab('_slRenderRefTimeline'), dCtx);
+      vm.runInContext(refDispBody, dCtx);
+
+      var _noLayoutFix = {
+        kind: 'layered',
+        layers: [{ id: 'l1', label: 'Perimeter', state: 'present' }],
+        core: { label: 'Core', assets: [] }
+      };
+      dCtx.noLayoutFix = _noLayoutFix;
+      var panelNoLayout = vm.runInContext('_slRenderReference(noLayoutFix);', dCtx);
+      var childNoLayout = panelNoLayout && panelNoLayout._children && panelNoLayout._children[0];
+      test('reference dispatch: layered ref WITHOUT layout still routes to nested renderer (sl-layered)',
+        childNoLayout && childNoLayout.className === 'sl-layered');
+
+      dCtx.stackedFix2 = _stackedFix;
+      var panelStacked = vm.runInContext('_slRenderReference(stackedFix2);', dCtx);
+      var childStacked = panelStacked && panelStacked._children && panelStacked._children[0];
+      test('reference dispatch: layered ref WITH layout:"stacked" routes to stacked renderer (sl-stacked)',
+        childStacked && childStacked.className === 'sl-stacked');
+    }
+
+  } catch (err) {
+    test('stacked renderer: vm smoke test (threw)', false);
+    results.errors.push('stacked renderer smoke test threw: ' + err.message);
   }
 })();
 

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20590,6 +20590,69 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── v7.62.x: Sim Lab — configure per-slot scoring (Task 2) ──
+// Behavioral smoke: extract simLabScoreScenario + its helpers into a vm
+// sandbox and prove configure steps score per-slot while other types stay 1-per-step.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: configure per-slot scoring ──\x1b[0m');
+  try {
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var normBody             = grab('_norm');
+    var normalizeMatchBody   = grab('_simLabNormalizeMatch');
+    var arrEqBody            = grab('_arrEq');
+    var setEqBody            = grab('_setEq');
+    var scoreSlotsBody       = grab('_scoreConfigureSlots');
+    var scoreStepBody        = grab('_scoreStep');
+    var scoreScenarioBody    = grab('simLabScoreScenario');
+
+    if (!normBody || !normalizeMatchBody || !arrEqBody || !setEqBody ||
+        !scoreSlotsBody || !scoreStepBody || !scoreScenarioBody) {
+      test('configure scoring: extraction of sim-lab scoring helpers', false);
+      results.errors.push('could not extract sim-lab scoring helpers from js; check function names/dedenting');
+      return;
+    }
+
+    var ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(normBody, ctx);
+    vm.runInContext(normalizeMatchBody, ctx);
+    vm.runInContext(arrEqBody, ctx);
+    vm.runInContext(setEqBody, ctx);
+    vm.runInContext(scoreSlotsBody, ctx);
+    vm.runInContext(scoreStepBody, ctx);
+    vm.runInContext(scoreScenarioBody, ctx);
+    vm.runInContext('globalThis.__slScore = simLabScoreScenario;', ctx);
+    var simLabScoreScenario = ctx.__slScore;
+
+    // 3-slot configure: 2 correct, 1 wrong → correct:2, total:3
+    var _scn3 = { id:'c2', cert:'netplus', scenario:'p', estMinutes:3, steps:[{
+      id:'s', type:'configure', prompt:'p', explanation:'e', points:1,
+      payload:{ slots:[
+        {id:'a',label:'A',options:[{id:'x',text:'x'},{id:'y',text:'y'}]},
+        {id:'b',label:'B',options:[{id:'x',text:'x'},{id:'y',text:'y'}]},
+        {id:'c',label:'C',options:[{id:'x',text:'x'},{id:'y',text:'y'}]} ]},
+      answer:{ slots:{ a:'x', b:'x', c:'x' } } }] };
+    var _r = simLabScoreScenario(_scn3, { s: { slots:{ a:'x', b:'x', c:'y' } } });
+    test('configure scores per-slot (2/3)',
+      _r.correct === 2 && _r.total === 3);
+
+    // non-configure (order): must still score 1 point per step
+    var _ord = { id:'c3', cert:'netplus', scenario:'p', estMinutes:3, steps:[{
+      id:'o', type:'order', prompt:'p', explanation:'e', points:1,
+      payload:{ items:[{id:'1',label:'1'},{id:'2',label:'2'}] }, answer:{ correctOrder:['1','2'] } }] };
+    var _ro = simLabScoreScenario(_ord, { o:{ order:['1','2'] } });
+    test('non-configure unchanged (1 per step)',
+      _ro.correct === 1 && _ro.total === 1);
+
+  } catch (err) {
+    test('configure scoring: vm smoke test (threw)', false);
+    results.errors.push('configure scoring vm smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -22486,6 +22486,106 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Task 16 (PBQ archetypes plan): cert-aware entry on the Sim Lab surface ──
+// Proves, behaviorally, that PBQ archetype scenarios are correctly SURFACED
+// for netplus/secplus and correctly ABSENT for non-PBQ certs (A+/Microsoft/
+// AWS), using the REAL cert-availability mechanisms already in the codebase
+// — no new allowlist/hook is introduced:
+//   1. `_SL_PBQ_CERTS_HOME` (app.js) is the Sim Lab entry-point allowlist
+//      consulted by `renderSimLabHomeEntry()` (called from `showPage('setup')`)
+//      to show/hide the Sim Lab tile. It includes netplus/secplus (PBQ certs)
+//      and correctly EXCLUDES the non-PBQ Decision Lab certs (az900/ai900/
+//      sc900/clfc02) — those get Decision Lab's own entry, not Sim Lab's.
+//   2. Archetype CONTENT is gated one level deeper, by which seed bank
+//      (`SIM_LAB_SEED_<CERT>`) actually contains `archetype`-tagged entries:
+//      netplus/secplus banks are non-empty for archetypes; a true non-PBQ
+//      cert has no Sim Lab seed bank global at all (`_slBank` returns []
+//      by construction, per `_SL_SEED_GLOBALS`); A+ has a Sim Lab bank but
+//      zero archetype-tagged scenarios in it (Phase 5 only authored netplus/
+//      secplus archetype content) — so even where Sim Lab entry is visible
+//      (A+), no archetype scenario can ever surface.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: cert-aware PBQ archetype entry (Task 16) ──\x1b[0m');
+  try {
+    // ── 1. Entry-point allowlist: PBQ certs in, non-PBQ certs out ──
+    var pbqCertsMatch = js.match(/_SL_PBQ_CERTS_HOME\s*=\s*\[([^\]]*)\]/);
+    test('Task 16: _SL_PBQ_CERTS_HOME allowlist exists', !!pbqCertsMatch);
+    if (pbqCertsMatch) {
+      var pbqCertsHome = pbqCertsMatch[1].split(',').map(function (s) { return s.replace(/['"\s]/g, ''); }).filter(Boolean);
+      test('Task 16: Sim Lab entry allowlist includes netplus', pbqCertsHome.indexOf('netplus') !== -1);
+      test('Task 16: Sim Lab entry allowlist includes secplus', pbqCertsHome.indexOf('secplus') !== -1);
+      test('Task 16: Sim Lab entry allowlist excludes az900/ai900/sc900/clfc02 (Decision Lab certs, not Sim Lab)',
+        ['az900', 'ai900', 'sc900', 'clfc02'].every(function (c) { return pbqCertsHome.indexOf(c) === -1; }));
+    }
+
+    // renderSimLabHomeEntry() must actually consult the allowlist to gate the
+    // tile, and must be wired into the setup-page render path (not orphaned).
+    var renderEntrySrc = (js.match(/function renderSimLabHomeEntry\(\) \{[\s\S]*?\n\}/) || [''])[0];
+    test('Task 16: renderSimLabHomeEntry() checks _SL_PBQ_CERTS_HOME before showing the tile',
+      !!renderEntrySrc && /_SL_PBQ_CERTS_HOME\.indexOf\(/.test(renderEntrySrc) && /is-hidden/.test(renderEntrySrc));
+    test('Task 16: renderSimLabHomeEntry() is called on setup-page render (real entry hook, not dead code)',
+      /if \(name === 'setup'[\s\S]{0,80}renderSimLabHomeEntry\(\)/.test(js));
+
+    // ── 2. Archetype content: present for netplus/secplus, absent for A+, and
+    //      no seed bank at all for a true non-PBQ cert (az900) ──
+    var netplusBankMatch = js.match(/window\.SIM_LAB_SEED_NETPLUS\s*=\s*\[[\s\S]*?\n\];/);
+    var secplusBankMatch = js.match(/window\.SIM_LAB_SEED_SECPLUS\s*=\s*\[[\s\S]*?\n\];/);
+    var aplus1BankMatch = js.match(/window\.SIM_LAB_SEED_APLUS_CORE1\s*=\s*\[[\s\S]*?\n\];/);
+    var aplus2BankMatch = js.match(/window\.SIM_LAB_SEED_APLUS_CORE2\s*=\s*\[[\s\S]*?\n\];/);
+
+    test('Task 16: Net+ Sim Lab seed bank has archetype-tagged scenarios (offered for netplus)',
+      !!netplusBankMatch && /archetype\s*:/.test(netplusBankMatch[0]));
+    test('Task 16: Sec+ Sim Lab seed bank has archetype-tagged scenarios (offered for secplus)',
+      !!secplusBankMatch && /archetype\s*:/.test(secplusBankMatch[0]));
+    test('Task 16: A+ Core1 Sim Lab seed bank exists but has NO archetype-tagged scenarios (not surfaced)',
+      !!aplus1BankMatch && !/archetype\s*:/.test(aplus1BankMatch[0]));
+    test('Task 16: A+ Core2 Sim Lab seed bank exists but has NO archetype-tagged scenarios (not surfaced)',
+      !!aplus2BankMatch && !/archetype\s*:/.test(aplus2BankMatch[0]));
+
+    // No SIM_LAB_SEED_<X> global exists at all for the non-PBQ Decision Lab
+    // certs — confirms _slBank('az900') etc. can only ever return [] via the
+    // _SL_SEED_GLOBALS registry (no accidental entry for a non-PBQ cert).
+    test('Task 16: no Sim Lab seed-bank global exists for az900/ai900/sc900/clfc02 (non-PBQ certs)',
+      ['AZ900', 'AI900', 'SC900', 'CLFC02'].every(function (c) {
+        return !new RegExp('window\\.SIM_LAB_SEED_' + c + '\\b').test(js);
+      }));
+
+    // ── 3. Behavioral proof via the real _slBank resolver (vm), mirroring the
+    //      Task 15 extraction approach: drive the ACTUAL selection function,
+    //      not a re-implementation, across a PBQ cert (netplus) and a non-PBQ
+    //      cert (az900) with no seed-bank entry in _SL_SEED_GLOBALS.
+    var vm = require('vm');
+    var grab16 = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var seedBankBody16 = grab16('_seedBank');
+    var slBankBody16 = grab16('_slBank');
+    var slGlobalsMatch16 = js.match(/var _SL_SEED_GLOBALS\s*=\s*\{[\s\S]*?\};/);
+
+    if (!seedBankBody16 || !slBankBody16 || !slGlobalsMatch16) {
+      test('Task 16: bank-resolver helper extraction succeeded', false);
+      results.errors.push('could not extract _seedBank/_slBank/_SL_SEED_GLOBALS for Task 16 test; check names/indenting');
+    } else {
+      var bankCtx16 = { window: { SIM_LAB_SEED_NETPLUS: [{ id: 'x', archetype: 'diagram' }] } };
+      vm.createContext(bankCtx16);
+      vm.runInContext('var window = this.window;', bankCtx16);
+      vm.runInContext(seedBankBody16, bankCtx16);
+      vm.runInContext(slGlobalsMatch16[0], bankCtx16);
+      vm.runInContext(slBankBody16, bankCtx16);
+      vm.runInContext('globalThis.__netplusBank = _slBank("netplus"); globalThis.__az900Bank = _slBank("az900");', bankCtx16);
+
+      test('Task 16: _slBank("netplus") returns a non-empty bank (archetype content reachable)',
+        Array.isArray(bankCtx16.__netplusBank) && bankCtx16.__netplusBank.length === 1 && bankCtx16.__netplusBank[0].archetype === 'diagram');
+      test('Task 16: _slBank("az900") returns [] — no PBQ/archetype content for a non-PBQ cert',
+        Array.isArray(bankCtx16.__az900Bank) && bankCtx16.__az900Bank.length === 0);
+    }
+  } catch (err) {
+    test('Task 16: vm smoke test (threw)', false);
+    results.errors.push('Task 16 cert-aware entry smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -22219,6 +22219,101 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// The 10 consensus-approved Defense in Depth scenarios (5 Net+, 5 Sec+) now
+// live for real in features/sim-lab-seed-netplus.js and
+// features/sim-lab-seed-secplus.js (window.SIM_LAB_SEED_NETPLUS /
+// window.SIM_LAB_SEED_SECPLUS). This proves every one of them is real,
+// production-ready content: each passes the same pure validator that gates
+// the dev fixture (simLabValidateScenario), extracted from features/sim-lab.js
+// by the same brace-matching approach as .superpowers/sdd/validate-drafts.js
+// (no reimplementation of validator logic). Defense scenarios use `layered`
+// refs without a deviceId configure step, so simLabValidateNetworkFidelity
+// does not apply here (mirrors Task 13's incident-bank test, minus the
+// fidelity check) — this is the real bank across BOTH cert seed banks
+// (Task 14).
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: Defense in Depth seed-bank validation, Net+ & Sec+ (Task 14) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── Extract the REAL pure validator from features/sim-lab.js, exactly
+    // as .superpowers/sdd/validate-drafts.js does ──
+    var isNonEmptyStrBody   = grab('_isNonEmptyStr');
+    var validatePayloadBody = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody) {
+      test('Defense in Depth bank: validator helper extraction succeeded', false);
+      results.errors.push('could not extract validator helpers for Task 14 bank test; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+
+    // ── Load both real seed banks: eval features/sim-lab-seed-netplus.js and
+    // features/sim-lab-seed-secplus.js in a sandbox with `var window = {}` so
+    // window.SIM_LAB_SEED_NETPLUS / window.SIM_LAB_SEED_SECPLUS populate ──
+    var netplusSrc = read('features/sim-lab-seed-netplus.js');
+    var netplusCtx = {};
+    vm.createContext(netplusCtx);
+    vm.runInContext('var window = {};\n' + netplusSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_NETPLUS;', netplusCtx);
+    var netplusBank = netplusCtx.__seed;
+
+    var secplusSrc = read('features/sim-lab-seed-secplus.js');
+    var secplusCtx = {};
+    vm.createContext(secplusCtx);
+    vm.runInContext('var window = {};\n' + secplusSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_SECPLUS;', secplusCtx);
+    var secplusBank = secplusCtx.__seed;
+
+    test('Defense in Depth bank: window.SIM_LAB_SEED_NETPLUS loaded as an array',
+      Array.isArray(netplusBank));
+    test('Defense in Depth bank: window.SIM_LAB_SEED_SECPLUS loaded as an array',
+      Array.isArray(secplusBank));
+    if (!Array.isArray(netplusBank) || !Array.isArray(secplusBank)) {
+      results.errors.push('could not load one or both seed banks for Task 14 Defense in Depth test');
+      return;
+    }
+
+    var netplusDefense = netplusBank.filter(function (s) { return s && s.archetype === 'defense'; });
+    var secplusDefense = secplusBank.filter(function (s) { return s && s.archetype === 'defense'; });
+
+    test('Defense in Depth bank: at least 5 defense-archetype scenarios in Net+ bank',
+      netplusDefense.length >= 5);
+    test('Defense in Depth bank: at least 5 defense-archetype scenarios in Sec+ bank',
+      secplusDefense.length >= 5);
+
+    var allValidateOk = true;
+    netplusDefense.concat(secplusDefense).forEach(function (s) {
+      var vr = simLabValidateScenario(s);
+      if (!vr || vr.ok !== true) {
+        allValidateOk = false;
+        results.errors.push('Defense in Depth bank: ' + (s && s.id) + ' failed simLabValidateScenario: ' + JSON.stringify(vr && vr.errors));
+      }
+    });
+
+    test('Defense in Depth bank: every defense scenario (both banks) passes simLabValidateScenario',
+      allValidateOk);
+
+  } catch (err) {
+    test('Defense in Depth bank: vm smoke test (threw)', false);
+    results.errors.push('Defense in Depth bank smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20819,6 +20819,264 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Task 5: reference asset model + validation + mount wiring ──
+// Validation tests use the existing simLabValidateScenario extracted from `js`.
+// Mount test uses a vm-sandbox + DOM shim (same pattern as configure renderer).
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: reference asset model (Task 5) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    // grab() pattern: matches dedented feature file functions (\n} closing brace)
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── Structural checks ──
+    test('reference: _slRenderReference defined',
+      /function _slRenderReference\(/.test(js));
+    test('reference: _slRenderRefNetwork defined',
+      /function _slRenderRefNetwork\(/.test(js));
+    test('reference: _slRenderRefTimeline defined',
+      /function _slRenderRefTimeline\(/.test(js));
+    test('reference: _slRenderRefLayered defined',
+      /function _slRenderRefLayered\(/.test(js));
+    test('reference: _slMountScenario wires _slRenderReference',
+      /scn\.assets && scn\.assets\.reference/.test(js) && /_slRenderReference\(/.test(js));
+    test('reference: simLabValidateScenario checks reference kind',
+      /reference: bad kind/.test(js));
+
+    // ── Validation tests — extract simLabValidateScenario + helpers into vm ──
+    var isNonEmptyStrBody = grabLine('_isNonEmptyStr') || grab('_isNonEmptyStr');
+    var validatePayloadBody = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+
+    // STEP_TYPES array — grab from source
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody) {
+      test('reference validation: helper extraction succeeded', false);
+      results.errors.push('could not extract simLabValidateScenario helpers; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+
+    // Minimal valid configure scenario used as base for all reference tests
+    var _baseScn = function () {
+      return {
+        id: 'r1', cert: 'netplus', scenario: 'Configure the router', estMinutes: 3,
+        steps: [{
+          id: 's1', type: 'configure', prompt: 'Set IP mode', explanation: 'e', points: 1,
+          payload: { slots: [{ id: 'ip', label: 'IP Mode', options: [{ id: 'a', text: 'Static' }, { id: 'b', text: 'DHCP' }] }] },
+          answer: { slots: { ip: 'a' } }
+        }]
+      };
+    };
+
+    // 1. Scenario without assets.reference still validates fine
+    var _plain = _baseScn();
+    test('reference validation: scenario without reference passes',
+      simLabValidateScenario(_plain).ok === true);
+
+    // 2. Valid network reference passes
+    var _scnNet = _baseScn();
+    _scnNet.assets = { reference: { kind: 'network', devices: [{ id: 'd1', label: 'PC', type: 'pc', zone: 'v10', x: 10, y: 10 }], links: [] } };
+    test('reference validation: valid network reference passes',
+      simLabValidateScenario(_scnNet).ok === true);
+
+    // 3. Unknown kind rejected
+    var _scnBad = _baseScn();
+    _scnBad.assets = { reference: { kind: 'nope' } };
+    var _badResult = simLabValidateScenario(_scnBad);
+    test('reference validation: unknown reference kind rejected',
+      _badResult.ok === false && _badResult.errors.some(function (e) { return /reference.*bad kind/i.test(e); }));
+
+    // 4. Network reference without devices[] rejected
+    var _scnNoDevs = _baseScn();
+    _scnNoDevs.assets = { reference: { kind: 'network' } };
+    var _noDevsResult = simLabValidateScenario(_scnNoDevs);
+    test('reference validation: network without devices[] rejected',
+      _noDevsResult.ok === false && _noDevsResult.errors.some(function (e) { return /devices/.test(e); }));
+
+    // 5. Valid timeline reference passes
+    var _scnTl = _baseScn();
+    _scnTl.assets = { reference: { kind: 'timeline', stages: [{ id: 'p', icon: '!', label: 'Prep', severity: 'low' }] } };
+    test('reference validation: valid timeline reference passes',
+      simLabValidateScenario(_scnTl).ok === true);
+
+    // 6. Valid layered reference passes
+    var _scnLy = _baseScn();
+    _scnLy.assets = { reference: { kind: 'layered', layers: [{ id: 'l1', label: 'Perimeter', state: 'ok' }], core: { label: 'Core', assets: [] } } };
+    test('reference validation: valid layered reference passes',
+      simLabValidateScenario(_scnLy).ok === true);
+
+    // ── Mount test — vm-sandbox + DOM shim ──
+    var elBody            = grab('_el');
+    var escBody           = grabLine('_esc');
+    var slAttrBody        = grabLine('_slAttr');
+    var renderCfgBody     = grab('_slRenderConfigure');
+    var renderStepBody    = grab('simLabRenderStep');
+    var refNetBody        = grab('_slRenderRefNetwork');
+    var refTimeBody       = grab('_slRenderRefTimeline');
+    var refLayBody        = grab('_slRenderRefLayered');
+    var refDispBody       = grab('_slRenderReference');
+    var mountBody         = grab('_slMountScenario');
+
+    if (!elBody || !escBody || !mountBody || !refDispBody || !refNetBody) {
+      test('reference mount: vm extraction succeeded', false);
+      results.errors.push('could not extract _slMountScenario / reference helpers; check names/indenting');
+      return;
+    }
+
+    // Minimal DOM shim (same as configure renderer test, with _children as getter
+    // so it tracks the live `children` array even after innerHTML resets it)
+    var makeEl = function (tag) {
+      var attrs = {}, listeners = {}, children = [], cls = '', inner = '', val = '';
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; },
+        set className(v) { cls = v; },
+        get innerHTML() { return inner; },
+        set innerHTML(v) { inner = v; children = []; },
+        get value() { return val; },
+        set value(v) { val = v; },
+        selected: false,
+        textContent: '',
+        style: {},
+        get _children() { return children; },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return attrs[k] || null; },
+        appendChild: function (c) { children.push(c); return c; },
+        querySelector: function (sel) {
+          for (var i = 0; i < children.length; i++) {
+            var c = children[i];
+            if (!c || !c.tagName) continue;
+            if (sel.toLowerCase() === c.tagName.toLowerCase()) return c;
+            if (c._children) {
+              for (var j = 0; j < c._children.length; j++) {
+                var gc = c._children[j];
+                if (gc && gc.tagName && sel.toLowerCase() === gc.tagName.toLowerCase()) return gc;
+              }
+            }
+          }
+          return null;
+        },
+        querySelectorAll: function (sel) {
+          var hits = [];
+          var search = function (node) {
+            if (!node || !node._children) return;
+            node._children.forEach(function (c) {
+              if (!c || !c.tagName) return;
+              var tag = sel.replace(/^\..*/, '').toUpperCase();
+              if (c.tagName === (tag || c.tagName)) hits.push(c);
+              search(c);
+            });
+          };
+          search(el);
+          return hits;
+        },
+        addEventListener: function (ev, fn) { listeners[ev] = (listeners[ev] || []); listeners[ev].push(fn); },
+        dispatchEvent: function (evObj) { var fns = listeners[evObj.type] || []; fns.forEach(function (fn) { fn(evObj); }); },
+        closest: function () { return null; },
+        remove: function () {}
+      };
+      return el;
+    };
+
+    var docShim = {
+      createElement: function (tag) { return makeEl(tag); },
+      createTextNode: function (t) { return { textContent: t, tagName: '#text' }; }
+    };
+    var windowShim = { CSS: null };
+
+    var mCtx = { document: docShim, window: windowShim, Object: Object, Array: Array, String: String };
+    vm.createContext(mCtx);
+    vm.runInContext(elBody, mCtx);
+    vm.runInContext(escBody, mCtx);
+    if (slAttrBody) vm.runInContext(slAttrBody, mCtx);
+    if (renderCfgBody) vm.runInContext(renderCfgBody, mCtx);
+    if (renderStepBody) vm.runInContext(renderStepBody, mCtx);
+    vm.runInContext(refNetBody, mCtx);
+    if (refTimeBody) vm.runInContext(refTimeBody, mCtx);
+    if (refLayBody) vm.runInContext(refLayBody, mCtx);
+    vm.runInContext(refDispBody, mCtx);
+    vm.runInContext(mountBody, mCtx);
+
+    // Scenario with a network reference
+    var _mountScn = {
+      id: 'r1', cert: 'netplus', scenario: 'Configure the router', estMinutes: 3,
+      assets: { reference: { kind: 'network', devices: [{ id: 'd1', label: 'PC', type: 'pc', zone: 'v10', x: 10, y: 10 }], links: [] } },
+      steps: [{
+        id: 's1', type: 'configure', prompt: 'Set IP mode', explanation: 'e', points: 1,
+        payload: { slots: [{ id: 'ip', label: 'IP Mode', options: [{ id: 'a', text: 'Static' }, { id: 'b', text: 'DHCP' }] }] },
+        answer: { slots: { ip: 'a' } }
+      }]
+    };
+
+    var host = makeEl('div');
+    mCtx.host = host;
+    mCtx.mountScn = _mountScn;
+    mCtx.mountOpts = { onSubmit: function () {} };
+    vm.runInContext('_slMountScenario(host, mountScn, mountOpts);', mCtx);
+
+    // host._children[0] is the sl-scenario wrap div
+    // wrap._children layout: [sl-scn-prose, sl-ref, ...steps, submit]
+    var wrap = host._children[0];
+    var refPanelFound = wrap && wrap._children.some(function (c) {
+      return c && c.className === 'sl-ref';
+    });
+    test('reference mount: _slMountScenario renders a .sl-ref panel',
+      refPanelFound === true);
+
+    // Verify reference panel comes before first step wrap
+    if (wrap) {
+      var refIdx = -1, stepIdx = -1;
+      wrap._children.forEach(function (c, i) {
+        if (c && c.className === 'sl-ref' && refIdx === -1) refIdx = i;
+        if (c && c.className === 'sl-step' && stepIdx === -1) stepIdx = i;
+      });
+      test('reference mount: reference panel is before first step',
+        refIdx !== -1 && stepIdx !== -1 && refIdx < stepIdx);
+    }
+
+    // Scenario WITHOUT reference: must still mount fine (no regression)
+    var _plainScn = {
+      id: 'r2', cert: 'netplus', scenario: 'Plain scenario', estMinutes: 3,
+      steps: [{
+        id: 's1', type: 'configure', prompt: 'Set IP mode', explanation: 'e', points: 1,
+        payload: { slots: [{ id: 'ip', label: 'IP Mode', options: [{ id: 'a', text: 'Static' }, { id: 'b', text: 'DHCP' }] }] },
+        answer: { slots: { ip: 'a' } }
+      }]
+    };
+    var host2 = makeEl('div');
+    mCtx.host2 = host2;
+    mCtx.plainScn = _plainScn;
+    vm.runInContext('_slMountScenario(host2, plainScn, mountOpts);', mCtx);
+    var wrap2 = host2._children[0];
+    var hasNoRefPanel = wrap2 && !wrap2._children.some(function (c) { return c && c.className === 'sl-ref'; });
+    test('reference mount: scenario without reference has no .sl-ref panel',
+      hasNoRefPanel === true);
+
+  } catch (err) {
+    test('reference asset model: vm smoke test (threw)', false);
+    results.errors.push('reference asset model smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -22036,6 +22036,109 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Task 12 (PBQ archetypes plan): Net+ Diagram seed-bank validation ──
+// The 16 consensus-approved Net+ Diagram scenarios now live for real in
+// features/sim-lab-seed-netplus.js (window.SIM_LAB_SEED_NETPLUS). This proves
+// every one of them is real, production-ready content: each passes the same
+// pure validators that gate the dev fixture above (simLabValidateScenario +
+// simLabValidateNetworkFidelity), extracted from features/sim-lab.js by the
+// same brace-matching approach as .superpowers/sdd/validate-drafts.js (no
+// reimplementation of validator logic). Not a fixture — this is the real bank.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: Net+ Diagram seed-bank validation (Task 12) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── Extract the REAL pure validators from features/sim-lab.js, exactly
+    // as .superpowers/sdd/validate-drafts.js does ──
+    var isNonEmptyStrBody   = grab('_isNonEmptyStr');
+    var validatePayloadBody = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    var ipToIntBody      = grab('_ipToInt');
+    var maskToIntBody    = grab('_maskToInt');
+    var inSubnetBody     = grab('_inSubnet');
+    var resolveSlotBody  = grab('_slFidelityResolveSlot');
+    var fidelityBody     = grab('simLabValidateNetworkFidelity');
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody ||
+        !ipToIntBody || !maskToIntBody || !inSubnetBody || !resolveSlotBody || !fidelityBody) {
+      test('Net+ Diagram bank: validator helper extraction succeeded', false);
+      results.errors.push('could not extract validator helpers for Task 12 bank test; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext(ipToIntBody, vCtx);
+    vm.runInContext(maskToIntBody, vCtx);
+    vm.runInContext(inSubnetBody, vCtx);
+    vm.runInContext(resolveSlotBody, vCtx);
+    vm.runInContext(fidelityBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario; globalThis.__fidelity = simLabValidateNetworkFidelity;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+    var simLabValidateNetworkFidelity = vCtx.__fidelity;
+
+    // ── Load the real seed bank: eval features/sim-lab-seed-netplus.js in a
+    // sandbox with `var window = {}` so window.SIM_LAB_SEED_NETPLUS populates ──
+    var seedSrc = read('features/sim-lab-seed-netplus.js');
+    var seedCtx = {};
+    vm.createContext(seedCtx);
+    vm.runInContext('var window = {};\n' + seedSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_NETPLUS;', seedCtx);
+    var seedBank = seedCtx.__seed;
+
+    test('Net+ Diagram bank: window.SIM_LAB_SEED_NETPLUS loaded as an array',
+      Array.isArray(seedBank));
+    if (!Array.isArray(seedBank)) {
+      results.errors.push('could not load window.SIM_LAB_SEED_NETPLUS from features/sim-lab-seed-netplus.js');
+      return;
+    }
+
+    var diagramScenarios = seedBank.filter(function (s) { return s && s.archetype === 'diagram'; });
+    test('Net+ Diagram bank: at least 16 diagram-archetype scenarios present',
+      diagramScenarios.length >= 16);
+
+    var allValidateOk = true, allFidelityOk = true;
+    diagramScenarios.forEach(function (s) {
+      var vr = simLabValidateScenario(s);
+      if (!vr || vr.ok !== true) {
+        allValidateOk = false;
+        results.errors.push('Net+ Diagram bank: ' + (s && s.id) + ' failed simLabValidateScenario: ' + JSON.stringify(vr && vr.errors));
+      }
+      if (s && s.assets && s.assets.reference) {
+        var cfgStep = (s.steps || []).filter(function (st) { return st.type === 'configure' && st.deviceId; })[0];
+        if (cfgStep) {
+          var fr = simLabValidateNetworkFidelity(s.assets.reference, cfgStep);
+          if (!fr || fr.ok !== true) {
+            allFidelityOk = false;
+            results.errors.push('Net+ Diagram bank: ' + (s && s.id) + ' failed simLabValidateNetworkFidelity: ' + JSON.stringify(fr && fr.errors));
+          }
+        }
+      }
+    });
+
+    test('Net+ Diagram bank: every diagram scenario passes simLabValidateScenario',
+      allValidateOk);
+    test('Net+ Diagram bank: every diagram scenario\'s configure(deviceId) step passes simLabValidateNetworkFidelity',
+      allFidelityOk);
+
+  } catch (err) {
+    test('Net+ Diagram bank: vm smoke test (threw)', false);
+    results.errors.push('Net+ Diagram bank smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21077,6 +21077,188 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Sim Lab: network reference renderer (Task 6) ──
+// The renderer builds SVG as a STRING mounted via _el('div','sl-net', svg), so
+// assertions run against that string (read from the .sl-net child's innerHTML),
+// plus shim-queried child blocks for the given/CLI panels. Same vm-sandbox +
+// DOM-shim pattern as the Task 5 mount test. Read-only: no listeners to drive.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: network reference renderer (Task 6) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // Structural: the stub is gone, real SVG-building landed
+    test('net renderer: stub replaced (no sl-ref-stub network branch)',
+      !/_slRenderRefNetwork\(ref\)\s*\{\s*return _el\('div', 'sl-ref-stub', 'network'\)/.test(js));
+    test('net renderer: builds an sl-net-svg element',
+      /sl-net-svg/.test(js));
+    test('net renderer: defines the attack arrow marker',
+      /id="sl-net-arrow"/.test(js));
+    test('net renderer: glyph map present',
+      /_SL_NET_GLYPHS/.test(js));
+
+    // ── DEV FIXTURE — Net+ Mercer & Hale branch (derived from
+    // mockups/diagram-pbq-concept.html). LABELED dev fixture for this test only.
+    // PC-2 is the flagged host → state 'compromised'; one synthetic 'attack'
+    // link exercises that path. Two distinct zones (v10 Staff, v20 Guest);
+    // RTR-1 has no zone (sits outside both, like the mockup gateway).
+    var _netFix = {
+      kind: 'network',
+      devices: [
+        { id: 'rtr', label: 'RTR-1', type: 'router', x: 1, y: 0, ip: 'gw .10.1 / .20.1' },
+        { id: 'swa', label: 'SW-A', type: 'switch', zone: 'VLAN 10 Staff', x: 0, y: 1, ip: 'access v10' },
+        { id: 'swb', label: 'SW-B', type: 'switch', zone: 'VLAN 20 Guest', x: 2, y: 1, ip: 'access v20' },
+        { id: 'fs1', label: 'FS-1', type: 'server', zone: 'VLAN 10 Staff', x: 0, y: 2, ip: '.10.20' },
+        { id: 'pc2', label: 'PC-2', type: 'pc', zone: 'VLAN 10 Staff', x: 1, y: 2, ip: '.20.45 ?', state: 'compromised' },
+        { id: 'pc7', label: 'PC-7', type: 'pc', zone: 'VLAN 20 Guest', x: 2, y: 2, ip: '.20.31' }
+      ],
+      links: [
+        { from: 'rtr', to: 'swa' },
+        { from: 'rtr', to: 'swb' },
+        { from: 'swa', to: 'fs1' },
+        { from: 'swa', to: 'pc2', kind: 'attack' },
+        { from: 'swb', to: 'pc7' }
+      ],
+      given: {
+        networkId: '192.168.10.0',
+        mask: '255.255.255.0  (/24)',
+        cli: ['PC-2> ipconfig', '  IPv4 Address . . : 192.168.20.45', 'PC-2> ping 192.168.10.20', '  Request timed out.']
+      }
+    };
+
+    var refNetBody = grab('_slRenderRefNetwork');
+    var elBody     = grab('_el');
+    var escBody    = grabLine('_esc');
+
+    if (!refNetBody || !elBody || !escBody) {
+      test('net renderer: vm extraction succeeded', false);
+      results.errors.push('could not extract _slRenderRefNetwork / helpers; check names/indenting');
+      return;
+    }
+
+    // Minimal DOM shim — _el needs createElement + className/innerHTML/appendChild.
+    // _esc() does `d.textContent = s; return d.innerHTML;`, so the textContent
+    // setter must populate innerHTML with HTML-escaped text for escaping to work.
+    var htmlEsc = function (s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    };
+    var makeEl = function (tag) {
+      var attrs = {}, children = [], cls = '', inner = '';
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; },
+        set className(v) { cls = v; },
+        get innerHTML() { return inner; },
+        set innerHTML(v) { inner = v; children = []; },
+        get textContent() { return ''; },
+        set textContent(v) { inner = htmlEsc(v); },
+        style: {},
+        get _children() { return children; },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return attrs[k] || null; },
+        appendChild: function (c) { children.push(c); return c; }
+      };
+      return el;
+    };
+    var docShim = { createElement: function (tag) { return makeEl(tag); } };
+
+    var nCtx = { document: docShim, window: { CSS: null }, Object: Object, Array: Array, String: String };
+    vm.createContext(nCtx);
+    vm.runInContext(elBody, nCtx);
+    vm.runInContext(escBody, nCtx);
+    vm.runInContext(refNetBody, nCtx);
+    nCtx.fix = _netFix;
+    var rootEl = vm.runInContext('_slRenderRefNetwork(fix);', nCtx);
+
+    // .sl-net child holds the SVG string in innerHTML
+    var netDiv = rootEl._children.filter(function (c) { return c.className === 'sl-net'; })[0];
+    var svg = netDiv ? netDiv.innerHTML : '';
+
+    test('net renderer: returns an sl-net-ref root', rootEl && rootEl.className === 'sl-net-ref');
+    test('net renderer: emits an <svg> with a computed viewBox',
+      /<svg class="sl-net-svg" viewBox="0 0 \d+ \d+"/.test(svg));
+
+    // one .sl-node group per device (6) — match the <g> opener, not sub-elements
+    var nodeCount = (svg.match(/<g class="sl-node/g) || []).length;
+    test('net renderer: one .sl-node per device (6)', nodeCount === 6);
+
+    // compromised device gets the compromised class
+    test('net renderer: compromised device gets compromised class',
+      /class="sl-node compromised"/.test(svg));
+
+    // attack link gets the attack class + arrow marker
+    test('net renderer: attack link gets .sl-link.attack class',
+      /class="sl-link attack"/.test(svg));
+    test('net renderer: attack link references the arrow marker',
+      /marker-end="url\(#sl-net-arrow\)"/.test(svg));
+
+    // one zone rect per distinct zone (2: v10, v20)
+    var zoneCount = (svg.match(/class="sl-vlan-zone"/g) || []).length;
+    test('net renderer: one zone rect per distinct zone (2)', zoneCount === 2);
+    test('net renderer: zone label uppercased', /VLAN 10 STAFF/.test(svg));
+
+    // RTR-1 has no zone → still rendered as a node, but not inside a zone count
+    test('net renderer: zoneless device still renders (RTR-1 node present)',
+      /sl-node-name[^>]*>RTR-1</.test(svg));
+
+    // node labels + ips escaped & present
+    test('net renderer: device label rendered', /sl-node-name[^>]*>PC-2</.test(svg));
+    test('net renderer: device ip rendered', /sl-node-ip[^>]*>\.20\.45 \?</.test(svg));
+
+    // glyph per node type (router/switch/server/pc all drawn)
+    test('net renderer: node glyph paths drawn', (svg.match(/class="sl-glyph"/g) || []).length === 6);
+
+    // given panel
+    var givenDiv = rootEl._children.filter(function (c) { return c.className === 'sl-net-given'; })[0];
+    test('net renderer: given panel rendered with Network ID + mask',
+      !!givenDiv && /Network ID/.test(givenDiv.innerHTML) && /192\.168\.10\.0/.test(givenDiv.innerHTML) && /255\.255\.255\.0/.test(givenDiv.innerHTML));
+
+    // CLI block lines present + escaped
+    var cliDiv = rootEl._children.filter(function (c) { return c.className === 'sl-net-cli'; })[0];
+    test('net renderer: given CLI lines appear',
+      !!cliDiv && /PC-2&gt; ipconfig/.test(cliDiv.innerHTML) && /Request timed out\./.test(cliDiv.innerHTML));
+
+    // ── arbitrary-scenario smoke: a totally different shape still renders ──
+    var _altFix = {
+      kind: 'network',
+      devices: [
+        { id: 'fw', label: 'FW', type: 'firewall', x: 1, y: 0 },
+        { id: 'srv', label: 'SRV', type: 'server', zone: 'DMZ', x: 0, y: 1 },
+        { id: 'wks', label: 'WKS', type: 'pc', zone: 'LAN', x: 2, y: 1, state: 'affected' }
+      ],
+      links: [{ from: 'fw', to: 'srv' }, { from: 'fw', to: 'wks' }]
+    };
+    nCtx.alt = _altFix;
+    var altRoot = vm.runInContext('_slRenderRefNetwork(alt);', nCtx);
+    var altNet = altRoot._children.filter(function (c) { return c.className === 'sl-net'; })[0];
+    var altSvg = altNet ? altNet.innerHTML : '';
+    test('net renderer: arbitrary scenario renders all nodes',
+      (altSvg.match(/<g class="sl-node/g) || []).length === 3);
+    test('net renderer: affected device gets affected class',
+      /class="sl-node affected"/.test(altSvg));
+    test('net renderer: arbitrary scenario zones (DMZ + LAN)',
+      (altSvg.match(/class="sl-vlan-zone"/g) || []).length === 2);
+    test('net renderer: unknown-coordinate firewall glyph drawn (no crash, 3 glyphs)',
+      (altSvg.match(/class="sl-glyph"/g) || []).length === 3);
+    test('net renderer: scenario without given renders no given/cli panel',
+      altRoot._children.every(function (c) { return c.className !== 'sl-net-given' && c.className !== 'sl-net-cli'; }));
+
+  } catch (err) {
+    test('net renderer: vm smoke test (threw)', false);
+    results.errors.push('network renderer smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -22314,6 +22314,178 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Task 15 (PBQ archetypes plan): archetype scenarios ride the EXISTING
+// free-1/day + Pro gating — reuse, no new metering. ──
+// Confirms two things behaviorally, not just structurally:
+//   1. The seed-bank pick path (_slBank/_slPickSeed/_slPickSeedFresh) treats
+//      an archetype-tagged scenario ('diagram'/'incident'/'defense') exactly
+//      like an ordinary scenario — same array, same index-based selection,
+//      no archetype branch exists that could special-case or bypass gating.
+//   2. simLabStart / _slSessionStart run the free-count check + Pro gate
+//      (_slIsPro, _pbqFreeRunsToday, PBQ_FREE_DAILY_CAP, _gateProOnly)
+//      BEFORE any scenario (archetype or not) is ever picked/generated — so
+//      an exhausted free cap blocks an archetype-only bank identically to a
+//      bank with zero archetype scenarios. Also confirms the free-tier
+//      session-bump path (_slSessionBumpOnce -> _bumpPbqFreeRun) is
+//      archetype-agnostic (fires once per session regardless of which
+//      scenario, archetype or not, gets served).
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: archetypes ride existing free/Pro gating (Task 15) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── 1. Bank/pick path is archetype-agnostic ──
+    // Build a tiny mixed bank: one ordinary scenario, one 'diagram'-archetype
+    // scenario. Extract the REAL _seedBank/_slBank/_slPickSeed/_slPickSeedFresh
+    // (no reimplementation) and prove selection never inspects `.archetype`.
+    var seedBankBody     = grab('_seedBank');
+    var slBankBody       = grab('_slBank');
+    var pickSeedBody     = grab('_slPickSeed');
+    var pickSeedFreshBody = grab('_slPickSeedFresh');
+    var slGlobalsMatch   = js.match(/var _SL_SEED_GLOBALS\s*=\s*\{[\s\S]*?\};/);
+    // simLabValidateScenario is called inside the pick functions — extract the
+    // real validator chain too (same approach as the Task 11/12/13/14 blocks).
+    var isNonEmptyStrBody    = grab('_isNonEmptyStr');
+    var validatePayloadBody  = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    if (!seedBankBody || !slBankBody || !pickSeedBody || !pickSeedFreshBody || !slGlobalsMatch ||
+        !isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody) {
+      test('Task 15: bank/pick helper extraction succeeded', false);
+      results.errors.push('could not extract _seedBank/_slBank/_slPickSeed/_slPickSeedFresh for Task 15 test; check names/indenting');
+    } else {
+      var bankCtx = { window: {} };
+      vm.createContext(bankCtx);
+      vm.runInContext('var window = this.window;', bankCtx);
+      vm.runInContext(stepTypesDecl, bankCtx);
+      vm.runInContext(isNonEmptyStrBody, bankCtx);
+      vm.runInContext(validatePayloadBody, bankCtx);
+      vm.runInContext(validateScenarioBody, bankCtx);
+      vm.runInContext(seedBankBody, bankCtx);
+      vm.runInContext(slGlobalsMatch[0], bankCtx);
+      vm.runInContext(slBankBody, bankCtx);
+      vm.runInContext(pickSeedBody, bankCtx);
+      vm.runInContext(pickSeedFreshBody, bankCtx);
+
+      var _t15Ordinary = {
+        id: 't15-ordinary-1', cert: 'netplus', objective: '1.4', topic: 'Subnetting',
+        title: 'Ordinary scenario', estMinutes: 4,
+        scenario: 'Plain scenario, no archetype tag.',
+        steps: [{ id: 's1', type: 'fillin', points: 1, prompt: 'x?', explanation: 'y', payload: { fields: [{ id: 'a', label: 'A' }] }, answer: { a: ['1'] } }]
+      };
+      var _t15Archetype = {
+        id: 't15-archetype-1', cert: 'netplus', archetype: 'diagram', objective: '1.4', topic: 'Diagram',
+        title: 'Archetype scenario', estMinutes: 4,
+        scenario: 'Archetype-tagged scenario.',
+        steps: [{ id: 's1', type: 'fillin', points: 1, prompt: 'x?', explanation: 'y', payload: { fields: [{ id: 'a', label: 'A' }] }, answer: { a: ['1'] } }]
+      };
+
+      vm.runInContext('window.SIM_LAB_SEED_NETPLUS = [' + JSON.stringify(_t15Ordinary) + ', ' + JSON.stringify(_t15Archetype) + '];', bankCtx);
+      vm.runInContext('globalThis.__bank = _slBank("netplus"); globalThis.__pickAt0 = _slPickSeed; globalThis.__pickFresh = _slPickSeedFresh;', bankCtx);
+
+      var t15Bank = bankCtx.__bank;
+      test('Task 15: mixed bank (ordinary + archetype) loads via the real _slBank resolver',
+        Array.isArray(t15Bank) && t15Bank.length === 2);
+
+      // _slPickSeed indexes by clock minute % bank.length — drive it at both
+      // indices directly to prove BOTH the ordinary and the archetype entries
+      // are reachable through the identical, unfiltered code path (no archetype
+      // branch skips or special-cases the archetype-tagged entry).
+      var _origDate = Date;
+      function _fakeMinuteDate(min) {
+        return function () {
+          var d = new _origDate();
+          d.getMinutes = function () { return min; };
+          return d;
+        };
+      }
+      bankCtx.Date = _fakeMinuteDate(0);
+      vm.runInContext('globalThis.__pick0 = _slPickSeed("netplus");', bankCtx);
+      bankCtx.Date = _fakeMinuteDate(1);
+      vm.runInContext('globalThis.__pick1 = _slPickSeed("netplus");', bankCtx);
+      var _pick0 = bankCtx.__pick0, _pick1 = bankCtx.__pick1;
+
+      test('Task 15: _slPickSeed can select the ordinary (non-archetype) entry',
+        _pick0 && _pick0.id === 't15-ordinary-1' && !_pick0.archetype);
+      test('Task 15: _slPickSeed can select the archetype-tagged entry via the SAME function/index logic',
+        _pick1 && _pick1.id === 't15-archetype-1' && _pick1.archetype === 'diagram');
+
+      // _slPickSeedFresh: prove the archetype entry is a normal member of the
+      // "fresh" pool (usedIds-filtered), not excluded or treated specially.
+      vm.runInContext('globalThis.__freshPool = _slPickSeedFresh("netplus", new Set());', bankCtx);
+      var _freshPick = bankCtx.__freshPool;
+      test('Task 15: _slPickSeedFresh draws from the unfiltered mixed pool (archetype included)',
+        _freshPick && (_freshPick.id === 't15-ordinary-1' || _freshPick.id === 't15-archetype-1'));
+
+      vm.runInContext('globalThis.__usedArch = new Set(["t15-ordinary-1"]); globalThis.__freshAfterOrdinaryUsed = _slPickSeedFresh("netplus", globalThis.__usedArch);', bankCtx);
+      var _freshAfterOrdinaryUsed = bankCtx.__freshAfterOrdinaryUsed;
+      test('Task 15: _slPickSeedFresh falls through to the archetype entry once the ordinary one is marked used (no exclusion)',
+        _freshAfterOrdinaryUsed && _freshAfterOrdinaryUsed.id === 't15-archetype-1');
+    }
+
+    // ── 2. Gating runs BEFORE scenario selection, for both entry points ──
+    // Static-source proof (mirrors the existing v7.57 "exam never calls
+    // _bumpPbqFreeRun" style pin): simLabStart and _slSessionStart both check
+    // _slIsPro()/_pbqFreeRunsToday()/PBQ_FREE_DAILY_CAP and call
+    // window._gateProOnly('Sim Lab', ...) strictly before _slGenerateScenario /
+    // _slRunRound (which is what eventually resolves to _slPickSeed and can
+    // surface an archetype scenario). No archetype-aware branch exists in
+    // either gate — the same gate blocks regardless of what the bank contains.
+    var simLabStartSrc = grab('simLabStart');
+    var slSessionStartSrc = grab('_slSessionStart');
+
+    test('Task 15: simLabStart defined and checks the free-cap/Pro gate before generating a scenario',
+      !!simLabStartSrc &&
+      /_slIsPro\(\)/.test(simLabStartSrc) &&
+      /_pbqFreeRunsToday/.test(simLabStartSrc) &&
+      /PBQ_FREE_DAILY_CAP/.test(simLabStartSrc) &&
+      /_gateProOnly\(\s*'Sim Lab'/.test(simLabStartSrc) &&
+      (function () {
+        var gateIdx = simLabStartSrc.indexOf('_gateProOnly(');
+        var genIdx = simLabStartSrc.indexOf('_slGenerateScenario(');
+        return gateIdx > -1 && genIdx > -1 && gateIdx < genIdx;
+      })());
+
+    test('Task 15: _slSessionStart defined and checks the SAME free-cap/Pro gate before starting a round (which may pick an archetype scenario)',
+      !!slSessionStartSrc &&
+      /_slIsPro\(\)/.test(slSessionStartSrc) &&
+      /_pbqFreeRunsToday/.test(slSessionStartSrc) &&
+      /PBQ_FREE_DAILY_CAP/.test(slSessionStartSrc) &&
+      /_gateProOnly\(\s*'Sim Lab'/.test(slSessionStartSrc) &&
+      /_slSessionBumpOnce\(\)/.test(slSessionStartSrc) &&
+      (function () {
+        var gateIdx = slSessionStartSrc.indexOf('_gateProOnly(');
+        var runIdx = slSessionStartSrc.indexOf('_slRunRound(');
+        return gateIdx > -1 && runIdx > -1 && gateIdx < runIdx;
+      })());
+
+    // No archetype-specific gate/metering identifiers exist anywhere in the
+    // feature module — confirms Task 15 introduced no new gating surface.
+    test('Task 15: no archetype-specific gating/metering was added (reuse only)',
+      !/archetype[A-Za-z]*(FreeCount|FreeRun|Gate|Metered|Quota)/i.test(js) &&
+      !/(FreeCount|FreeRun|Gate|Metered|Quota)[A-Za-z]*[Aa]rchetype/.test(js));
+
+    // ── 3. Session bump path is archetype-agnostic ──
+    // _slSessionBumpOnce (called from _slSessionStart) always calls the SAME
+    // window._bumpPbqFreeRun — it has no knowledge of which scenario/archetype
+    // will be served this session, proving the metering key is shared.
+    var sessionBumpOnceSrc = grab('_slSessionBumpOnce');
+    test('Task 15: _slSessionBumpOnce calls the existing window._bumpPbqFreeRun (no new/second counter)',
+      !!sessionBumpOnceSrc && /window\._bumpPbqFreeRun\(\)/.test(sessionBumpOnceSrc));
+
+  } catch (err) {
+    test('Task 15: vm smoke test (threw)', false);
+    results.errors.push('Task 15 archetype-gating smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -22586,6 +22586,167 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Task 17 (PBQ archetypes plan): archetype scenarios inside Exam mode ──
+// Confirms — behaviorally — that an archetype-tagged scenario (here: a
+// 'diagram' scenario with a configure×3 step, mirroring the Task 11 fixture)
+// flows correctly through the EXISTING Exam-mode block: picked into a round
+// via _slExamBlankState (the same session-state constructor _slExamStart
+// uses), survives flag-and-return navigation (_slToggleFlag + the
+// capture/restore pattern _slExamNav uses via _slCloneResp), gets scored via
+// the SAME simLabScoreScenario call _slExamSubmit makes per round, and rolls
+// up into the SAME _slAggregateSession the exam result screen reads. No new
+// exam/scoring code is introduced — archetype scenarios ride the existing
+// multi-round exam block by construction (scoring only ever inspects
+// step.type / step.answer, never scenario.archetype).
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: archetypes in Exam mode (Task 17) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    var blankStateBody   = grab('_slExamBlankState');
+    var isProBody        = grab('_slIsPro');
+    var cloneRespBody    = grab('_slCloneResp');
+    var scoreSlotsBody   = grab('_scoreConfigureSlots');
+    var scoreStepBody    = grab('_scoreStep');
+    var scoreScenarioBody = grab('simLabScoreScenario');
+    var aggregateBody    = grab('_slAggregateSession');
+    var normBody          = grab('_norm');
+    var normalizeMatchBody = grab('_simLabNormalizeMatch');
+    var arrEqBody         = grab('_arrEq');
+    var setEqBody         = grab('_setEq');
+
+    if (!blankStateBody || !scoreScenarioBody || !scoreSlotsBody || !scoreStepBody || !aggregateBody || !cloneRespBody) {
+      test('Task 17: exam/scoring vm extraction succeeded', false);
+      results.errors.push('could not extract _slExamBlankState/simLabScoreScenario/_slAggregateSession for Task 17 test; check names/indenting');
+      return;
+    }
+
+    var eCtx = { window: { CURRENT_CERT: 'netplus' }, Set: Set, Object: Object, Array: Array, String: String, Date: Date };
+    vm.createContext(eCtx);
+    // _slExamBlankState calls _slIsPro() — stub it in-context (irrelevant to scoring).
+    vm.runInContext('function _slIsPro() { return true; }', eCtx);
+    vm.runInContext(blankStateBody, eCtx);
+    vm.runInContext(cloneRespBody, eCtx);
+    vm.runInContext(normBody, eCtx);
+    vm.runInContext(normalizeMatchBody, eCtx);
+    vm.runInContext(arrEqBody, eCtx);
+    vm.runInContext(setEqBody, eCtx);
+    vm.runInContext(scoreSlotsBody, eCtx);
+    vm.runInContext(scoreStepBody, eCtx);
+    vm.runInContext(scoreScenarioBody, eCtx);
+    vm.runInContext(aggregateBody, eCtx);
+    vm.runInContext('globalThis.__blank = _slExamBlankState; globalThis.__score = simLabScoreScenario; globalThis.__agg = _slAggregateSession; globalThis.__clone = _slCloneResp;', eCtx);
+    var _slExamBlankState17  = eCtx.__blank;
+    var simLabScoreScenario17 = eCtx.__score;
+    var _slAggregateSession17 = eCtx.__agg;
+    var _slCloneResp17        = eCtx.__clone;
+
+    // Round 0: ordinary (non-archetype) order-step scenario.
+    var t17Ordinary = {
+      id: 't17-ordinary-1', cert: 'netplus', topic: 'Cabling',
+      scenario: 'Order the steps to terminate a Cat6 cable.', estMinutes: 2,
+      steps: [{
+        id: 'ord1', type: 'order', prompt: 'Order the steps.', explanation: 'Standard termination order.', points: 1,
+        payload: { items: ['Strip', 'Untwist', 'Crimp'] },
+        answer: { correctOrder: ['Strip', 'Untwist', 'Crimp'] }
+      }]
+    };
+
+    // Round 1: 'diagram' archetype scenario with a configure×3 step (per-slot
+    // scoring), mirroring the Task 11 fixture shape.
+    var t17Archetype = {
+      id: 't17-archetype-1', cert: 'netplus', archetype: 'diagram', topic: 'Diagram',
+      scenario: 'Correct PC-2’s misconfigured IP settings.', estMinutes: 4,
+      assets: { reference: { kind: 'network', devices: [], given: {} } },
+      steps: [{
+        id: 'fix1', type: 'configure', prompt: 'Correct PC-2’s IP configuration.', explanation: 'PC-2 was on the wrong VLAN.', points: 1,
+        deviceId: 'pc2',
+        payload: {
+          slots: [
+            { id: 'ip', label: 'IP Address', options: [{ id: 'ip_bad', text: '192.168.20.45' }, { id: 'ip_good', text: '192.168.10.45' }] },
+            { id: 'mask', label: 'Subnet Mask', options: [{ id: 'm_good', text: '255.255.255.0' }, { id: 'm_bad', text: '255.255.0.0' }] },
+            { id: 'gateway', label: 'Gateway', options: [{ id: 'gw_good', text: '192.168.10.1' }, { id: 'gw_bad', text: '192.168.20.1' }] }
+          ]
+        },
+        answer: { slots: { ip: 'ip_good', mask: 'm_good', gateway: 'gw_good' } }
+      }]
+    };
+
+    var t17Scenarios = [t17Ordinary, t17Archetype];
+    var t17Budget = 6 * 0.9 * 60000;
+    var sess = _slExamBlankState17(t17Scenarios, t17Budget);
+
+    test('Task 17: _slExamBlankState builds a 2-round exam session containing the archetype scenario',
+      sess && sess.mode === 'exam' && sess.rounds === 2 && sess.scenarios[1].archetype === 'diagram');
+
+    // ── Flag-and-return: flag round 1 (the archetype round), navigate away to
+    // round 0, then back — mirrors _slToggleFlag + _slExamNav's capture/restore
+    // (window.__slResponses -> answers[idx] via _slCloneResp) without needing
+    // the DOM mount path, since flag state and answer capture are pure data. ──
+    sess.flagged.add(1);
+    test('Task 17: flagging round 1 (archetype round) is tracked in session.flagged',
+      sess.flagged.has(1) === true);
+
+    // Simulate answering round 1 (archetype), navigating to round 0, back to 1
+    // — answers persist across nav (the real bug this would catch: an
+    // archetype's configure response getting dropped/overwritten on flag-return).
+    sess.answers[1] = _slCloneResp17({ fix1: { slots: { ip: 'ip_good', mask: 'm_good', gateway: 'gw_good' } } });
+    sess.idx = 0;   // navigated away
+    sess.idx = 1;   // navigated back (flag-and-return)
+    test('Task 17: archetype round answer survives flag-and-return navigation',
+      sess.answers[1] && sess.answers[1].fix1 && sess.answers[1].fix1.slots.ip === 'ip_good');
+
+    // Answer round 0 (ordinary) correctly too.
+    sess.answers[0] = _slCloneResp17({ ord1: { order: ['Strip', 'Untwist', 'Crimp'] } });
+
+    test('Task 17: flagged set is preserved through submit-time (flag-and-return does not clear flags)',
+      sess.flagged.has(1) === true);
+
+    // ── Submit: mirrors _slExamSubmit's exact per-round scoring loop ──
+    sess.results = sess.scenarios.map(function (scn, i) {
+      var resp = sess.answers[i] || {};
+      var score = simLabScoreScenario17(scn, resp);
+      return { scenario: scn, score: score, passed: score.fraction === 1 };
+    });
+
+    test('Task 17: archetype round scores correct === total via simLabScoreScenario (configure per-slot all correct)',
+      sess.results[1].score.correct === 3 && sess.results[1].score.total === 3 && sess.results[1].passed === true);
+    test('Task 17: archetype round perStep reflects per-slot configure breakdown ({total,correct} for the configure step)',
+      sess.results[1].score.perStep.fix1 && sess.results[1].score.perStep.fix1.total === 3 && sess.results[1].score.perStep.fix1.correct === 3);
+    test('Task 17: ordinary round also scores correctly (both rounds correct)',
+      sess.results[0].passed === true);
+
+    var agg = _slAggregateSession17(sess.results);
+    test('Task 17: _slAggregateSession reports correct === total across the exam block (2/2 rounds passed, 4/4 steps incl. 3 configure slots)',
+      agg.passed === 2 && agg.rounds === 2 && agg.stepsCorrect === 4 && agg.stepsTotal === 4 && agg.pct === 100);
+
+    // ── Negative control: one wrong configure slot in the archetype round
+    // must NOT score correct===total and must drag the aggregate below 100%,
+    // proving the assertions above aren't vacuously true. ──
+    var sess2 = _slExamBlankState17(t17Scenarios, t17Budget);
+    sess2.answers[0] = _slCloneResp17({ ord1: { order: ['Strip', 'Untwist', 'Crimp'] } });
+    sess2.answers[1] = _slCloneResp17({ fix1: { slots: { ip: 'ip_bad', mask: 'm_good', gateway: 'gw_good' } } });
+    sess2.results = sess2.scenarios.map(function (scn, i) {
+      var resp = sess2.answers[i] || {};
+      var score = simLabScoreScenario17(scn, resp);
+      return { scenario: scn, score: score, passed: score.fraction === 1 };
+    });
+    var agg2 = _slAggregateSession17(sess2.results);
+    test('Task 17 negative control: one wrong configure slot drops the archetype round below perfect and the aggregate below 100%',
+      sess2.results[1].score.correct === 2 && sess2.results[1].passed === false &&
+      agg2.passed === 1 && agg2.stepsCorrect === 3 && agg2.stepsTotal === 4 && agg2.pct !== 100);
+
+  } catch (err) {
+    test('Task 17: exam-mode archetype smoke test (threw)', false);
+    results.errors.push('Task 17 exam-mode archetype smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Summary ──
 console.log('\n' + '═'.repeat(50));
 const total = results.pass + results.fail;


### PR DESCRIPTION
## Sim Lab PBQ Archetypes — Diagram (Net+), Incident Response (Sec+), Defense in Depth (Net+ & Sec+)

Adds three new **Sim Lab PBQ scenario archetypes** on one shared engine in `features/sim-lab.js`, plus 46 exam-authored, consensus-gated seed scenarios. Ships as **v7.61.0**.

Built subagent-driven from the approved plan (`docs/superpowers/plans/2026-06-30-sim-lab-pbq-implementation.md`), one implementer + spec/quality review per task, a two-agent consensus gate for all content, and a final whole-branch review.

### What's in it
**Engine (Phases 1–4)**
- `configure` step type — per-slot native `<select>` dropdowns with per-slot partial-credit scoring (backward-compatible: `STEP_TYPES` appended, existing 5 types untouched).
- Pluggable visual `reference` assets rendered above steps, with data-driven SVG renderers: `network` (diagram + incident overlay), `timeline` (attack stages), and `layered` defense-in-depth in two layouts — **nested-frames** (Net+) and **stacked-bands** (Sec+), selected by an optional `layout` field (faithful lift of each cert's mockup).
- `simLabValidateNetworkFidelity` — deterministic Net+ subnetting/CIDR validator (confirms the flagged device is out-of-subnet pre-fix and the correct answer re-homes it in-subnet; rejects scenarios whose "correct" answer is itself out-of-subnet).
- Optional `archetype` tag; end-to-end vertical slice through the existing Practice path (no new mode).

**Content (Phase 5) — two-agent consensus gate (hard rule)**
- 16 Net+ Diagram, 20 Sec+ Incident Response, 10 Defense-in-Depth (5 Net+ / 5 Sec+) = **46 scenarios**.
- Every scenario passed **both** a domain-engineer agent **and** a CompTIA-examiner agent (revise-until-consensus); Net+ diagrams additionally cleared the deterministic subnetting validator. New UAT tests assert every archetype scenario in the banks passes the real validators (non-vacuous — verified via mutation testing).

**Integration (Phase 6)**
- Free-1/day + Pro gating, cert-aware entry, and Exam mode all confirmed **reuse-by-construction** (RED-proven tests; no new gating/mode code).
- **Live browser verification** of all three renderers on localhost. Caught + fixed a real live-only bug: the layered missing-layer/exposed-core, timeline crit/high severity, and configure wrong-answer highlight all rendered **black** because the CSS used an undefined `var(--fail)` token — remapped to the defined `var(--red)`.

### Verification
- `node tests/uat.js` → **4436/4436 ALL PASS** (was 4353 at branch base; +83 behavioral checks).
- `node tests/tech-debt.js` → clean.
- `npm run test:ios` (WebKit + mobile-safari Playwright) → **10 passed, 0 failed**.
- All three renderers driven live in-browser (desktop + 375px mobile): render correctly, native selects work, scenarios score, no console errors, no horizontal overflow, reduced-motion respected (attack-flow animation gated behind `prefers-reduced-motion: no-preference`).

### Lane & notes
- **Fast lane** (JS + content + CSS). `sw.js` change is the normal `bump-version.js` cache-name rotation only — no functional service-worker change. PR (rather than direct push) given the size.
- Final whole-branch review: **READY** — no Critical/Important code issues (contracts aligned across validation↔scoring↔renderer↔mount↔fidelity, XSS-safe via `_esc`/`textContent`, `--fail` fully eliminated, no reskin leakage into `styles.css`).

### Deferred (Minor, non-blocking)
- Long Defense-in-Depth missing-layer labels can clip at the SVG right edge (SVG text doesn't wrap) — cosmetic, verbose labels only.
- Dormant `.sl-cfg-select.is-correct` rule references pre-existing undefined `var(--pass)` (class never applied by the renderer).
- Minor test-helper dedup (`grab`/`grab16`) and a naming-heuristic gating assertion.

### Layered layout (resolved)
Sec+ Defense-in-Depth now renders in the mockup's **stacked-bands** layout (perimeter frame + stacked interior layer-bands + exposed core), while Net+ keeps **nested-frames** — each a faithful lift of its own mockup, selected by the `layout` field. Both verified live in-browser (UAT 4436/4436).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
