### PR TITLE
Sim Lab Wave 2 PBQs: CLI Fault Isolation, Discovery Audit, Evidence Triage (v7.63.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Initial archive during the v4.42.3 reorg (2026-04-16). Re-trimmed in the v4.52.0
 |---|---|
 | v7.61.0 | Sim Lab PBQ archetypes — Diagram (Net+), Incident Response (Sec+), Defense in Depth (Net+ nested-frames / Sec+ stacked-bands): configure step type + per-slot partial credit, network/timeline/layered SVG reference renderers, deterministic subnetting fidelity validator, 46 two-agent-gated seed scenarios, reuse of free/Pro gating + cert-aware entry + Exam mode |
 | v7.60.0 | Per-cert milestones + 12 drill milestones (Sim Lab/Decision Lab/Why-Not/Gauntlet) + orphan cleanup + bronze celebration toast |
+| v7.60.0 | Per-cert milestones + 12 drill milestones (Sim Lab/Decision Lab/Why-Not/Gauntlet) + orphan cleanup + bronze celebration toast |
 | v7.59.0 | Decision Lab: cloud-cert scenario decision drill (engine + 4 seed banks) |
 | v7.58.0 | Sim Lab: A+ Core 1 (220-1201) + Core 2 (220-1202) PBQ seed banks live (cert rollout) |
 | v7.57.2 | Sim Lab entry target: derive cert label from pack name+code (Sec+ shows Security+ SY0-701, not bare Mixed) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,11 +115,11 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.63.0 | Sim Lab Wave 2 PBQs: CLI Fault Isolation, Network Discovery Audit, Command-Output Evidence Triage |
 | v7.62.0 | Sim Lab Wave 1 PBQs: Wireless Deployment, Firewall Rule Table, SOHO Router |
 | v7.61.0 | Sim Lab PBQ archetypes: Diagram, Incident Response, Defense in Depth |
-| v7.60.0 | Per-cert milestones + 12 drill milestones (Sim Lab/Decision Lab/Why-Not/Gauntlet) + orphan cleanup + bronze celebration toast |
 
-_Older releases (v7.59.0 and back) live in [CHANGELOG.md](./CHANGELOG.md). The v7.60.1–v7.60.5 CSS `?v=` cache-bump stubs from the PBQ-archetypes build were collapsed into this single v7.61.0 ship at consolidation._
+_Older releases (v7.60.0 and back) live in [CHANGELOG.md](./CHANGELOG.md)._
 
 ## CSS Theme System
 Dark theme in `:root`, light theme in `[data-theme="light"]`. Key variables: `--bg`, `--surface`, `--accent`, `--text`, `--green`, `--red`, `--yellow`. Toggle via `toggleTheme()`. Semantic status aliases `--pass`/`--fail`/`--warn` (→ `--green`/`--red`/`--yellow`) are defined in every `dg-system.css` token block; a UAT ratchet guard fails any NEW undefined `var(--x)` referenced in `dg-system.css`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ _Older releases (v7.59.0 and back) live in [CHANGELOG.md](./CHANGELOG.md). The v
 
 ## CSS Theme System
 Dark theme in `:root`, light theme in `[data-theme="light"]`. Key variables: `--bg`, `--surface`, `--accent`, `--text`, `--green`, `--red`, `--yellow`. Toggle via `toggleTheme()`. Semantic status aliases `--pass`/`--fail`/`--warn` (→ `--green`/`--red`/`--yellow`) are defined in every `dg-system.css` token block; a UAT ratchet guard fails any NEW undefined `var(--x)` referenced in `dg-system.css`.
+The Sim Lab terminal reference (`.term*`) tokens live in `dg-system.css` (Wave 2), mapped onto `--text`/`--text-mid`/`--border` per the file's existing mockup-token precedent.
 
 ## Common Gotchas
 

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.62.0
+// Network+ AI Quiz — app.js  v7.63.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.62.0';
+const APP_VERSION = '7.63.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/dg-system.css
+++ b/dg-system.css
@@ -4435,3 +4435,40 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 #page-sim-lab .sl-fw-box,#page-decision-lab .sl-fw-box{fill:var(--surface);stroke:var(--border);stroke-width:1.2}
 #page-sim-lab .sl-fw-nm,#page-decision-lab .sl-fw-nm{font:700 11px Inter,sans-serif;fill:var(--text);text-anchor:middle}
 #page-sim-lab .sl-fw-glyph,#page-decision-lab .sl-fw-glyph{stroke:var(--accent);stroke-width:1.7;fill:none}
+
+/* ════════════════════════════════════════════════════════════════════════
+   SIM LAB · terminal / output-excerpt reference (Wave 2 — Task 7)
+   ────────────────────────────────────────────────────────────────────────
+   Faithful STYLE lift of the approved mockups' .term* terminal renderer.
+   Mockup tokens mapped to this file's already-DEFINED tokens (same
+   precedent as the Task 6 block above): --ink→--text, --ink-soft→--text-mid,
+   --muted→--text-mid, --border-soft→--border, --ease→literal `ease` timing
+   function. Tokens only, 0 hardcoded hex; color-mix() is allowed. */
+.term { margin: 8px 0; background: color-mix(in oklab, var(--text) 7%, var(--surface)); border: 1px solid var(--border); border-radius: 13px; overflow: hidden; }
+.term-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 13px; border-bottom: 1px solid var(--border); background: color-mix(in oklab, var(--text) 5%, transparent); }
+.term-host { display: flex; align-items: center; gap: 8px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11px; font-weight: 700; color: var(--text-mid); }
+.term-host .lamp { display: grid; grid-template-columns: repeat(3, 5px); gap: 3px; }
+.term-host .lamp i { width: 5px; height: 5px; border-radius: 50%; background: color-mix(in oklab, var(--text-mid) 45%, transparent); }
+.term-sess { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10.5px; font-weight: 600; color: var(--text-mid); }
+.term-body { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; line-height: 1.5; color: var(--text-mid); padding: 4px 0 6px; max-height: 430px; overflow-y: auto; }
+.term-empty { padding: 30px 16px; color: var(--text-mid); font-size: 12px; text-align: center; font-style: italic; }
+.term-block { padding: 7px 6px 9px; }
+.term-block + .term-block { border-top: 1px dashed var(--border); }
+.term-scroll { overflow-x: auto; padding: 0 11px; }
+.term-cmd { white-space: pre; color: var(--text); font-weight: 700; }
+.term-cmd .pmt { color: var(--accent); }
+.term-out { white-space: pre; margin-top: 3px; }
+.term-out .k, .term-ctx { color: var(--text-mid); }
+.term-out .hot, .term-line .hot { color: var(--fail); font-weight: 700; }
+.term-out .good, .term-line .good { color: var(--text); font-weight: 700; }
+.term-ln { white-space: pre; }
+.term-line { display: block; width: 100%; text-align: left; white-space: pre; font: inherit; color: var(--text-mid); background: transparent; border: 1px solid transparent; border-radius: 6px; padding: 1px 5px; cursor: pointer; }
+.term-line:focus-visible { outline: none; border-color: color-mix(in oklab, var(--accent) 55%, var(--border)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 16%, transparent); }
+.term-line.sl-sel { border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); background: color-mix(in oklab, var(--accent) 10%, transparent); }
+.term-tabs { display: flex; flex-wrap: wrap; gap: 6px; padding: 9px 11px 3px; }
+.term-tab { font-family: ui-monospace, Menlo, monospace; font-size: 11px; font-weight: 700; color: var(--text-mid); background: transparent; border: 1px solid var(--border); border-radius: 7px; padding: 4px 9px; cursor: pointer; }
+.term-tab.on { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 34%, var(--border)); background: color-mix(in oklab, var(--accent) 9%, transparent); }
+.term-tab.seen::after { content: " ✓"; color: var(--pass); }
+.term-anim { animation: termIn .34s ease; }
+@keyframes termIn { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .term-anim { animation: none !important; } }

--- a/features/sim-lab-seed-aplus-core1.js
+++ b/features/sim-lab-seed-aplus-core1.js
@@ -1875,5 +1875,609 @@ window.SIM_LAB_SEED_APLUS_CORE1 = [
         ] },
         answer: { slots: { dhcpStart: 'sg', dhcpEnd: 'eg', extPort: 'ext', fwdTo: 'fg' } } }
     ]
-  }
+  },
+  // ---------- APIPA (4) — objective 2.5 (Compare common network configuration concepts) ----------
+  {
+    id: 'a1-cot-01', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — client IP addressing',
+    title: 'Home user: "the internet just stopped working" on a wired desktop', estMinutes: 6,
+    scenario: 'A home user calls in saying their wired desktop PC "can\'t get on the internet" this morning, though it worked fine yesterday. Nothing else changed in the house. You have them run ipconfig /all and a ping to a known-good site over the phone. Review the output, flag the lines that are actual evidence of the fault, then diagnose it.',
+    triage: { fault: 'apipa' },
+    assets: { reference: { kind: 'terminal', host: 'DESKTOP-HOME1', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Windows IP Configuration' },
+        { id: 'l2', select: false, ctx: true, text: '   Host Name . . . . . . . . . . . : DESKTOP-HOME1' },
+        { id: 'l3', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l4', select: true, evidence: false, text: '   Media State . . . . . . . . . . : Media connected' },
+        { id: 'l5', select: false, ctx: true, text: '   Description . . . . . . . . . . : Realtek PCIe GbE Family Controller' },
+        { id: 'l6', select: true, evidence: true, text: '   Autoconfiguration Enabled . . . : Yes' },
+        { id: 'l7', select: true, evidence: true, text: '   IPv4 Address. . . . . . . . . . : 169.254.83.12(Preferred)' },
+        { id: 'l8', select: false, ctx: true, text: '   Subnet Mask . . . . . . . . . . : 255.255.0.0' },
+        { id: 'l9', select: true, evidence: true, text: '   Default Gateway                  :' },
+        { id: 'l10', select: false, ctx: true, text: '   DHCP Enabled. . . . . . . . . . : Yes' }
+      ] },
+      { id: 'ping', promptLine: 'ping 8.8.8.8', lines: [
+        { id: 'l11', select: false, ctx: true, text: 'Pinging 8.8.8.8 with 32 bytes of data:' },
+        { id: 'l12', select: false, ctx: true, text: 'PING: transmit failed. General failure.' },
+        { id: 'l13', select: false, ctx: true, text: 'PING: transmit failed. General failure.' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that are evidence of why this PC has no internet.',
+        explanation: 'A 169.254.x.x address with no default gateway and autoconfiguration enabled is the classic self-assigned APIPA address the OS falls back to when it cannot reach a DHCP server. "Media connected" only proves the cable/link is up — it does not explain the missing internet, so it is not evidence of this fault.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l6', 'l7', 'l9'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'The 169.254.x.x address confirms the NIC gave up waiting on DHCP and self-assigned an APIPA address — no usable default gateway exists at that address. Releasing and renewing the lease (or power-cycling the router if renew keeps failing) is the correct first move, not replacing hardware.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'No DHCP response received; NIC self-assigned an APIPA (169.254.x.x) address' },
+            { id: 'b', text: 'The Ethernet cable is physically damaged' },
+            { id: 'c', text: 'A firewall rule is blocking all outbound traffic' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Run ipconfig /release then ipconfig /renew to request a fresh DHCP lease' },
+            { id: 'b', text: 'Replace the Ethernet cable' },
+            { id: 'c', text: 'Reinstall the operating system' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-02', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — client IP addressing',
+    title: 'Small office: one laptop can\'t reach the shared printer or internet over Wi-Fi', estMinutes: 6,
+    scenario: 'In a 6-person office, one employee\'s laptop suddenly can\'t print to the network printer or browse the web, while every other coworker on the same Wi-Fi is fine. You remote in and pull ipconfig /all and a ping to the router. Flag the evidence, then diagnose and pick the fix.',
+    triage: { fault: 'apipa' },
+    assets: { reference: { kind: 'terminal', host: 'LAPTOP-EMP07', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Wireless LAN adapter Wi-Fi:' },
+        { id: 'l2', select: true, evidence: false, text: '   Connection-specific DNS Suffix  . :' },
+        { id: 'l3', select: false, ctx: true, text: '   Description . . . . . . . . . . : Intel(R) Wi-Fi 6 AX201' },
+        { id: 'l4', select: true, evidence: true, text: '   Autoconfiguration Enabled . . . : Yes' },
+        { id: 'l5', select: true, evidence: true, text: '   IPv4 Address. . . . . . . . . . : 169.254.211.4(Preferred)' },
+        { id: 'l6', select: false, ctx: true, text: '   Subnet Mask . . . . . . . . . . : 255.255.0.0' },
+        { id: 'l7', select: true, evidence: true, text: '   Default Gateway                  :' },
+        { id: 'l8', select: false, ctx: true, text: '   DHCP Server . . . . . . . . . . :' },
+        { id: 'l9', select: false, ctx: true, text: '   Physical Address. . . . . . . . : 3C-58-C2-11-A9-77' }
+      ] },
+      { id: 'ping', promptLine: 'ping 192.168.1.1', lines: [
+        { id: 'l10', select: false, ctx: true, text: 'Pinging 192.168.1.1 with 32 bytes of data:' },
+        { id: 'l11', select: false, ctx: true, text: 'Reply from 169.254.211.4: Destination host unreachable.' },
+        { id: 'l12', select: false, ctx: true, text: 'Reply from 169.254.211.4: Destination host unreachable.' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that are evidence of why this one laptop lost network access.',
+        explanation: 'The IPv4 address in the 169.254.x.x range, autoconfiguration enabled, and a blank default gateway together confirm the laptop never got a real lease from the office router and fell back to APIPA. A blank DNS suffix is normal/cosmetic on plenty of healthy machines and proves nothing about this fault on its own.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l4', 'l5', 'l7'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'A single machine failing to get a lease while peers succeed points to that host\'s DHCP negotiation failing, not a router-wide outage — the fix is to force a fresh release/renew on the affected laptop first.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'Laptop failed to receive a DHCP lease and self-assigned an APIPA address' },
+            { id: 'b', text: 'The office router\'s firmware crashed' },
+            { id: 'c', text: 'The printer\'s IP address changed' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'ipconfig /release and ipconfig /renew on the affected laptop' },
+            { id: 'b', text: 'Reboot the network printer' },
+            { id: 'c', text: 'Change the laptop\'s DNS suffix' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-03', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — client IP addressing',
+    title: 'Freelancer\'s desktop loses connectivity after an overnight power blip', estMinutes: 6,
+    scenario: 'A freelance designer says their desktop was fine last night, but after a brief power flicker overnight nothing loads this morning. The router\'s lights look normal. You ask them to run ipconfig /all and ping the router\'s address. Flag the evidence, then diagnose.',
+    triage: { fault: 'apipa' },
+    assets: { reference: { kind: 'terminal', host: 'DESKTOP-FREELANCE', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: true, evidence: false, text: '   Media State . . . . . . . . . . : Media connected' },
+        { id: 'l3', select: false, ctx: true, text: '   Description . . . . . . . . . . : Killer E3000 Gigabit Ethernet Controller' },
+        { id: 'l4', select: true, evidence: true, text: '   Autoconfiguration Enabled . . . : Yes' },
+        { id: 'l5', select: true, evidence: true, text: '   IPv4 Address. . . . . . . . . . : 169.254.19.201(Preferred)' },
+        { id: 'l6', select: false, ctx: true, text: '   Subnet Mask . . . . . . . . . . : 255.255.0.0' },
+        { id: 'l7', select: true, evidence: true, text: '   Default Gateway                  :' },
+        { id: 'l8', select: false, ctx: true, text: '   Lease Obtained. . . . . . . . . : N/A' }
+      ] },
+      { id: 'ping', promptLine: 'ping 192.168.0.1', lines: [
+        { id: 'l9', select: false, ctx: true, text: 'Pinging 192.168.0.1 with 32 bytes of data:' },
+        { id: 'l10', select: false, ctx: true, text: 'PING: transmit failed. General failure.' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why the desktop has no connectivity this morning.',
+        explanation: 'The 169.254.x.x address, autoconfiguration enabled, and empty default gateway together prove the router\'s DHCP service was not reachable when the PC last tried to renew — likely because the router itself was still rebooting after the power blip. "Media connected" only shows the cable link is physically up, which is true here and irrelevant to the address problem.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l4', 'l5', 'l7'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'A self-assigned APIPA address after a power event most often means the DHCP server (the router) was down or still booting at lease-renewal time. Renewing the lease now that the router should be back up is the correct first move.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'DHCP request failed and the PC self-assigned an APIPA address' },
+            { id: 'b', text: 'The Ethernet NIC driver is corrupted' },
+            { id: 'c', text: 'A duplicate IP address exists on the network' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Run ipconfig /release then ipconfig /renew to re-request a DHCP lease' },
+            { id: 'b', text: 'Update the NIC driver' },
+            { id: 'c', text: 'Assign a static IP address permanently' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-04', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — client IP addressing',
+    title: 'Laptop on guest Wi-Fi shows connected but nothing loads', estMinutes: 6,
+    scenario: 'A guest at a small clinic says their Windows laptop shows "connected" to the guest Wi-Fi but no web pages load. Front desk asks you to check it over a remote session. You capture ipconfig /all plus a ping. Flag the evidence, then diagnose.',
+    triage: { fault: 'apipa' },
+    assets: { reference: { kind: 'terminal', host: 'GUEST-LAPTOP', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Wireless LAN adapter Wi-Fi:' },
+        { id: 'l2', select: false, ctx: true, text: '   Description . . . . . . . . . . : Qualcomm QCA9377 Wireless Network Adapter' },
+        { id: 'l3', select: true, evidence: false, text: '   Physical Address. . . . . . . . : A4-C3-F0-88-12-6E' },
+        { id: 'l4', select: true, evidence: true, text: '   Autoconfiguration Enabled . . . : Yes' },
+        { id: 'l5', select: true, evidence: true, text: '   IPv4 Address. . . . . . . . . . : 169.254.44.90(Preferred)' },
+        { id: 'l6', select: false, ctx: true, text: '   Subnet Mask . . . . . . . . . . : 255.255.0.0' },
+        { id: 'l7', select: true, evidence: true, text: '   Default Gateway                  :' }
+      ] },
+      { id: 'ping', promptLine: 'ping guestgateway.local', lines: [
+        { id: 'l8', select: false, ctx: true, text: 'Ping request could not find host guestgateway.local. Please check the name and try again.' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that are evidence of why the laptop appears connected but nothing loads.',
+        explanation: 'A 169.254.x.x address with autoconfiguration on and no default gateway proves the guest device never obtained a real lease from the guest SSID\'s DHCP scope, even though the radio link ("connected") is up. The physical (MAC) address is device identity, not evidence of an addressing fault.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l4', 'l5', 'l7'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'This is textbook APIPA: link/association succeeded but DHCP never handed out a lease, possibly because the guest scope is exhausted or the AP\'s DHCP relay is misconfigured. The first move on the affected client is still to force a fresh DHCP request before escalating to the network side.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'Device associated to Wi-Fi but never received a DHCP lease; it self-assigned an APIPA address' },
+            { id: 'b', text: 'The guest SSID uses the wrong Wi-Fi security protocol' },
+            { id: 'c', text: 'The laptop\'s Wi-Fi radio is defective' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Forget the network and reconnect, or release/renew the IP, to request a fresh DHCP lease' },
+            { id: 'b', text: 'Reinstall the laptop\'s operating system' },
+            { id: 'c', text: 'Change the guest SSID password' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  // ---------- DEAD DNS (4) — objective 2.5 (Compare common network configuration concepts) ----------
+  {
+    id: 'a1-cot-05', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — DNS resolution',
+    title: 'Home user: websites won\'t load by name but streaming apps still work', estMinutes: 6,
+    scenario: 'A home user reports that typing web addresses into the browser gives "can\'t find this page" errors, but their smart TV streaming apps (which use their own internal servers, not the browser) still work fine. You have them run ipconfig /all, ping a site by name, and an nslookup. Flag the evidence, then diagnose.',
+    triage: { fault: 'deadDns' },
+    assets: { reference: { kind: 'terminal', host: 'DESKTOP-HOME2', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: true, evidence: false, text: '   Media State . . . . . . . . . . : Media connected' },
+        { id: 'l3', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 192.168.1.55(Preferred)' },
+        { id: 'l4', select: false, ctx: true, text: '   Default Gateway . . . . . . . . : 192.168.1.1' },
+        { id: 'l5', select: false, ctx: true, text: '   DHCP Server . . . . . . . . . . : 192.168.1.1' },
+        { id: 'l6', select: false, ctx: true, text: '   DNS Servers . . . . . . . . . . : 192.168.1.1' }
+      ] },
+      { id: 'ping', promptLine: 'ping www.example.com', lines: [
+        { id: 'l7', select: true, evidence: true, text: 'Ping request could not find host www.example.com. Please check the name and try again.' }
+      ] },
+      { id: 'pingip', promptLine: 'ping 93.184.216.34', lines: [
+        { id: 'l8', select: false, ctx: true, text: 'Pinging 93.184.216.34 with 32 bytes of data:' },
+        { id: 'l9', select: false, ctx: true, text: 'Reply from 93.184.216.34: bytes=32 time=21ms TTL=54' },
+        { id: 'l10', select: false, ctx: true, text: 'Reply from 93.184.216.34: bytes=32 time=19ms TTL=54' }
+      ] },
+      { id: 'nslookup', promptLine: 'nslookup www.example.com', lines: [
+        { id: 'l11', select: false, ctx: true, text: 'Server:  UnKnown' },
+        { id: 'l12', select: false, ctx: true, text: 'Address:  192.168.1.1' },
+        { id: 'l13', select: true, evidence: true, text: 'DNS request timed out.' },
+        { id: 'l14', select: true, evidence: true, text: '*** Request to UnKnown timed-out' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why web addresses won\'t resolve while raw IPs still work.',
+        explanation: 'Pinging the site by name fails to resolve, and nslookup against the configured DNS server times out entirely — while a ping straight to the site\'s IP address succeeds, proving the network path itself is fine and only name resolution is broken. "Media connected" only confirms the link is up, which is not in question here.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l7', 'l13', 'l14'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'IP connectivity works but name lookups time out against the configured DNS server, so the DNS server itself is unreachable or down — not a routing or cabling problem. Flushing the resolver cache and testing an alternate DNS server (e.g., 8.8.8.8) is the appropriate first move.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The configured DNS server is unreachable, so name resolution is failing' },
+            { id: 'b', text: 'The default gateway is down' },
+            { id: 'c', text: 'The Ethernet cable is unplugged' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Run ipconfig /flushdns and try an alternate DNS server such as 8.8.8.8' },
+            { id: 'b', text: 'Replace the network cable' },
+            { id: 'c', text: 'Restart the smart TV' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-06', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — DNS resolution',
+    title: 'Small office: everyone can email internally but nobody can browse out', estMinutes: 6,
+    scenario: 'Office staff report that internal email (which uses a hostname on the local mail server, cached in DNS earlier this morning) still works, but every external website fails to load for all 6 users at once. You remote into one workstation and pull ipconfig /all, ping by name, and nslookup. Flag the evidence, then diagnose.',
+    triage: { fault: 'deadDns' },
+    assets: { reference: { kind: 'terminal', host: 'LAPTOP-EMP03', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 10.10.0.42(Preferred)' },
+        { id: 'l3', select: false, ctx: true, text: '   Default Gateway . . . . . . . . : 10.10.0.1' },
+        { id: 'l4', select: true, evidence: false, text: '   Physical Address. . . . . . . . : 00-1B-44-11-3A-B7' },
+        { id: 'l5', select: false, ctx: true, text: '   DNS Servers . . . . . . . . . . : 10.10.0.5' }
+      ] },
+      { id: 'pinggw', promptLine: 'ping 10.10.0.1', lines: [
+        { id: 'l6', select: false, ctx: true, text: 'Pinging 10.10.0.1 with 32 bytes of data:' },
+        { id: 'l7', select: false, ctx: true, text: 'Reply from 10.10.0.1: bytes=32 time<1ms TTL=64' }
+      ] },
+      { id: 'ping', promptLine: 'ping www.vendorportal.com', lines: [
+        { id: 'l8', select: true, evidence: true, text: 'Ping request could not find host www.vendorportal.com. Please check the name and try again.' }
+      ] },
+      { id: 'nslookup', promptLine: 'nslookup www.vendorportal.com 10.10.0.5', lines: [
+        { id: 'l9', select: false, ctx: true, text: 'Server:  UnKnown' },
+        { id: 'l10', select: false, ctx: true, text: 'Address:  10.10.0.5' },
+        { id: 'l11', select: true, evidence: true, text: 'DNS request timed out.' },
+        { id: 'l12', select: true, evidence: true, text: 'timeout was 2 seconds.' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why external browsing failed office-wide while internal traffic to a cached name still works.',
+        explanation: 'The failed name ping and the timed-out nslookup against the office\'s internal DNS server (10.10.0.5) point straight at that server as the failure point, while the successful gateway ping confirms the LAN and routing are healthy. The workstation\'s own MAC address is identity information, not evidence of a DNS fault.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l8', 'l11', 'l12'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'The gateway is reachable but the office\'s internal DNS server times out on every fresh lookup — that server (or the DNS service on it) is down. The first move is to point the affected client at a known-good external DNS server to restore browsing while the internal DNS server is investigated.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The office\'s internal DNS server is down or unreachable' },
+            { id: 'b', text: 'The office router lost its internet uplink' },
+            { id: 'c', text: 'A duplicate IP address is on the network' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Temporarily point clients to a public DNS server (e.g., 8.8.8.8) and check the internal DNS server' },
+            { id: 'b', text: 'Reboot the office router' },
+            { id: 'c', text: 'Reassign static IP addresses to every workstation' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-07', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — DNS resolution',
+    title: 'Traveler on hotel Wi-Fi: laptop connects but no site will open', estMinutes: 6,
+    scenario: 'A traveling employee connects their laptop to hotel guest Wi-Fi and can see the connection is active, but no website opens, including ones they know are up. They call IT and you walk them through ipconfig /all, a ping by name, and nslookup. Flag the evidence, then diagnose.',
+    triage: { fault: 'deadDns' },
+    assets: { reference: { kind: 'terminal', host: 'LAPTOP-TRAVELER', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Wireless LAN adapter Wi-Fi:' },
+        { id: 'l2', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 172.16.4.203(Preferred)' },
+        { id: 'l3', select: false, ctx: true, text: '   Default Gateway . . . . . . . . : 172.16.4.1' },
+        { id: 'l4', select: true, evidence: false, text: '   Lease Obtained. . . . . . . . . : Tuesday, July 7, 2026 8:02:11 PM' },
+        { id: 'l5', select: false, ctx: true, text: '   DNS Servers . . . . . . . . . . : 172.16.4.1' }
+      ] },
+      { id: 'pinggw', promptLine: 'ping 172.16.4.1', lines: [
+        { id: 'l6', select: false, ctx: true, text: 'Pinging 172.16.4.1 with 32 bytes of data:' },
+        { id: 'l7', select: false, ctx: true, text: 'Reply from 172.16.4.1: bytes=32 time=2ms TTL=64' }
+      ] },
+      { id: 'ping', promptLine: 'ping www.companyportal.com', lines: [
+        { id: 'l8', select: true, evidence: true, text: 'Ping request could not find host www.companyportal.com. Please check the name and try again.' }
+      ] },
+      { id: 'nslookup', promptLine: 'nslookup www.companyportal.com', lines: [
+        { id: 'l9', select: false, ctx: true, text: 'Server:  UnKnown' },
+        { id: 'l10', select: false, ctx: true, text: 'Address:  172.16.4.1' },
+        { id: 'l11', select: true, evidence: true, text: 'DNS request timed out.' },
+        { id: 'l12', select: true, evidence: true, text: '*** Request to UnKnown timed-out' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why no site opens even though the laptop is on the hotel Wi-Fi.',
+        explanation: 'The failed name-based ping and the DNS timeouts against the hotel gateway (which is also serving as DNS here) confirm name resolution is broken, while the successful gateway ping shows the wireless link and local routing are fine. The DHCP lease timestamp is routine informational output, not fault evidence.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l8', 'l11', 'l12'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'The hotel\'s gateway is also acting as the DNS server here, and it isn\'t forwarding DNS queries out — so lookups time out even though the link and the gateway itself still respond to pings. Manually setting a public DNS server on the laptop is the fastest first move to restore browsing.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The hotel\'s DNS service is not resolving queries even though the gateway itself is reachable' },
+            { id: 'b', text: 'The laptop\'s Wi-Fi adapter is defective' },
+            { id: 'c', text: 'The laptop has an IP address conflict with another guest' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Manually set a public DNS server (e.g., 1.1.1.1) on the laptop\'s network adapter' },
+            { id: 'b', text: 'Forget and rejoin the same hotel Wi-Fi network' },
+            { id: 'c', text: 'Replace the laptop\'s Wi-Fi card' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-08', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — DNS resolution',
+    title: 'Retail kiosk PC can reach the card processor by IP but not the vendor update site', estMinutes: 7,
+    scenario: 'A retail store\'s kiosk PC processes payments fine (it\'s hardcoded to the processor\'s IP address) but fails to check for software updates, which point to a hostname. The manager asks you to check it. You capture ipconfig /all, a ping by name, and nslookup. Flag the evidence, then diagnose.',
+    triage: { fault: 'deadDns' },
+    assets: { reference: { kind: 'terminal', host: 'KIOSK-PC-04', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 192.168.50.12(Preferred)' },
+        { id: 'l3', select: false, ctx: true, text: '   Default Gateway . . . . . . . . : 192.168.50.1' },
+        { id: 'l4', select: true, evidence: false, text: '   Subnet Mask . . . . . . . . . . : 255.255.255.0' },
+        { id: 'l5', select: false, ctx: true, text: '   DNS Servers . . . . . . . . . . : 192.168.50.2' }
+      ] },
+      { id: 'pingproc', promptLine: 'ping 54.219.10.7', lines: [
+        { id: 'l6', select: false, ctx: true, text: 'Pinging 54.219.10.7 with 32 bytes of data:' },
+        { id: 'l7', select: false, ctx: true, text: 'Reply from 54.219.10.7: bytes=32 time=44ms TTL=51' }
+      ] },
+      { id: 'ping', promptLine: 'ping updates.posvendor.com', lines: [
+        { id: 'l8', select: true, evidence: true, text: 'Ping request could not find host updates.posvendor.com. Please check the name and try again.' }
+      ] },
+      { id: 'nslookup', promptLine: 'nslookup updates.posvendor.com', lines: [
+        { id: 'l9', select: false, ctx: true, text: 'Server:  UnKnown' },
+        { id: 'l10', select: false, ctx: true, text: 'Address:  192.168.50.2' },
+        { id: 'l11', select: true, evidence: true, text: 'DNS request timed out.' },
+        { id: 'l12', select: true, evidence: true, text: 'timeout was 2 seconds.' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why the kiosk can process payments but can\'t check for updates.',
+        explanation: 'Payments work because the processor is hardcoded by IP, but the update check needs a hostname lookup — the failed name ping and the DNS timeout against 192.168.50.2 prove that server isn\'t answering. The subnet mask line is routine addressing detail, not evidence of a DNS problem.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l8', 'l11', 'l12'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'The store\'s DNS server at 192.168.50.2 is not responding to queries, which explains why IP-based traffic works but hostname-based traffic doesn\'t. Flushing the DNS cache and testing against an alternate DNS server confirms the diagnosis and restores functionality.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The store\'s DNS server (192.168.50.2) is not responding to lookup requests' },
+            { id: 'b', text: 'The kiosk\'s network cable is faulty' },
+            { id: 'c', text: 'The card processor\'s service is down' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Run ipconfig /flushdns and test resolution against an alternate DNS server' },
+            { id: 'b', text: 'Swap the network cable on the kiosk' },
+            { id: 'c', text: 'Call the card processor\'s support line' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  // ---------- BAD GATEWAY (4) — objective 2.5 (Compare common network configuration concepts) ----------
+  {
+    id: 'a1-cot-09', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — gateway/routing',
+    title: 'Home office: local file share works but nothing external loads', estMinutes: 6,
+    scenario: 'A remote worker says they can still print to their local network printer and reach a NAS on the home LAN, but no websites or cloud apps load. You have them run ipconfig /all, ping the printer\'s local IP, and ping the router. Flag the evidence, then diagnose.',
+    triage: { fault: 'badGw' },
+    assets: { reference: { kind: 'terminal', host: 'DESKTOP-HOMEOFFICE', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: true, evidence: false, text: '   Media State . . . . . . . . . . : Media connected' },
+        { id: 'l3', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 192.168.1.88(Preferred)' },
+        { id: 'l4', select: true, evidence: true, text: '   Default Gateway . . . . . . . . : 192.168.1.254' },
+        { id: 'l5', select: false, ctx: true, text: '   DNS Servers . . . . . . . . . . : 192.168.1.1' }
+      ] },
+      { id: 'pinglocal', promptLine: 'ping 192.168.1.30', lines: [
+        { id: 'l6', select: false, ctx: true, text: 'Pinging 192.168.1.30 with 32 bytes of data:' },
+        { id: 'l7', select: false, ctx: true, text: 'Reply from 192.168.1.30: bytes=32 time=1ms TTL=64' }
+      ] },
+      { id: 'pinggw', promptLine: 'ping 192.168.1.254', lines: [
+        { id: 'l8', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l9', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l10', select: false, ctx: true, text: 'Ping statistics for 192.168.1.254:' },
+        { id: 'l11', select: false, ctx: true, text: '    Packets: Sent = 4, Received = 0, Lost = 4 (100% loss)' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why the local printer/NAS still work but the internet doesn\'t.',
+        explanation: 'The configured default gateway address, together with that same gateway address failing to answer pings at all, proves the router is unreachable — which explains why LAN traffic (to the printer at .30) still works while anything that must leave the LAN cannot. "Media connected" only confirms the physical link, which is not the problem here.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l4', 'l8', 'l9'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'Local (same-subnet) traffic succeeds but the configured default gateway itself does not respond to ping, so the router is down, overloaded, or has lost its LAN interface — not a DNS or cabling issue on this PC. Power-cycling the router is the standard first move for an unresponsive SOHO gateway.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The default gateway (router) is unreachable or down' },
+            { id: 'b', text: 'The PC\'s DNS server setting is wrong' },
+            { id: 'c', text: 'The NAS has a duplicate IP address' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Power-cycle the router and retest connectivity' },
+            { id: 'b', text: 'Change the DNS server on the PC' },
+            { id: 'c', text: 'Reboot the NAS' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-10', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — gateway/routing',
+    title: 'Small office: every workstation lost internet at the same time', estMinutes: 6,
+    scenario: 'All 6 workstations in a small office lose internet access simultaneously, though they can still reach each other and the internal file server. You remote into one machine and capture ipconfig /all plus pings to the file server and the router. Flag the evidence, then diagnose.',
+    triage: { fault: 'badGw' },
+    assets: { reference: { kind: 'terminal', host: 'LAPTOP-EMP01', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 10.10.0.15(Preferred)' },
+        { id: 'l3', select: true, evidence: true, text: '   Default Gateway . . . . . . . . : 10.10.0.1' },
+        { id: 'l4', select: true, evidence: false, text: '   DHCP Enabled. . . . . . . . . . : Yes' }
+      ] },
+      { id: 'pingfs', promptLine: 'ping 10.10.0.5', lines: [
+        { id: 'l5', select: false, ctx: true, text: 'Pinging 10.10.0.5 with 32 bytes of data:' },
+        { id: 'l6', select: false, ctx: true, text: 'Reply from 10.10.0.5: bytes=32 time<1ms TTL=64' }
+      ] },
+      { id: 'pinggw', promptLine: 'ping 10.10.0.1', lines: [
+        { id: 'l7', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l8', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l9', select: true, evidence: true, text: 'Request timed out.' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why the whole office lost internet at once while internal traffic still works.',
+        explanation: 'The configured default gateway address plus three straight timeouts pinging that exact gateway prove the router is unreachable from the LAN, matching an office-wide outage while internal server traffic keeps working. DHCP being enabled is routine configuration detail, not evidence the gateway itself is down.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l3', 'l7', 'l8', 'l9'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'Every user losing internet at the same moment while internal LAN traffic is unaffected, combined with the gateway itself not answering pings, points squarely at the router/gateway device having failed or lost its uplink. The first move is to check and, if needed, power-cycle the router.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The office router (default gateway) has failed or lost its uplink' },
+            { id: 'b', text: 'The internal file server crashed' },
+            { id: 'c', text: 'Every workstation\'s NIC failed simultaneously' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Check the router\'s status lights and power-cycle it if unresponsive' },
+            { id: 'b', text: 'Restart the internal file server' },
+            { id: 'c', text: 'Replace the network cable on each workstation' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-11', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — gateway/routing',
+    title: 'Home user: static IP set manually after a "how-to" video, now nothing works', estMinutes: 7,
+    scenario: 'A home user followed an online video to set a "faster" static IP on their gaming PC and now nothing loads, though the PC still shows as connected and can reach other devices on the LAN like their console. You capture ipconfig /all and pings to the console and to the address they typed as the gateway. Flag the evidence, then diagnose.',
+    triage: { fault: 'badGw' },
+    assets: { reference: { kind: 'terminal', host: 'DESKTOP-GAMING', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 192.168.1.150(Preferred)' },
+        { id: 'l3', select: true, evidence: true, text: '   Default Gateway . . . . . . . . : 192.168.1.100' },
+        { id: 'l4', select: true, evidence: false, text: '   Autoconfiguration Enabled . . . : Yes' }
+      ] },
+      { id: 'pingconsole', promptLine: 'ping 192.168.1.60', lines: [
+        { id: 'l5', select: false, ctx: true, text: 'Pinging 192.168.1.60 with 32 bytes of data:' },
+        { id: 'l6', select: false, ctx: true, text: 'Reply from 192.168.1.60: bytes=32 time=2ms TTL=64' }
+      ] },
+      { id: 'pinggw', promptLine: 'ping 192.168.1.100', lines: [
+        { id: 'l7', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l8', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l9', select: false, ctx: true, text: 'Ping statistics for 192.168.1.100:' },
+        { id: 'l10', select: false, ctx: true, text: '    Packets: Sent = 4, Received = 0, Lost = 4 (100% loss)' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why the gaming PC lost internet after the manual IP change.',
+        explanation: 'The gateway address the user typed in (192.168.1.100) is not the router\'s real address, and pinging it returns nothing, proving traffic destined off the LAN has no working next hop — even though local traffic to the console still succeeds. Autoconfiguration Enabled is a leftover default flag, not evidence this specific gateway is wrong.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l3', 'l7', 'l8'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'The user manually typed an incorrect default gateway address that doesn\'t match the actual router, so nothing that needs to leave the LAN can route out, while same-subnet traffic is unaffected. The fix is to correct the gateway to the router\'s real address, or simplest, revert to DHCP.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The manually entered default gateway address is wrong / does not match the router' },
+            { id: 'b', text: 'The gaming console is causing an IP conflict' },
+            { id: 'c', text: 'The router\'s DNS server is down' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Correct the default gateway to the router\'s actual address, or switch the adapter back to DHCP' },
+            { id: 'b', text: 'Power-cycle the gaming console' },
+            { id: 'c', text: 'Reinstall the network adapter driver' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'a1-cot-12', cert: 'aplus-core1', archetype: 'triage', objective: '2.5',
+    topic: 'Command-output evidence triage — gateway/routing',
+    title: 'Nonprofit branch office: router went unresponsive overnight', estMinutes: 7,
+    scenario: 'A small nonprofit\'s branch office reports that, as of this morning, staff can still reach the internal file share but no browsing or email works. Nothing was changed on purpose — the router has been running for months without a reboot. You remote into a workstation and capture ipconfig /all plus pings to the file server and the gateway. Flag the evidence, then diagnose.',
+    triage: { fault: 'badGw' },
+    assets: { reference: { kind: 'terminal', host: 'DESKTOP-BRANCH02', session: 'cmd', excerpts: [
+      { id: 'ipcfg', promptLine: 'ipconfig /all', lines: [
+        { id: 'l1', select: false, ctx: true, text: 'Ethernet adapter Ethernet:' },
+        { id: 'l2', select: false, ctx: true, text: '   IPv4 Address. . . . . . . . . . : 172.20.5.44(Preferred)' },
+        { id: 'l3', select: true, evidence: true, text: '   Default Gateway . . . . . . . . : 172.20.5.1' },
+        { id: 'l4', select: true, evidence: false, text: '   Description . . . . . . . . . . : Intel(R) Ethernet Connection I219-V' }
+      ] },
+      { id: 'pingfs', promptLine: 'ping 172.20.5.10', lines: [
+        { id: 'l5', select: false, ctx: true, text: 'Pinging 172.20.5.10 with 32 bytes of data:' },
+        { id: 'l6', select: false, ctx: true, text: 'Reply from 172.20.5.10: bytes=32 time<1ms TTL=64' }
+      ] },
+      { id: 'pinggw', promptLine: 'ping 172.20.5.1', lines: [
+        { id: 'l7', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l8', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l9', select: true, evidence: true, text: 'Request timed out.' },
+        { id: 'l10', select: false, ctx: true, text: 'Ping statistics for 172.20.5.1:' },
+        { id: 'l11', select: false, ctx: true, text: '    Packets: Sent = 4, Received = 0, Lost = 4 (100% loss)' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1,
+        prompt: 'Tap the specific output lines that prove why the branch office lost outbound access overnight.',
+        explanation: 'The workstation\'s default gateway address, combined with that exact address timing out on every ping attempt, proves the router is unreachable — while the file server on the same subnet still answers fine. The NIC description line is hardware identity, not evidence of a routing fault.',
+        payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['l3', 'l7', 'l8', 'l9'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and your first troubleshooting move.',
+        explanation: 'Same-subnet traffic works but the configured default gateway does not respond at all, with no recent config changes and months of uptime — a strong sign the router itself has simply locked up and needs to be power-cycled, a common failure mode for consumer/SOHO-grade routers left running for long stretches.',
+        payload: { slots: [
+          { id: 'diagnosis', label: 'Root cause', options: [
+            { id: 'a', text: 'The router (default gateway) has locked up after extended uptime and stopped responding' },
+            { id: 'b', text: 'The file server\'s network card failed' },
+            { id: 'c', text: 'The workstation has a stale ARP cache entry' }
+          ] },
+          { id: 'firstMove', label: 'First troubleshooting step', options: [
+            { id: 'a', text: 'Power-cycle the router and verify its LAN cabling once it comes back up' },
+            { id: 'b', text: 'Replace the file server\'s network card' },
+            { id: 'c', text: 'Clear the ARP cache on the workstation' }
+          ] }
+        ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } }
+    ]
+  },
 ];

--- a/features/sim-lab-seed-netplus.js
+++ b/features/sim-lab-seed-netplus.js
@@ -3335,6 +3335,621 @@ window.SIM_LAB_SEED_NETPLUS = [
         ] },
         answer: { selected: ['l1', 'l2', 'l3'] } }
     ]
+  },
+
+// ---------- DUPLEX (3) ----------
+  {
+    id: 'np-cli-01', cert: 'netplus', archetype: 'cli', objective: '5.2', topic: 'CLI fault isolation — physical/data link',
+    title: 'Slow file transfers on a warehouse access switch', estMinutes: 6,
+    scenario: 'Users on GigabitEthernet0/3 of a warehouse access switch report file transfers that used to take seconds now take minutes. The port link light is solid green and the host has an IP address. You have console access to the switch. Pick the commands that isolate the fault, then diagnose and fix it.',
+    cliFault: { fault: 'duplex' },
+    assets: { reference: { kind: 'terminal', host: 'SW-WH1', session: 'console', reveal: 'external', excerpts: [
+      { id: 'ping', necessary: false, promptLine: 'ping 10.20.4.15', reveal: 'ping', lines: [
+        { text: 'Sending 5, 100-byte ICMP Echos to 10.20.4.15, timeout is 2 seconds:' },
+        { text: '!!!!!' },
+        { text: 'Success rate is 100 percent (5/5), round-trip min/avg/max = 1/3/8 ms' }
+      ] },
+      { id: 'status', necessary: true, promptLine: 'show interface gi0/3 status', reveal: 'status', lines: [
+        { text: 'Port      Name    Status       Vlan  Duplex  Speed Type' },
+        { text: 'Gi0/3             connected    20    half-duplex   100  10/100/1000BaseTX' }
+      ] },
+      { id: 'counters', necessary: true, promptLine: 'show interface gi0/3 counters errors', reveal: 'counters', lines: [
+        { text: 'Port      Align-Err  FCS-Err  Xmit-Err  Rcv-Err  UnderSize  Late collision' },
+        { text: 'Gi0/3     0          0        0         0        0          1188' }
+      ] },
+      { id: 'log', necessary: true, promptLine: 'show logging | include DUPLEX', reveal: 'log', lines: [
+        { text: '%CDP-4-DUPLEX_MISMATCH: duplex mismatch discovered on GigabitEthernet0/3 (not full-duplex), with WH-SCANNER-04 (full-duplex)' }
+      ] },
+      { id: 'mac', necessary: false, promptLine: 'show mac address-table interface gi0/3', reveal: 'mac', lines: [
+        { text: '  20    001a.2b3c.4d5e    DYNAMIC     Gi0/3' }
+      ] },
+      { id: 'ver', necessary: false, promptLine: 'show version', reveal: 'ver', lines: [
+        { text: 'Cisco IOS Software, C2960X Software, Version 15.2(7)E3' },
+        { text: 'Uptime: 214 days' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'The link is up and the host can reach the network, so basic connectivity is not the issue. Select the commands that actually isolate why transfers are slow.',
+        explanation: '`show interface status` exposes the negotiated duplex/speed per port, `show interface counters errors` exposes late collisions, and the syslog line shows IOS itself detected the mismatch and named the host as full-duplex — together the facts prove a duplex mismatch. Ping and MAC-table output confirm reachability/location but say nothing about performance.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['status', 'counters', 'log'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and the correct fix.',
+        explanation: 'Half-duplex on the switch port against a full-duplex host produces late collisions under load, which manifests as slow, degraded throughput rather than an outage. Forcing (or restoring) auto-negotiation on both ends resolves the mismatch.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'Duplex mismatch between the switch port and the host NIC' },
+            { id: 'b', text: 'Bad Ethernet cable causing intermittent link loss' },
+            { id: 'c', text: 'VLAN 20 is not permitted on the uplink trunk' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Set both the switch port and NIC to auto-negotiate duplex/speed' },
+            { id: 'b', text: 'Replace the patch cable' },
+            { id: 'c', text: 'Add VLAN 20 to the trunk allowed list' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-02', cert: 'netplus', archetype: 'cli', objective: '5.2', topic: 'CLI fault isolation — physical/data link',
+    title: 'Server team reports intermittent packet loss to a NAS', estMinutes: 7,
+    scenario: 'A storage admin says backups to a NAS appliance are failing partway through with checksum errors, though the NAS is pingable and mounted. It connects via a hardened 1000Mb copper run to GigabitEthernet1/0/12 on a core switch that was recently re-patched during a rack cleanup.',
+    cliFault: { fault: 'duplex' },
+    assets: { reference: { kind: 'terminal', host: 'CORE-SW2', session: 'ssh', reveal: 'external', excerpts: [
+      { id: 'arp', necessary: false, promptLine: 'show arp | include 10.30.1.40', reveal: 'arp', lines: [
+        { text: 'Internet  10.30.1.40   -   00e0.4c68.a112  ARPA   Vlan30' }
+      ] },
+      { id: 'status', necessary: true, promptLine: 'show interfaces gi1/0/12 status', reveal: 'status', lines: [
+        { text: 'Port        Name  Status       Vlan  Duplex  Speed  Type' },
+        { text: 'Gi1/0/12          connected    30    full-duplex   1000   10/100/1000BaseTX' }
+      ] },
+      { id: 'counters', necessary: true, promptLine: 'show interfaces gi1/0/12', reveal: 'counters', lines: [
+        { text: 'GigabitEthernet1/0/12 is up, line protocol is up' },
+        { text: '  5 minute input rate 812000 bits/sec, 5 minute output rate 940000 bits/sec' },
+        { text: '  1523 late collision events, 0 giants, 0 runts' }
+      ] },
+      { id: 'log', necessary: true, promptLine: 'show logging | include DUPLEX', reveal: 'log', lines: [
+        { text: '%CDP-4-DUPLEX_MISMATCH: duplex mismatch discovered on GigabitEthernet1/0/12 (not half-duplex), with NAS-PROD-01 (half-duplex)' }
+      ] },
+      { id: 'cdp', necessary: false, promptLine: 'show cdp neighbors gi1/0/12 detail', reveal: 'cdp', lines: [
+        { text: 'Device ID: NAS-PROD-01' },
+        { text: 'Platform: Synology RS3621, Capabilities: Host' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'Choose the commands needed to prove why backups are corrupting mid-transfer.',
+        explanation: 'The interface status line shows the switch side negotiated full-duplex, the counters view shows late collisions climbing with sustained throughput, and the syslog line shows IOS itself detected a duplex mismatch and named the NAS as running half-duplex — together the fingerprint of a duplex mismatch under load. ARP and CDP only establish reachability and identity, not the fault.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['status', 'counters', 'log'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Diagnose the fault and select the fix.',
+        explanation: 'One side auto-negotiated to full-duplex while the other side was hard-set to half-duplex — a classic duplex mismatch that shows up as collisions and corrupted transfers under sustained load, not as a hard link failure. Matching both sides to auto-negotiate (or forcing both to the same explicit duplex) clears it.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'Duplex mismatch: switch full-duplex vs. NAS NIC hard-set half-duplex' },
+            { id: 'b', text: 'Faulty SFP transceiver on the core switch' },
+            { id: 'c', text: 'MTU mismatch causing fragmentation' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Reconfigure the NAS NIC to auto-negotiate duplex/speed to match the switch' },
+            { id: 'b', text: 'Swap the SFP transceiver' },
+            { id: 'c', text: 'Lower the MTU on the switch port' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-03', cert: 'netplus', archetype: 'cli', objective: '5.2', topic: 'CLI fault isolation — tools: interface diagnostics',
+    title: 'Conference room AV cart drops during screen sharing', estMinutes: 6,
+    scenario: 'A conference room AV cart, wired to FastEthernet0/8 on a small edge switch, disconnects and reconnects mid-meeting whenever screen sharing starts (high sustained throughput). Facilities swapped the cable last week during a different, unrelated ticket.',
+    cliFault: { fault: 'duplex' },
+    assets: { reference: { kind: 'terminal', host: 'EDGE-SW5', session: 'console', reveal: 'external', excerpts: [
+      { id: 'status', necessary: true, promptLine: 'show interface fa0/8 status', reveal: 'status', lines: [
+        { text: 'Port  Name  Status       Vlan  Duplex  Speed  Type' },
+        { text: 'Fa0/8       connected    10    full-duplex   100    10/100BaseTX' }
+      ] },
+      { id: 'errcount', necessary: true, promptLine: 'show interface fa0/8', reveal: 'errcount', lines: [
+        { text: 'FastEthernet0/8 is up, line protocol is up (connected)' },
+        { text: '  0 input errors, 0 CRC, 0 frame' },
+        { text: '  2114 late collision events, 0 collisions' }
+      ] },
+      { id: 'log', necessary: true, promptLine: 'show logging | include DUPLEX', reveal: 'log', lines: [
+        { text: '%CDP-4-DUPLEX_MISMATCH: duplex mismatch discovered on FastEthernet0/8 (not half-duplex), with AV-CART-05 (half-duplex)' }
+      ] },
+      { id: 'dhcp', necessary: false, promptLine: 'show ip dhcp binding', reveal: 'dhcp', lines: [
+        { text: '10.40.2.55   001b.44aa.9c02   Automatic   Vlan10' }
+      ] },
+      { id: 'trunk', necessary: false, promptLine: 'show interfaces trunk', reveal: 'trunk', lines: [
+        { text: 'Port      Mode   Encapsulation  Status     Native vlan' },
+        { text: 'Gi0/1     on     802.1q         trunking   1' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'The problem only appears under heavy traffic. Select the commands that would surface the actual cause.',
+        explanation: 'Duplex mismatches are load-dependent: they look fine on a quiet link and fail only once traffic climbs. `show interface status` exposes the negotiated Full/Half state per side, the interface counters expose late collisions rising with load, and the syslog line shows IOS detected the mismatch and named the AV cart as half-duplex. DHCP binding and trunk state are unrelated to this symptom.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['status', 'errcount', 'log'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'What is the root cause, and how do you fix it?',
+        explanation: 'The switch negotiated full-duplex while the AV cart adapter is fixed at half-duplex; under the sustained load of screen sharing this produces late collisions, which upstream devices interpret as a dropped link. Forcing both ends to consistent auto-negotiation (or matching explicit settings) resolves it.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'Duplex mismatch between the switch port and the AV cart adapter' },
+            { id: 'b', text: 'Spanning-tree port flapping into blocking state' },
+            { id: 'c', text: 'DHCP lease exhaustion on VLAN 10' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Match duplex/speed (auto-negotiate both ends) on switch port and AV adapter' },
+            { id: 'b', text: 'Enable PortFast on the switch port' },
+            { id: 'c', text: 'Expand the DHCP scope on VLAN 10' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  // ---------- GATEWAY (3) ----------
+  {
+    id: 'np-cli-04', cert: 'netplus', archetype: 'cli', objective: '5.2', topic: 'CLI fault isolation — network layer/routing',
+    title: 'New subnet cannot reach anything off-site', estMinutes: 6,
+    scenario: 'A newly provisioned VLAN 50 (10.50.0.0/24) for a satellite office can reach hosts within the subnet but nothing else — not the internet, not other internal VLANs. A junior tech just finished configuring the new SVI on the L3 switch this morning.',
+    cliFault: { fault: 'gateway' },
+    assets: { reference: { kind: 'terminal', host: 'HOST-50-12', session: 'cmd', reveal: 'external', excerpts: [
+      { id: 'ipconfig', necessary: false, promptLine: 'ipconfig /all', reveal: 'ipconfig', lines: [
+        { text: 'IPv4 Address. . . . . . . . . . . : 10.50.0.12' },
+        { text: 'Subnet Mask . . . . . . . . . . . : 255.255.255.0' },
+        { text: 'Default Gateway . . . . . . . . . : 10.50.0.1' }
+      ] },
+      { id: 'pinglocal', necessary: false, promptLine: 'ping 10.50.0.20', reveal: 'pinglocal', lines: [
+        { text: 'Reply from 10.50.0.20: bytes=32 time=1ms TTL=128' },
+        { text: 'Reply from 10.50.0.20: bytes=32 time=1ms TTL=128' }
+      ] },
+      { id: 'pinggw', necessary: true, promptLine: 'ping 10.50.0.1', reveal: 'pinggw', lines: [
+        { text: 'Pinging 10.50.0.1 with 32 bytes of data:' },
+        { text: 'Request timed out.' },
+        { text: 'Request timed out.' },
+        { text: 'Ping statistics for 10.50.0.1: Sent = 4, Received = 0, Lost = 4 (100% loss)' }
+      ] },
+      { id: 'svi', necessary: true, promptLine: 'show running-config interface vlan50', reveal: 'svi', lines: [
+        { text: 'interface Vlan50' },
+        { text: ' description Gateway - VLAN50 satellite office' },
+        { text: ' ip address 10.50.0.1 255.255.255.0' },
+        { text: ' shutdown' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'Local hosts can reach each other but nothing else. Choose the commands that isolate the fault.',
+        explanation: 'Pinging the default gateway reveals it is unreachable, and the VLAN 50 SVI running-config on the L3 switch shows a `shutdown` line — the gateway interface itself never came up. ipconfig and a same-subnet ping only confirm local addressing, which was never in question.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['pinggw', 'svi'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Diagnose the fault and pick the fix.',
+        explanation: 'The junior tech configured the SVI but left it administratively shut, so the gateway address never comes online — hosts can talk to each other switched within VLAN 50 but have no router to leave the subnet. `no shutdown` on the SVI brings the gateway up.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'The VLAN 50 gateway SVI is administratively shut down' },
+            { id: 'b', text: 'The host has a duplicate IP address' },
+            { id: 'c', text: 'DNS server is unreachable from VLAN 50' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Bring the gateway SVI up with "no shutdown" so the gateway route is live' },
+            { id: 'b', text: 'Release and renew the host DHCP lease' },
+            { id: 'c', text: 'Point the host at a different DNS server' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-05', cert: 'netplus', archetype: 'cli', objective: '5.2', topic: 'CLI fault isolation — network layer/routing',
+    title: 'SOHO router replacement breaks internet for the whole office', estMinutes: 7,
+    scenario: 'After a weekend hardware swap, a small office\'s router was replaced with a spare unit. Monday morning, every workstation can reach the file server (10.10.10.5) but nobody can browse the internet. IT staged the spare with what they believed were matching settings.',
+    cliFault: { fault: 'gateway' },
+    assets: { reference: { kind: 'terminal', host: 'WKS-07', session: 'cmd', reveal: 'external', excerpts: [
+      { id: 'ipfile', necessary: false, promptLine: 'ping 10.10.10.5', reveal: 'ipfile', lines: [
+        { text: 'Reply from 10.10.10.5: bytes=32 time=2ms TTL=64' },
+        { text: 'Reply from 10.10.10.5: bytes=32 time=1ms TTL=64' }
+      ] },
+      { id: 'ipwan', necessary: false, promptLine: 'ping 8.8.8.8', reveal: 'ipwan', lines: [
+        { text: 'Pinging 8.8.8.8 with 32 bytes of data:' },
+        { text: 'Destination host unreachable.' },
+        { text: 'Destination host unreachable.' }
+      ] },
+      { id: 'ipconfig', necessary: true, promptLine: 'ipconfig /all', reveal: 'ipconfig', lines: [
+        { text: 'IPv4 Address. . . . . . . . . . . : 10.10.10.44' },
+        { text: 'Subnet Mask . . . . . . . . . . . : 255.255.255.0' },
+        { text: 'Default Gateway . . . . . . . . . : 10.10.10.1' },
+        { text: 'DHCP Server . . . . . . . . . . . : 10.10.10.1' },
+        { text: 'Lease Obtained. . . . . . . . . . : Thursday, July 2, 2026 8:14:03 AM' },
+        { text: 'Lease Expires . . . . . . . . . . : Thursday, July 9, 2026 8:14:03 AM' }
+      ] },
+      { id: 'pinggw', necessary: true, promptLine: 'ping 10.10.10.1', reveal: 'pinggw', lines: [
+        { text: 'Pinging 10.10.10.1 with 32 bytes of data:' },
+        { text: 'Request timed out.' },
+        { text: 'Request timed out.' },
+        { text: 'Ping statistics for 10.10.10.1: Sent = 4, Received = 0, Lost = 4 (100% loss)' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'File-server access is fine but internet is dead office-wide. Select the commands that pin down the cause.',
+        explanation: '`ipconfig /all` shows the lease was obtained the Thursday before the weekend router swap, meaning this host is still holding a pre-swap gateway address, and pinging that exact gateway address directly (10.10.10.1) times out — proving the old gateway no longer answers because the new router replaced it. Together they prove the host is stranded on a stale lease pointing at a dead gateway. The internet ping and local-server ping only confirm reachability symptoms already known from the ticket, not the underlying cause.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['ipconfig', 'pinggw'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'What broke, and what fixes it?',
+        explanation: 'The spare router was staged over the weekend, but this workstation\'s DHCP lease (obtained the prior Thursday) had not yet expired, so it never re-requested an address and is still holding the old gateway — which the new router no longer answers on. Releasing and renewing the lease (or rebooting the host) pulls a current lease with the live gateway and restores internet access.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'The host is still holding a stale pre-swap DHCP lease with a dead gateway address' },
+            { id: 'b', text: 'The file server NIC is set to half-duplex' },
+            { id: 'c', text: 'A duplicate VLAN ID was assigned to the LAN port' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Release and renew the DHCP lease so the host picks up the current gateway' },
+            { id: 'b', text: 'Force the file server NIC to full-duplex' },
+            { id: 'c', text: 'Reassign the LAN port to a unique VLAN ID' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-06', cert: 'netplus', archetype: 'cli', objective: '5.2', topic: 'CLI fault isolation — network layer/routing',
+    title: 'One VLAN loses inter-VLAN routing after a switch reload', estMinutes: 7,
+    scenario: 'A core L3 switch was reloaded overnight after a firmware update. This morning, VLAN 40 (finance, 10.40.0.0/24) hosts cannot reach any other VLAN or the internet, though VLAN 10 and VLAN 20 are unaffected.',
+    cliFault: { fault: 'gateway' },
+    assets: { reference: { kind: 'terminal', host: 'FIN-WKS-12', session: 'cmd', reveal: 'external', excerpts: [
+      { id: 'vlanbrief', necessary: false, promptLine: 'show vlan brief', reveal: 'vlanbrief', lines: [
+        { text: '40    FINANCE    active    Gi1/0/20, Gi1/0/21' }
+      ] },
+      { id: 'pinggw40', necessary: true, promptLine: 'ping 10.40.0.1', reveal: 'pinggw40', lines: [
+        { text: 'Pinging 10.40.0.1 with 32 bytes of data:' },
+        { text: 'Destination host unreachable.' },
+        { text: 'Destination host unreachable.' },
+        { text: 'Ping statistics for 10.40.0.1: Sent = 4, Received = 0, Lost = 4 (100% loss)' }
+      ] },
+      { id: 'sviup', necessary: true, promptLine: 'show running-config interface vlan40', reveal: 'sviup', lines: [
+        { text: 'interface Vlan40' },
+        { text: ' description Gateway - Finance VLAN40' },
+        { text: 'end' }
+      ] },
+      { id: 'cdpnbr', necessary: false, promptLine: 'show cdp neighbors', reveal: 'cdpnbr', lines: [
+        { text: 'Device ID   Local Intrfce   Capability   Platform' },
+        { text: 'ACCESS-SW1  Gig 1/0/20      S            C2960X' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'Only VLAN 40 lost inter-VLAN routing after the reload. Choose the commands that isolate why.',
+        explanation: 'Pinging the VLAN 40 gateway comes back unreachable, and the SVI\'s running-config shows only a description line — no `ip address` line at all, meaning the address was never written to the startup config before the firmware reload wiped the running config. VLAN brief and CDP neighbors describe topology, not the fault.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['pinggw40', 'sviup'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Identify the root cause and the fix.',
+        explanation: 'The VLAN 40 SVI\'s IP address configuration was never written to NVRAM before the firmware reload wiped the running config, so the interface came back up with no gateway address at all — every other VLAN\'s config had been saved. Re-adding the gateway address and saving the config restores routing.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'The VLAN 40 SVI lost its gateway IP address on reload (unsaved config)' },
+            { id: 'b', text: 'A native VLAN mismatch on the access-switch trunk' },
+            { id: 'c', text: 'DNS resolution is broken for finance hosts only' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Re-apply the Vlan40 gateway address to the SVI and save the running config' },
+            { id: 'b', text: 'Set the native VLAN to match on both ends of the trunk' },
+            { id: 'c', text: 'Point finance hosts at a working DNS server' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  // ---------- DNS (3) ----------
+  {
+    id: 'np-cli-07', cert: 'netplus', archetype: 'cli', objective: '5.3', topic: 'CLI fault isolation — name resolution',
+    title: 'Intranet portal unreachable by name, fine by IP', estMinutes: 6,
+    scenario: 'Employees say the intranet portal (portal.corp.local) is "down," but a helpdesk tech confirms the server itself responds fine to a direct IP. Users can browse public internet sites normally.',
+    cliFault: { fault: 'dns' },
+    assets: { reference: { kind: 'terminal', host: 'WKS-22', session: 'cmd', reveal: 'external', excerpts: [
+      { id: 'pingip', necessary: false, promptLine: 'ping 10.5.10.30', reveal: 'pingip', lines: [
+        { text: 'Reply from 10.5.10.30: bytes=32 time=1ms TTL=128' },
+        { text: 'Reply from 10.5.10.30: bytes=32 time=1ms TTL=128' }
+      ] },
+      { id: 'nslookup', necessary: true, promptLine: 'nslookup portal.corp.local', reveal: 'nslookup', lines: [
+        { text: 'Server:  ns1.corp.local' },
+        { text: 'Address:  10.5.1.10' },
+        { text: '*** ns1.corp.local can\'t find portal.corp.local: Non-existent domain' }
+      ] },
+      { id: 'ipconfig', necessary: true, promptLine: 'ipconfig /all', reveal: 'ipconfig', lines: [
+        { text: 'DNS Servers . . . . . . . . . . . : 10.5.1.10' }
+      ] },
+      { id: 'pingpublic', necessary: false, promptLine: 'ping google.com', reveal: 'pingpublic', lines: [
+        { text: 'Pinging google.com [142.250.72.14] with 32 bytes of data:' },
+        { text: 'Reply from 142.250.72.14: bytes=32 time=9ms TTL=115' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'The server answers by IP but not by name, and public sites resolve fine. Select the commands that isolate the cause.',
+        explanation: '`nslookup` against the internal name shows a Non-existent domain error from the internal DNS server itself, and `ipconfig /all` confirms which DNS server the host is actually querying — together they prove the internal DNS record/zone is the problem, not host connectivity. The IP ping and public-site ping only confirm reachability, which was never in doubt.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['nslookup', 'ipconfig'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Diagnose the fault and choose the fix.',
+        explanation: 'The internal DNS server has no record for portal.corp.local (or the zone/record was deleted), so the name never resolves even though the host, its DNS server address, and public resolution all work correctly. The fix is on the DNS server: recreate the missing A record and confirm the zone is intact.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'Missing/deleted DNS A record for portal.corp.local on the internal DNS server' },
+            { id: 'b', text: 'The workstation has an incorrect default gateway' },
+            { id: 'c', text: 'A duplex mismatch on the server NIC' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Recreate the A record for portal.corp.local on the internal DNS server' },
+            { id: 'b', text: 'Correct the workstation default gateway' },
+            { id: 'c', text: 'Force the server NIC to full-duplex' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-08', cert: 'netplus', archetype: 'cli', objective: '5.3', topic: 'CLI fault isolation — tools: dns diagnostics',
+    title: 'Newly joined laptop cannot resolve any internal hostname', estMinutes: 6,
+    scenario: 'A laptop freshly imaged and joined to the domain this morning can reach internal servers by IP address and browses the internet fine, but every internal hostname lookup fails, while a coworker\'s laptop on the same VLAN resolves everything normally.',
+    cliFault: { fault: 'dns' },
+    assets: { reference: { kind: 'terminal', host: 'LAPTOP-NEW14', session: 'cmd', reveal: 'external', excerpts: [
+      { id: 'ipconfig', necessary: true, promptLine: 'ipconfig /all', reveal: 'ipconfig', lines: [
+        { text: 'DNS Servers . . . . . . . . . . . : 8.8.8.8' }
+      ] },
+      { id: 'nslookup', necessary: true, promptLine: 'nslookup fileserver01.corp.local', reveal: 'nslookup', lines: [
+        { text: 'Server:  resolver-public-1' },
+        { text: 'Address:  8.8.8.8' },
+        { text: '*** resolver-public-1 can\'t find fileserver01.corp.local: Non-existent domain' }
+      ] },
+      { id: 'pingip', necessary: false, promptLine: 'ping 10.15.2.10', reveal: 'pingip', lines: [
+        { text: 'Reply from 10.15.2.10: bytes=32 time=1ms TTL=64' }
+      ] },
+      { id: 'internetok', necessary: false, promptLine: 'ping 1.1.1.1', reveal: 'internetok', lines: [
+        { text: 'Reply from 1.1.1.1: bytes=32 time=6ms TTL=59' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'A coworker on the same VLAN has no issue, so this looks device-specific. Choose the commands that confirm and isolate the cause.',
+        explanation: '`ipconfig /all` reveals this laptop is pointed at a public DNS server (8.8.8.8) instead of internal AD DNS, and `nslookup` against an internal hostname confirms that public server correctly reports the internal-only name as non-existent. Pinging by IP and pinging a public host only confirm connectivity, which is not the issue.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['ipconfig', 'nslookup'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'What is the root cause and the fix?',
+        explanation: 'The imaging template hardcoded a public DNS server instead of pulling the internal AD-integrated DNS server via DHCP, so this one laptop can never resolve internal-only names — a public resolver has no knowledge of the corp.local zone. Fixing the DNS server assignment (or the imaging template) resolves it.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'The laptop is configured to use a public DNS server instead of internal AD DNS' },
+            { id: 'b', text: 'The laptop has a duplicate IP address on the VLAN' },
+            { id: 'c', text: 'The default gateway is unreachable from this laptop' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Set the laptop to use the internal AD DNS server (fix DHCP/imaging template)' },
+            { id: 'b', text: 'Release and renew to obtain a non-conflicting IP' },
+            { id: 'c', text: 'Correct the default gateway address' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-09', cert: 'netplus', archetype: 'cli', objective: '5.3', topic: 'CLI fault isolation — tools: dns diagnostics',
+    title: 'Email client repeatedly fails to find the mail server', estMinutes: 6,
+    scenario: 'A user\'s email client throws "server not found" errors for mail.corp.local, though the mail server has been up all week and other users are unaffected. IT recalls the DNS team retired the old mail server (mailsrv-old.corp.local) this week and was supposed to repoint the mail.corp.local record.',
+    cliFault: { fault: 'dns' },
+    assets: { reference: { kind: 'terminal', host: 'WKS-33', session: 'cmd', reveal: 'external', excerpts: [
+      { id: 'nslookup1', necessary: true, promptLine: 'nslookup mail.corp.local', reveal: 'nslookup1', lines: [
+        { text: 'Server:  dns1.corp.local' },
+        { text: 'Address:  10.5.1.10' },
+        { text: 'Name:    mail.corp.local' },
+        { text: 'Address:  10.5.1.55' }
+      ] },
+      { id: 'nslookup2', necessary: true, promptLine: 'nslookup mailsrv-old.corp.local', reveal: 'nslookup2', lines: [
+        { text: 'Server:  UnKnown' },
+        { text: 'Address:  10.5.1.10' },
+        { text: '*** UnKnown can\'t find mailsrv-old.corp.local: Non-existent domain' }
+      ] },
+      { id: 'ping55', necessary: false, promptLine: 'ping 10.5.1.55', reveal: 'ping55', lines: [
+        { text: 'Pinging 10.5.1.55 with 32 bytes of data:' },
+        { text: 'Request timed out.' },
+        { text: 'Request timed out.' },
+        { text: 'Ping statistics for 10.5.1.55: Sent = 4, Received = 0, Lost = 4 (100% loss)' }
+      ] },
+      { id: 'ping72', necessary: false, promptLine: 'ping 10.5.1.72', reveal: 'ping72', lines: [
+        { text: 'Reply from 10.5.1.72: bytes=32 time=2ms TTL=64' }
+      ] },
+      { id: 'ipconfig', necessary: false, promptLine: 'ipconfig /displaydns | findstr mail', reveal: 'ipconfig', lines: [
+        { text: 'mail.corp.local' },
+        { text: '    Record Name . . . . . : mail.corp.local' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'The mail server is confirmed up, yet this client can\'t reach it by name. Select the commands that reveal why.',
+        explanation: '`nslookup` on mail.corp.local shows it still resolves to 10.5.1.55, and a lookup on the retired server\'s own hostname (mailsrv-old.corp.local) comes back Non-existent domain — proving that host\'s DNS entry was properly cleaned up during decommissioning, but mail.corp.local still points at its old address. Pinging either IP and the local DNS cache dump don\'t establish the fault by themselves.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['nslookup1', 'nslookup2'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Name the root cause and the fix.',
+        explanation: 'The DNS A record for mail.corp.local still points at the decommissioned mail server\'s IP instead of the new one; the record was never updated (or the change hasn\'t propagated) when the server was retired. Updating the DNS record to the current mail server IP fixes it for all clients.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'Stale DNS A record still pointing at the retired mail server IP' },
+            { id: 'b', text: 'The client\'s default gateway is misconfigured' },
+            { id: 'c', text: 'A VLAN mismatch is isolating this workstation' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Update the DNS A record for mail.corp.local to the current server IP' },
+            { id: 'b', text: 'Correct the client default gateway' },
+            { id: 'c', text: 'Move the workstation to the correct VLAN' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  // ---------- VLAN (3) ----------
+  {
+    id: 'np-cli-10', cert: 'netplus', archetype: 'cli', objective: '5.4', topic: 'CLI fault isolation — VLAN/trunking',
+    title: 'New desk drop places a workstation on the wrong network', estMinutes: 6,
+    scenario: 'A workstation freshly cabled into a new desk drop pulls an IP address but it\'s from the guest Wi-Fi subnet (10.90.0.0/24) instead of the corporate LAN (10.15.0.0/24). Facilities patched the drop into what they thought was a standard access port.',
+    cliFault: { fault: 'vlan' },
+    assets: { reference: { kind: 'terminal', host: 'ACCESS-SW9', session: 'console', reveal: 'external', excerpts: [
+      { id: 'ipconfig', necessary: false, promptLine: 'ipconfig', reveal: 'ipconfig', lines: [
+        { text: 'IPv4 Address. . . . . . . . . . . : 10.90.0.87' },
+        { text: 'Default Gateway . . . . . . . . . : 10.90.0.1' }
+      ] },
+      { id: 'macfind', necessary: false, promptLine: 'show mac address-table address 001a.99cc.4401', reveal: 'macfind', lines: [
+        { text: 'Vlan  Mac Address     Type    Ports' },
+        { text: '90    001a.99cc.4401  DYNAMIC  Gi0/14' }
+      ] },
+      { id: 'swport', necessary: true, promptLine: 'show running-config interface gi0/14', reveal: 'swport', lines: [
+        { text: 'interface GigabitEthernet0/14' },
+        { text: ' switchport access vlan 90' },
+        { text: ' switchport mode access' },
+        { text: 'end' }
+      ] },
+      { id: 'vlandb', necessary: false, promptLine: 'show vlan brief | include 15|90', reveal: 'vlandb', lines: [
+        { text: 'VLAN Name                             Status    Ports' },
+        { text: '15    CORP-LAN   active    Gi0/1, Gi0/2, Gi0/3' },
+        { text: '90    GUEST      active    Gi0/13, Gi0/14, Gi0/15' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'The host is getting an IP, just from the wrong subnet. Select the commands that isolate why.',
+        explanation: 'The running-config for Gi0/14 shows `switchport access vlan 90`, which on its own proves the port is bound to the wrong VLAN — `show vlan brief` is useful follow-up context (confirming VLAN 90 is the guest network vs. the intended VLAN 15) but isn\'t required to prove the fault. The host ipconfig and MAC-table lookup only confirm symptoms already known from the ticket.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['swport'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Diagnose the fault and pick the fix.',
+        explanation: 'The desk-drop\'s switch port was statically assigned to the guest access VLAN (90) instead of the corporate LAN VLAN (15), so DHCP correctly hands out a guest-subnet address for that port\'s broadcast domain. Reassigning the port\'s access VLAN to 15 puts the host on the correct network.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'The access port is assigned to the guest VLAN (90) instead of corp LAN (15)' },
+            { id: 'b', text: 'The DHCP scope for VLAN 15 has been exhausted' },
+            { id: 'c', text: 'A duplex mismatch on the access port' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Change the port\'s access VLAN from 90 to 15' },
+            { id: 'b', text: 'Expand the DHCP scope for VLAN 15' },
+            { id: 'c', text: 'Force the port to full-duplex' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-11', cert: 'netplus', archetype: 'cli', objective: '5.4', topic: 'CLI fault isolation — VLAN/trunking',
+    title: 'Two switches, one trunk, and a phantom native VLAN', estMinutes: 7,
+    scenario: 'Since a new access switch was added to an existing trunk uplink, users on the far switch report seeing occasional traffic and CDP warnings that don\'t belong to their VLAN, and voice VLAN tagging looks inconsistent. Both switches were configured by different techs.',
+    cliFault: { fault: 'vlan' },
+    assets: { reference: { kind: 'terminal', host: 'DIST-SW1', session: 'ssh', reveal: 'external', excerpts: [
+      { id: 'cdplog', necessary: false, promptLine: 'show logging | include CDP', reveal: 'cdplog', lines: [
+        { text: '%CDP-4-NATIVE_VLAN_MISMATCH: Native VLAN mismatch discovered on GigabitEthernet0/24' }
+      ] },
+      { id: 'trunklocal', necessary: false, promptLine: 'show interface gi0/24 trunk', reveal: 'trunklocal', lines: [
+        { text: 'Port       Mode   Encapsulation  Status     Native vlan' },
+        { text: 'Gi0/24     on     802.1q         trunking   1' }
+      ] },
+      { id: 'trunkremote', necessary: true, promptLine: 'show interface gi0/1 trunk', reveal: 'trunkremote', lines: [
+        { text: 'Port       Mode   Encapsulation  Status     Native vlan' },
+        { text: 'Gi0/1      on     802.1q         trunking   99' }
+      ] },
+      { id: 'sviremote', necessary: false, promptLine: 'show ip interface brief', reveal: 'sviremote', lines: [
+        { text: 'Vlan1     10.15.0.1    YES NVRAM  up    up' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'Traffic is leaking across VLANs on this trunk. Select the commands that isolate the cause.',
+        explanation: 'A native VLAN mismatch only shows up by comparing both ends of the trunk, so a technician should run `show interface trunk` on the local switch as well as the remote one — but the remote side\'s output (native VLAN 99, versus this switch\'s own default of native VLAN 1) is what actually confirms the mismatch and drives the fix, since a mismatch is defined relative to the far end\'s configuration. The CDP log line hints something is wrong but doesn\'t itself prove the fault, and the SVI listing is unrelated.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['trunkremote'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'What is the root cause, and how do you fix it?',
+        explanation: 'The two ends of the 802.1q trunk were configured with different native VLANs (1 vs. 99); untagged frames on one end get interpreted as belonging to the other end\'s native VLAN, leaking traffic across VLAN boundaries. Setting both ends to the same native VLAN eliminates the leak.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'Native VLAN mismatch across the trunk (VLAN 1 vs. VLAN 99)' },
+            { id: 'b', text: 'A duplex mismatch on the trunk uplink' },
+            { id: 'c', text: 'The trunk is missing an IP gateway' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Configure the same native VLAN on both ends of the trunk' },
+            { id: 'b', text: 'Force both trunk ends to full-duplex' },
+            { id: 'c', text: 'Assign an SVI IP address to the trunk port' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
+  },
+
+  {
+    id: 'np-cli-12', cert: 'netplus', archetype: 'cli', objective: '5.4', topic: 'CLI fault isolation — VLAN/trunking',
+    title: 'VoIP phones register but calls have no audio path', estMinutes: 7,
+    scenario: 'After a phone-system firmware push, desk phones on VLAN 60 (voice) register with the call manager, but calls connect with no audio. Data traffic from the same desks (PCs daisy-chained through the phones on VLAN 15) is unaffected.',
+    cliFault: { fault: 'vlan' },
+    assets: { reference: { kind: 'terminal', host: 'ACCESS-SW3', session: 'console', reveal: 'external', excerpts: [
+      { id: 'voipreg', necessary: false, promptLine: 'show ip phone registration', reveal: 'voipreg', lines: [
+        { text: 'Phone 10.60.0.44 registered with call manager 10.60.0.5' }
+      ] },
+      { id: 'swportvoice', necessary: true, promptLine: 'show running-config interface gi0/9', reveal: 'swportvoice', lines: [
+        { text: 'interface GigabitEthernet0/9' },
+        { text: ' switchport access vlan 15' },
+        { text: ' switchport mode access' },
+        { text: 'end' }
+      ] },
+      { id: 'vlanaudio', necessary: false, promptLine: 'show vlan brief | include 60', reveal: 'vlanaudio', lines: [
+        { text: 'VLAN Name                             Status    Ports' },
+        { text: '60    VOICE      active    Gi0/1, Gi0/2' }
+      ] },
+      { id: 'cdpphone', necessary: false, promptLine: 'show cdp neighbors gi0/9 detail', reveal: 'cdpphone', lines: [
+        { text: 'Device ID: SEP001A2233' },
+        { text: 'Platform: Cisco IP Phone 8845' }
+      ] }
+    ] } },
+    steps: [
+      { id: 'cmds', type: 'analyze', points: 1,
+        prompt: 'Phones register (control-plane works) but audio never flows. Select the commands that isolate why.',
+        explanation: 'The running-config for Gi0/9 shows only `switchport access vlan 15` — no `switchport voice vlan` line at all — which on its own proves the audio VLAN was never bound to this port even though signaling (which rides the data VLAN\'s reachability to the call manager) succeeds. `show vlan brief` is useful corroborating context (confirming VLAN 60 exists elsewhere but not on this port) but isn\'t required to prove the fault. Registration status and CDP detail confirm the phone is present but not why audio fails.',
+        payload: { multi: true, mode: 'reveal', scoring: 'lenient' },
+        answer: { selected: ['swportvoice'] } },
+      { id: 'dx', type: 'configure', points: 1,
+        prompt: 'Diagnose the root cause and select the fix.',
+        explanation: 'The firmware push apparently reset (or never had) the voice VLAN assignment on the access port, so the phone registers over the data VLAN\'s reachability to the call manager but the actual RTP audio VLAN (60) was never trunked to this port — audio has no VLAN to ride on. Configuring the voice VLAN on the access port restores the audio path.',
+        payload: { slots: [
+          { id: 'rootCause', label: 'Root cause', options: [
+            { id: 'a', text: 'The access port has no voice VLAN configured, so VLAN 60 never reaches the phone' },
+            { id: 'b', text: 'The phone NIC is set to half-duplex' },
+            { id: 'c', text: 'The call manager\'s DNS record is stale' }
+          ] },
+          { id: 'fix', label: 'Fix', options: [
+            { id: 'a', text: 'Configure "switchport voice vlan 60" on the access port' },
+            { id: 'b', text: 'Force the phone port to full-duplex' },
+            { id: 'c', text: 'Update the call manager DNS record' }
+          ] }
+        ] },
+        answer: { slots: { rootCause: 'a', fix: 'a' } } }
+    ]
   }
 
 ];

--- a/features/sim-lab-seed-netplus.js
+++ b/features/sim-lab-seed-netplus.js
@@ -3950,6 +3950,2481 @@ window.SIM_LAB_SEED_NETPLUS = [
         ] },
         answer: { slots: { rootCause: 'a', fix: 'a' } } }
     ]
-  }
+  },
 
+// ---------- NETWORK DISCOVERY AUDIT (11) ----------
+  {
+    id: 'np-disc-01',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Marketing floor port map reconciliation',
+    estMinutes: 8,
+    scenario: 'Facilities is renumbering the 3rd-floor marketing suite and asked you to confirm the current port map before they touch anything. You have console access to SW-MKT3. The existing documentation (a CSV exported from the old ticketing system) is the only record anyone has — reconcile it against live discovery output and flag anything it got wrong.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi1/0/5',
+          device: 'PRT-MKT-M608',
+          mgmt: '10.30.10.15'
+        },
+        {
+          port: 'Gi1/0/12',
+          device: 'PHN-MKT-214',
+          mgmt: '10.30.10.44'
+        },
+        {
+          port: 'Gi1/0/18',
+          device: 'CAM-MKT-N4',
+          mgmt: '10.30.10.61'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-MKT3',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi1/0/5    Port ID: eth0    System Name: PRT-MKT-M608    Mgmt Address: 10.30.10.15    Capability: S',
+                fact: {
+                  port: 'Gi1/0/5',
+                  device: 'PRT-MKT-M608',
+                  mgmt: '10.30.10.15'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi1/0/12    Port ID: port1    System Name: PHN-MKT-214    Mgmt Address: 10.30.10.44    Capability: T',
+                fact: {
+                  port: 'Gi1/0/12',
+                  device: 'PHN-MKT-214',
+                  mgmt: '10.30.10.44'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  30    0c8b.d3a1.7f02    DYNAMIC     Gi1/0/18',
+                fact: {
+                  mac: '0c8b.d3a1.7f02',
+                  port: 'Gi1/0/18'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.30.10.61   42   0c8b.d3a1.7f02  ARPA   Vlan30',
+                fact: {
+                  ip: '10.30.10.61',
+                  mac: '0c8b.d3a1.7f02'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.30.10.44   6   aab1.22cd.9911  ARPA   Vlan30',
+                fact: {
+                  ip: '10.30.10.44',
+                  mac: 'aab1.22cd.9911'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi1/0/5,PRT-MKT-M608,10.30.10.16,IDF-3A',
+                select: true,
+                fact: {
+                  port: 'Gi1/0/5',
+                  device: 'PRT-MKT-M608',
+                  mgmt: '10.30.10.16'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi1/0/12,PHN-MKT-214,10.30.10.44,IDF-3A',
+                select: true,
+                fact: {
+                  port: 'Gi1/0/12',
+                  device: 'PHN-MKT-214',
+                  mgmt: '10.30.10.44'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi1/0/18,CAM-MKT-N4,10.30.10.61,IDF-3A',
+                select: true,
+                fact: {
+                  port: 'Gi1/0/18',
+                  device: 'CAM-MKT-N4',
+                  mgmt: '10.30.10.61'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each of the three ports above using the LLDP, MAC-table, and ARP output.',
+        explanation: 'Gi1/0/5 and Gi1/0/12 answer LLDP directly. Gi1/0/18 is silent on LLDP; its MAC-table entry names the port, and joining that MAC through the ARP table resolves the camera’s IP without any LLDP frame from the camera itself.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi1/0/5__ip',
+              label: 'Reconciled management IP — Gi1/0/5',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.30.10.15'
+                },
+                {
+                  id: 'b',
+                  text: '10.30.10.16'
+                },
+                {
+                  id: 'c',
+                  text: '10.30.10.115'
+                }
+              ]
+            },
+            {
+              id: 'Gi1/0/12__ip',
+              label: 'Reconciled management IP — Gi1/0/12',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.30.10.44'
+                },
+                {
+                  id: 'b',
+                  text: '10.30.10.45'
+                },
+                {
+                  id: 'c',
+                  text: '10.30.10.144'
+                }
+              ]
+            },
+            {
+              id: 'Gi1/0/18__ip',
+              label: 'Reconciled management IP — Gi1/0/18',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.30.10.61'
+                },
+                {
+                  id: 'b',
+                  text: '10.30.10.60'
+                },
+                {
+                  id: 'c',
+                  text: '10.30.10.161'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi1/0/5__ip': 'a',
+            'Gi1/0/12__ip': 'a',
+            'Gi1/0/18__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single row in the legacy CSV that no longer matches reconciled reality.',
+        explanation: 'The legacy sheet lists the marketing printer at .16, but live LLDP reports its management address as .15 — the CSV is stale for that one row; the phone and camera rows match the reconciled truth exactly.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg1']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-02',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Warehouse mezzanine AP and label printer audit',
+    estMinutes: 8,
+    scenario: 'A vendor is about to swap out label printers on the warehouse mezzanine and wants a confirmed port map first. The site’s only documentation is a spreadsheet export from three years ago. Pull live discovery from SW-WH-MEZ and reconcile it before the vendor arrives.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/3',
+          device: 'AP-WH-MEZ-02',
+          mgmt: '10.40.5.12'
+        },
+        {
+          port: 'Gi0/9',
+          device: 'WKS-WH-07',
+          mgmt: '10.40.5.33'
+        },
+        {
+          port: 'Gi0/14',
+          device: 'ZEBRA-LBL-04',
+          mgmt: '10.40.5.51'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-WH-MEZ',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/3    Port ID: GE0    System Name: AP-WH-MEZ-02    Mgmt Address: 10.40.5.12    Capability: W',
+                fact: {
+                  port: 'Gi0/3',
+                  device: 'AP-WH-MEZ-02',
+                  mgmt: '10.40.5.12'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/9    Port ID: eth0    System Name: WKS-WH-07    Mgmt Address: 10.40.5.33    Capability: S',
+                fact: {
+                  port: 'Gi0/9',
+                  device: 'WKS-WH-07',
+                  mgmt: '10.40.5.33'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  40    3c5a.b4e1.20f7    DYNAMIC     Gi0/14',
+                fact: {
+                  mac: '3c5a.b4e1.20f7',
+                  port: 'Gi0/14'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.40.5.51   17   3c5a.b4e1.20f7  ARPA   Vlan40',
+                fact: {
+                  ip: '10.40.5.51',
+                  mac: '3c5a.b4e1.20f7'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.40.5.12   88   9911.aabb.1122  ARPA   Vlan40',
+                fact: {
+                  ip: '10.40.5.12',
+                  mac: '9911.aabb.1122'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/3,AP-WH-MEZ-01,10.40.5.12,MEZ-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/3',
+                  device: 'AP-WH-MEZ-01',
+                  mgmt: '10.40.5.12'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/9,WKS-WH-07,10.40.5.33,MEZ-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/9',
+                  device: 'WKS-WH-07',
+                  mgmt: '10.40.5.33'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/14,ZEBRA-LBL-04,10.40.5.51,MEZ-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/14',
+                  device: 'ZEBRA-LBL-04',
+                  mgmt: '10.40.5.51'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port using the discovery output.',
+        explanation: 'The AP and workstation both answer LLDP directly. The label printer never sends LLDP; its MAC-table entry on Gi0/14 joined against the ARP table is the only way to resolve its address.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/3__ip',
+              label: 'Reconciled management IP — Gi0/3',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.40.5.12'
+                },
+                {
+                  id: 'b',
+                  text: '10.40.5.13'
+                },
+                {
+                  id: 'c',
+                  text: '10.40.5.112'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/9__ip',
+              label: 'Reconciled management IP — Gi0/9',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.40.5.33'
+                },
+                {
+                  id: 'b',
+                  text: '10.40.5.34'
+                },
+                {
+                  id: 'c',
+                  text: '10.40.5.133'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/14__ip',
+              label: 'Reconciled management IP — Gi0/14',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.40.5.51'
+                },
+                {
+                  id: 'b',
+                  text: '10.40.5.50'
+                },
+                {
+                  id: 'c',
+                  text: '10.40.5.151'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/3__ip': 'a',
+            'Gi0/9__ip': 'a',
+            'Gi0/14__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The spreadsheet names the mezzanine AP "AP-WH-MEZ-01", but live LLDP reports its system name as "AP-WH-MEZ-02" — the AP was swapped and the old name never got updated. IP and closet for that row are otherwise correct, and the other two rows match exactly.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg1']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-03',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Clinic nurse station port map audit',
+    estMinutes: 8,
+    scenario: 'A clinic’s 2nd-floor nurse station is being re-cabled for a new badge-reader rollout, and the facilities team’s only record is a legacy access-control CSV. Confirm the current port map from SW-CLN-2F before anyone pulls a cable.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/2',
+          device: 'WKS-CLN-11',
+          mgmt: '10.22.4.20'
+        },
+        {
+          port: 'Gi0/7',
+          device: 'PRT-CLN-2F',
+          mgmt: '10.22.4.40'
+        },
+        {
+          port: 'Gi0/11',
+          device: 'BADGE-CLN-2F-3',
+          mgmt: '10.22.4.71'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-CLN-2F',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/2    Port ID: eth0    System Name: WKS-CLN-11    Mgmt Address: 10.22.4.20    Capability: S',
+                fact: {
+                  port: 'Gi0/2',
+                  device: 'WKS-CLN-11',
+                  mgmt: '10.22.4.20'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/7    Port ID: eth0    System Name: PRT-CLN-2F    Mgmt Address: 10.22.4.40    Capability: S',
+                fact: {
+                  port: 'Gi0/7',
+                  device: 'PRT-CLN-2F',
+                  mgmt: '10.22.4.40'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  22    5566.7788.99aa    DYNAMIC     Gi0/11',
+                fact: {
+                  mac: '5566.7788.99aa',
+                  port: 'Gi0/11'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.22.4.71   121   5566.7788.99aa  ARPA   Vlan22',
+                fact: {
+                  ip: '10.22.4.71',
+                  mac: '5566.7788.99aa'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.22.4.20   3   1122.3344.5566  ARPA   Vlan22',
+                fact: {
+                  ip: '10.22.4.20',
+                  mac: '1122.3344.5566'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/2,WKS-CLN-11,10.22.4.20,IDF-2F',
+                select: true,
+                fact: {
+                  port: 'Gi0/2',
+                  device: 'WKS-CLN-11',
+                  mgmt: '10.22.4.20'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/7,PRT-CLN-2F,10.22.4.140,IDF-2F',
+                select: true,
+                fact: {
+                  port: 'Gi0/7',
+                  device: 'PRT-CLN-2F',
+                  mgmt: '10.22.4.140'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/11,BADGE-CLN-2F-3,10.22.4.71,IDF-2F',
+                select: true,
+                fact: {
+                  port: 'Gi0/11',
+                  device: 'BADGE-CLN-2F-3',
+                  mgmt: '10.22.4.71'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The workstation and printer both resolve directly via LLDP. The badge reader is silent on LLDP; its MAC-table entry on Gi0/11 joined against the ARP table gives the only way to resolve it.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/2__ip',
+              label: 'Reconciled management IP — Gi0/2',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.22.4.20'
+                },
+                {
+                  id: 'b',
+                  text: '10.22.4.21'
+                },
+                {
+                  id: 'c',
+                  text: '10.22.4.120'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/7__ip',
+              label: 'Reconciled management IP — Gi0/7',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.22.4.40'
+                },
+                {
+                  id: 'b',
+                  text: '10.22.4.41'
+                },
+                {
+                  id: 'c',
+                  text: '10.22.4.140'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/11__ip',
+              label: 'Reconciled management IP — Gi0/11',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.22.4.71'
+                },
+                {
+                  id: 'b',
+                  text: '10.22.4.70'
+                },
+                {
+                  id: 'c',
+                  text: '10.22.4.171'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/2__ip': 'a',
+            'Gi0/7__ip': 'a',
+            'Gi0/11__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The access-control CSV records the nurse-station printer at 10.22.4.140, but live LLDP reports its true management address as 10.22.4.40 — the legacy record overstates the last octet by 100. The other two rows match reconciled truth.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg2']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-04',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Data center rack port map audit',
+    estMinutes: 8,
+    scenario: 'A change window is coming up for rack R14 and the run book still points at a port map nobody has verified since the last hardware refresh. Reconcile the port map from SW-DC-R14 before the change window opens.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Te1/0/1',
+          device: 'ESX-DC-14A',
+          mgmt: '10.12.1.10'
+        },
+        {
+          port: 'Te1/0/2',
+          device: 'KVM-DC-R14',
+          mgmt: '10.12.1.18'
+        },
+        {
+          port: 'Te1/0/6',
+          device: 'IDRAC-DC-R14-5',
+          mgmt: '10.12.1.44'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-DC-R14',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Te1/0/1    Port ID: vmnic0    System Name: ESX-DC-14A    Mgmt Address: 10.12.1.10    Capability: S',
+                fact: {
+                  port: 'Te1/0/1',
+                  device: 'ESX-DC-14A',
+                  mgmt: '10.12.1.10'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Te1/0/2    Port ID: eth0    System Name: KVM-DC-R14    Mgmt Address: 10.12.1.18    Capability: S',
+                fact: {
+                  port: 'Te1/0/2',
+                  device: 'KVM-DC-R14',
+                  mgmt: '10.12.1.18'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  12    e0d5.5e11.a201    DYNAMIC     Te1/0/6',
+                fact: {
+                  mac: 'e0d5.5e11.a201',
+                  port: 'Te1/0/6'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.12.1.44   55   e0d5.5e11.a201  ARPA   Vlan12',
+                fact: {
+                  ip: '10.12.1.44',
+                  mac: 'e0d5.5e11.a201'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.12.1.10   9   f0a3.11bb.2c00  ARPA   Vlan12',
+                fact: {
+                  ip: '10.12.1.10',
+                  mac: 'f0a3.11bb.2c00'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Te1/0/1,ESX-DC-14A,10.12.1.10,R14',
+                select: true,
+                fact: {
+                  port: 'Te1/0/1',
+                  device: 'ESX-DC-14A',
+                  mgmt: '10.12.1.10'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Te1/0/2,KVM-DC-R14,10.12.1.18,R14',
+                select: true,
+                fact: {
+                  port: 'Te1/0/2',
+                  device: 'KVM-DC-R14',
+                  mgmt: '10.12.1.18'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Te1/0/6,IDRAC-DC-R14-5,10.12.1.144,R14',
+                select: true,
+                fact: {
+                  port: 'Te1/0/6',
+                  device: 'IDRAC-DC-R14-5',
+                  mgmt: '10.12.1.144'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The hypervisor host and KVM appliance both resolve directly via LLDP. The out-of-band management NIC never speaks LLDP; joining its MAC-table entry on Te1/0/6 against the ARP table is the only way to resolve it.',
+        payload: {
+          slots: [
+            {
+              id: 'Te1/0/1__ip',
+              label: 'Reconciled management IP — Te1/0/1',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.12.1.10'
+                },
+                {
+                  id: 'b',
+                  text: '10.12.1.11'
+                },
+                {
+                  id: 'c',
+                  text: '10.12.1.110'
+                }
+              ]
+            },
+            {
+              id: 'Te1/0/2__ip',
+              label: 'Reconciled management IP — Te1/0/2',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.12.1.18'
+                },
+                {
+                  id: 'b',
+                  text: '10.12.1.19'
+                },
+                {
+                  id: 'c',
+                  text: '10.12.1.118'
+                }
+              ]
+            },
+            {
+              id: 'Te1/0/6__ip',
+              label: 'Reconciled management IP — Te1/0/6',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.12.1.44'
+                },
+                {
+                  id: 'b',
+                  text: '10.12.1.45'
+                },
+                {
+                  id: 'c',
+                  text: '10.12.1.144'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Te1/0/1__ip': 'a',
+            'Te1/0/2__ip': 'a',
+            'Te1/0/6__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The run book lists the out-of-band management NIC (IDRAC-DC-R14-5) at 10.12.1.144, but the MAC/ARP join resolves its live address as 10.12.1.44 — the run book carried over a stale address from before the last hardware refresh and was never corrected. The other two rows match.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg3']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-05',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Retail store point-of-sale port map audit',
+    estMinutes: 8,
+    scenario: 'Loss prevention wants confirmation of every port feeding the register lane before a PCI walk-through. The store’s documentation is a CSV last touched during store opening. Reconcile it against live discovery from SW-RTL-118.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/4',
+          device: 'POS-RTL-03',
+          mgmt: '10.55.2.13'
+        },
+        {
+          port: 'Gi0/8',
+          device: 'CAM-RTL-LANE1',
+          mgmt: '10.55.2.28'
+        },
+        {
+          port: 'Gi0/15',
+          device: 'PHN-RTL-LANE1',
+          mgmt: '10.55.2.49'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-RTL-118',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/4    Port ID: eth0    System Name: POS-RTL-03    Mgmt Address: 10.55.2.13    Capability: S',
+                fact: {
+                  port: 'Gi0/4',
+                  device: 'POS-RTL-03',
+                  mgmt: '10.55.2.13'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/8    Port ID: eth0    System Name: CAM-RTL-LANE1    Mgmt Address: 10.55.2.28    Capability: S',
+                fact: {
+                  port: 'Gi0/8',
+                  device: 'CAM-RTL-LANE1',
+                  mgmt: '10.55.2.28'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  55    a4c1.3e02.7788    DYNAMIC     Gi0/15',
+                fact: {
+                  mac: 'a4c1.3e02.7788',
+                  port: 'Gi0/15'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.55.2.49   63   a4c1.3e02.7788  ARPA   Vlan55',
+                fact: {
+                  ip: '10.55.2.49',
+                  mac: 'a4c1.3e02.7788'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.55.2.13   14   00de.ad11.beef  ARPA   Vlan55',
+                fact: {
+                  ip: '10.55.2.13',
+                  mac: '00de.ad11.beef'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/4,POS-RTL-03,10.55.2.31,BACK-OFFICE',
+                select: true,
+                fact: {
+                  port: 'Gi0/4',
+                  device: 'POS-RTL-03',
+                  mgmt: '10.55.2.31'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/8,CAM-RTL-LANE1,10.55.2.28,BACK-OFFICE',
+                select: true,
+                fact: {
+                  port: 'Gi0/8',
+                  device: 'CAM-RTL-LANE1',
+                  mgmt: '10.55.2.28'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/15,PHN-RTL-LANE1,10.55.2.49,BACK-OFFICE',
+                select: true,
+                fact: {
+                  port: 'Gi0/15',
+                  device: 'PHN-RTL-LANE1',
+                  mgmt: '10.55.2.49'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The POS terminal and camera both resolve directly via LLDP. The lane phone is silent on LLDP; joining its MAC-table entry on Gi0/15 against the ARP table resolves its address.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/4__ip',
+              label: 'Reconciled management IP — Gi0/4',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.55.2.13'
+                },
+                {
+                  id: 'b',
+                  text: '10.55.2.14'
+                },
+                {
+                  id: 'c',
+                  text: '10.55.2.113'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/8__ip',
+              label: 'Reconciled management IP — Gi0/8',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.55.2.28'
+                },
+                {
+                  id: 'b',
+                  text: '10.55.2.29'
+                },
+                {
+                  id: 'c',
+                  text: '10.55.2.128'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/15__ip',
+              label: 'Reconciled management IP — Gi0/15',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.55.2.49'
+                },
+                {
+                  id: 'b',
+                  text: '10.55.2.48'
+                },
+                {
+                  id: 'c',
+                  text: '10.55.2.149'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/4__ip': 'a',
+            'Gi0/8__ip': 'a',
+            'Gi0/15__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The opening-day CSV lists the register-lane POS terminal at 10.55.2.31, but live LLDP reports its management address as 10.55.2.13 — the terminal was re-addressed after opening and the record was never updated. The camera and phone rows match reconciled truth.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg1']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-06',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Classroom AV closet port map audit',
+    estMinutes: 8,
+    scenario: 'IT is prepping classroom B12 for a projector replacement and wants the port map confirmed against live discovery before the installer shows up. The only existing record is a CSV from the AV integrator’s original install.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/6',
+          device: 'WKS-CLS-B12',
+          mgmt: '10.60.3.16'
+        },
+        {
+          port: 'Gi0/10',
+          device: 'PROJ-CLS-B12',
+          mgmt: '10.60.3.22'
+        },
+        {
+          port: 'Gi0/13',
+          device: 'SIGN-CLS-HALLB',
+          mgmt: '10.60.3.58'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-CLS-B12',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/6    Port ID: eth0    System Name: WKS-CLS-B12    Mgmt Address: 10.60.3.16    Capability: S',
+                fact: {
+                  port: 'Gi0/6',
+                  device: 'WKS-CLS-B12',
+                  mgmt: '10.60.3.16'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/10    Port ID: eth0    System Name: PROJ-CLS-B12    Mgmt Address: 10.60.3.22    Capability: S',
+                fact: {
+                  port: 'Gi0/10',
+                  device: 'PROJ-CLS-B12',
+                  mgmt: '10.60.3.22'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  60    88aa.2211.ffdd    DYNAMIC     Gi0/13',
+                fact: {
+                  mac: '88aa.2211.ffdd',
+                  port: 'Gi0/13'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.60.3.58   29   88aa.2211.ffdd  ARPA   Vlan60',
+                fact: {
+                  ip: '10.60.3.58',
+                  mac: '88aa.2211.ffdd'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.60.3.16   4   77bb.4455.2200  ARPA   Vlan60',
+                fact: {
+                  ip: '10.60.3.16',
+                  mac: '77bb.4455.2200'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/6,WKS-CLS-B12,10.60.3.16,IDF-B',
+                select: true,
+                fact: {
+                  port: 'Gi0/6',
+                  device: 'WKS-CLS-B12',
+                  mgmt: '10.60.3.16'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/10,PROJ-CLS-B12,10.60.3.22,IDF-B',
+                select: true,
+                fact: {
+                  port: 'Gi0/10',
+                  device: 'PROJ-CLS-B12',
+                  mgmt: '10.60.3.22'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/13,SIGN-CLS-HALLB,10.60.3.158,IDF-B',
+                select: true,
+                fact: {
+                  port: 'Gi0/13',
+                  device: 'SIGN-CLS-HALLB',
+                  mgmt: '10.60.3.158'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The classroom PC and projector both resolve directly via LLDP. The hallway digital-signage player never speaks LLDP; joining its MAC-table entry on Gi0/13 against the ARP table resolves it.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/6__ip',
+              label: 'Reconciled management IP — Gi0/6',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.60.3.16'
+                },
+                {
+                  id: 'b',
+                  text: '10.60.3.17'
+                },
+                {
+                  id: 'c',
+                  text: '10.60.3.116'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/10__ip',
+              label: 'Reconciled management IP — Gi0/10',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.60.3.22'
+                },
+                {
+                  id: 'b',
+                  text: '10.60.3.23'
+                },
+                {
+                  id: 'c',
+                  text: '10.60.3.122'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/13__ip',
+              label: 'Reconciled management IP — Gi0/13',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.60.3.58'
+                },
+                {
+                  id: 'b',
+                  text: '10.60.3.57'
+                },
+                {
+                  id: 'c',
+                  text: '10.60.3.158'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/6__ip': 'a',
+            'Gi0/10__ip': 'a',
+            'Gi0/13__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The AV integrator’s CSV lists the hallway signage player at 10.60.3.158, but the MAC/ARP join resolves its live address as 10.60.3.58 — the integrator’s original paperwork carried an address from staging that was never corrected. The PC and projector rows match.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg3']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-07',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Hospital floor telemetry port map audit',
+    estMinutes: 8,
+    scenario: 'Biomed is auditing every network-connected device on the 2E telemetry wing ahead of a compliance review. The wing’s only documentation is a CSV last updated by a contractor two device refreshes ago. Reconcile it against live discovery from SW-HOSP-2E.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/5',
+          device: 'NURSECALL-2E',
+          mgmt: '10.18.6.12'
+        },
+        {
+          port: 'Gi0/9',
+          device: 'PRT-HOSP-2E',
+          mgmt: '10.18.6.30'
+        },
+        {
+          port: 'Gi0/16',
+          device: 'PUMP-HOSP-2E-9',
+          mgmt: '10.18.6.67'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-HOSP-2E',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/5    Port ID: eth0    System Name: NURSECALL-2E    Mgmt Address: 10.18.6.12    Capability: S',
+                fact: {
+                  port: 'Gi0/5',
+                  device: 'NURSECALL-2E',
+                  mgmt: '10.18.6.12'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/9    Port ID: eth0    System Name: PRT-HOSP-2E    Mgmt Address: 10.18.6.30    Capability: S',
+                fact: {
+                  port: 'Gi0/9',
+                  device: 'PRT-HOSP-2E',
+                  mgmt: '10.18.6.30'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  18    2244.6688.aacc    DYNAMIC     Gi0/16',
+                fact: {
+                  mac: '2244.6688.aacc',
+                  port: 'Gi0/16'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.18.6.67   97   2244.6688.aacc  ARPA   Vlan18',
+                fact: {
+                  ip: '10.18.6.67',
+                  mac: '2244.6688.aacc'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.18.6.12   11   99ee.3311.5577  ARPA   Vlan18',
+                fact: {
+                  ip: '10.18.6.12',
+                  mac: '99ee.3311.5577'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/5,NURSECALL-2E,10.18.6.12,IDF-2E',
+                select: true,
+                fact: {
+                  port: 'Gi0/5',
+                  device: 'NURSECALL-2E',
+                  mgmt: '10.18.6.12'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/9,PRT-HOSP-2E,10.18.6.30,IDF-2E',
+                select: true,
+                fact: {
+                  port: 'Gi0/9',
+                  device: 'PRT-HOSP-2E',
+                  mgmt: '10.18.6.30'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/16,PUMP-HOSP-2E-9,10.18.6.68,IDF-2E',
+                select: true,
+                fact: {
+                  port: 'Gi0/16',
+                  device: 'PUMP-HOSP-2E-9',
+                  mgmt: '10.18.6.68'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The nurse-call panel and printer both resolve directly via LLDP. The infusion pump is silent on LLDP; joining its MAC-table entry on Gi0/16 against the ARP table resolves its address.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/5__ip',
+              label: 'Reconciled management IP — Gi0/5',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.18.6.12'
+                },
+                {
+                  id: 'b',
+                  text: '10.18.6.13'
+                },
+                {
+                  id: 'c',
+                  text: '10.18.6.112'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/9__ip',
+              label: 'Reconciled management IP — Gi0/9',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.18.6.30'
+                },
+                {
+                  id: 'b',
+                  text: '10.18.6.31'
+                },
+                {
+                  id: 'c',
+                  text: '10.18.6.130'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/16__ip',
+              label: 'Reconciled management IP — Gi0/16',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.18.6.67'
+                },
+                {
+                  id: 'b',
+                  text: '10.18.6.66'
+                },
+                {
+                  id: 'c',
+                  text: '10.18.6.167'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/5__ip': 'a',
+            'Gi0/9__ip': 'a',
+            'Gi0/16__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The contractor’s CSV lists the infusion pump at 10.18.6.68, but the MAC/ARP join resolves its actual address as 10.18.6.67 — the pump was reassigned during a DHCP reservation cleanup and the sheet was never updated. The other two rows match reconciled truth.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg3']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-08',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Bank branch teller line port map audit',
+    estMinutes: 8,
+    scenario: 'Branch operations is replacing the lobby digital menu board and wants the port map confirmed first — the branch’s only record is a CSV from the original branch build-out. Reconcile it against live discovery from SW-BNK-118.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/3',
+          device: 'TELLER-BNK-04',
+          mgmt: '10.8.2.11'
+        },
+        {
+          port: 'Gi0/7',
+          device: 'ATMCTRL-BNK-1',
+          mgmt: '10.8.2.20'
+        },
+        {
+          port: 'Gi0/12',
+          device: 'MENU-BNK-LOBBY',
+          mgmt: '10.8.2.55'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-BNK-118',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/3    Port ID: eth0    System Name: TELLER-BNK-04    Mgmt Address: 10.8.2.11    Capability: S',
+                fact: {
+                  port: 'Gi0/3',
+                  device: 'TELLER-BNK-04',
+                  mgmt: '10.8.2.11'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/7    Port ID: eth0    System Name: ATMCTRL-BNK-1    Mgmt Address: 10.8.2.20    Capability: S',
+                fact: {
+                  port: 'Gi0/7',
+                  device: 'ATMCTRL-BNK-1',
+                  mgmt: '10.8.2.20'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  8    6699.aabb.ccdd    DYNAMIC     Gi0/12',
+                fact: {
+                  mac: '6699.aabb.ccdd',
+                  port: 'Gi0/12'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.8.2.55   38   6699.aabb.ccdd  ARPA   Vlan8',
+                fact: {
+                  ip: '10.8.2.55',
+                  mac: '6699.aabb.ccdd'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.8.2.11   5   4411.8822.cc33  ARPA   Vlan8',
+                fact: {
+                  ip: '10.8.2.11',
+                  mac: '4411.8822.cc33'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/3,TELLER-BNK-04,10.8.2.11,BR-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/3',
+                  device: 'TELLER-BNK-04',
+                  mgmt: '10.8.2.11'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/7,ATMCTRL-BNK-1,10.8.2.20,BR-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/7',
+                  device: 'ATMCTRL-BNK-1',
+                  mgmt: '10.8.2.20'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/12,MENU-BNK-LOBBY,10.8.2.155,BR-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/12',
+                  device: 'MENU-BNK-LOBBY',
+                  mgmt: '10.8.2.155'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The teller workstation and ATM controller both resolve directly via LLDP. The lobby menu board is silent on LLDP; joining its MAC-table entry on Gi0/12 against the ARP table resolves its address.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/3__ip',
+              label: 'Reconciled management IP — Gi0/3',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.8.2.11'
+                },
+                {
+                  id: 'b',
+                  text: '10.8.2.12'
+                },
+                {
+                  id: 'c',
+                  text: '10.8.2.111'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/7__ip',
+              label: 'Reconciled management IP — Gi0/7',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.8.2.20'
+                },
+                {
+                  id: 'b',
+                  text: '10.8.2.21'
+                },
+                {
+                  id: 'c',
+                  text: '10.8.2.120'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/12__ip',
+              label: 'Reconciled management IP — Gi0/12',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.8.2.55'
+                },
+                {
+                  id: 'b',
+                  text: '10.8.2.54'
+                },
+                {
+                  id: 'c',
+                  text: '10.8.2.155'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/3__ip': 'a',
+            'Gi0/7__ip': 'a',
+            'Gi0/12__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The build-out CSV lists the lobby menu board at 10.8.2.155, but the MAC/ARP join resolves its live address as 10.8.2.55 — the equipment was swapped from an interactive kiosk to a menu board during the same visit its address was reassigned, and the sheet was never updated. The teller and ATM controller rows match.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg3']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-09',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Hotel guest-floor port map audit',
+    estMinutes: 8,
+    scenario: 'Engineering is troubleshooting complaints about a guest-floor travel router someone plugged into the wall, and wants the whole 4th-floor port map confirmed before they go pull a cable. The only documentation is a CSV from the hotel’s IT contractor.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/4',
+          device: 'FDPC-HTL-4F',
+          mgmt: '10.44.1.10'
+        },
+        {
+          port: 'Gi0/9',
+          device: 'PHN-HTL-4F-12',
+          mgmt: '10.44.1.26'
+        },
+        {
+          port: 'Gi0/22',
+          device: 'UNK-TRAVELRTR-4F',
+          mgmt: '10.44.1.73'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-HTL-4F',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/4    Port ID: eth0    System Name: FDPC-HTL-4F    Mgmt Address: 10.44.1.10    Capability: S',
+                fact: {
+                  port: 'Gi0/4',
+                  device: 'FDPC-HTL-4F',
+                  mgmt: '10.44.1.10'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/9    Port ID: port1    System Name: PHN-HTL-4F-12    Mgmt Address: 10.44.1.26    Capability: T',
+                fact: {
+                  port: 'Gi0/9',
+                  device: 'PHN-HTL-4F-12',
+                  mgmt: '10.44.1.26'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  44    ccdd.eeff.0011    DYNAMIC     Gi0/22',
+                fact: {
+                  mac: 'ccdd.eeff.0011',
+                  port: 'Gi0/22'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.44.1.73   71   ccdd.eeff.0011  ARPA   Vlan44',
+                fact: {
+                  ip: '10.44.1.73',
+                  mac: 'ccdd.eeff.0011'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.44.1.10   19   1234.5678.9abc  ARPA   Vlan44',
+                fact: {
+                  ip: '10.44.1.10',
+                  mac: '1234.5678.9abc'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/4,FDPC-HTL-4F,10.44.1.10,IDF-4F',
+                select: true,
+                fact: {
+                  port: 'Gi0/4',
+                  device: 'FDPC-HTL-4F',
+                  mgmt: '10.44.1.10'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/9,PHN-HTL-4F-12,10.44.1.26,IDF-4F',
+                select: true,
+                fact: {
+                  port: 'Gi0/9',
+                  device: 'PHN-HTL-4F-12',
+                  mgmt: '10.44.1.26'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/22,VACANT-4F-22,10.44.1.75,IDF-4F',
+                select: true,
+                fact: {
+                  port: 'Gi0/22',
+                  device: 'VACANT-4F-22',
+                  mgmt: '10.44.1.75'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The front-desk PC and room phone both resolve directly via LLDP. The unauthorized travel router does not speak LLDP; joining its MAC-table entry on Gi0/22 against the ARP table is the only way to see it exists and where it landed.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/4__ip',
+              label: 'Reconciled management IP — Gi0/4',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.44.1.10'
+                },
+                {
+                  id: 'b',
+                  text: '10.44.1.11'
+                },
+                {
+                  id: 'c',
+                  text: '10.44.1.110'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/9__ip',
+              label: 'Reconciled management IP — Gi0/9',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.44.1.26'
+                },
+                {
+                  id: 'b',
+                  text: '10.44.1.27'
+                },
+                {
+                  id: 'c',
+                  text: '10.44.1.126'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/22__ip',
+              label: 'Reconciled management IP — Gi0/22',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.44.1.73'
+                },
+                {
+                  id: 'b',
+                  text: '10.44.1.72'
+                },
+                {
+                  id: 'c',
+                  text: '10.44.1.173'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/4__ip': 'a',
+            'Gi0/9__ip': 'a',
+            'Gi0/22__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The contractor’s sheet lists Gi0/22 as vacant at .75, but live discovery shows an active host answering at .73 on that same port — the port isn’t vacant at all, it has an unauthorized device plugged in. The other two rows match reconciled truth.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg3']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-10',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Manufacturing floor HMI port map audit',
+    estMinutes: 8,
+    scenario: 'Controls engineering wants the line-2 network map confirmed before a PLC firmware push this weekend. The floor’s only documentation is a CSV that predates the last panel rebuild. Reconcile it against live discovery from SW-MFG-L2.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/2',
+          device: 'HMI-MFG-L2',
+          mgmt: '10.70.9.14'
+        },
+        {
+          port: 'Gi0/6',
+          device: 'PRT-MFG-L2',
+          mgmt: '10.70.9.28'
+        },
+        {
+          port: 'Gi0/19',
+          device: 'PLC-MFG-L2-3',
+          mgmt: '10.70.9.60'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-MFG-L2',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/2    Port ID: eth0    System Name: HMI-MFG-L2    Mgmt Address: 10.70.9.14    Capability: S',
+                fact: {
+                  port: 'Gi0/2',
+                  device: 'HMI-MFG-L2',
+                  mgmt: '10.70.9.14'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/6    Port ID: eth0    System Name: PRT-MFG-L2    Mgmt Address: 10.70.9.28    Capability: S',
+                fact: {
+                  port: 'Gi0/6',
+                  device: 'PRT-MFG-L2',
+                  mgmt: '10.70.9.28'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  70    de11.ad22.be33    DYNAMIC     Gi0/19',
+                fact: {
+                  mac: 'de11.ad22.be33',
+                  port: 'Gi0/19'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.70.9.60   150   de11.ad22.be33  ARPA   Vlan70',
+                fact: {
+                  ip: '10.70.9.60',
+                  mac: 'de11.ad22.be33'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.70.9.14   8   55aa.66bb.77cc  ARPA   Vlan70',
+                fact: {
+                  ip: '10.70.9.14',
+                  mac: '55aa.66bb.77cc'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/2,HMI-MFG-L2,10.70.9.14,MFG-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/2',
+                  device: 'HMI-MFG-L2',
+                  mgmt: '10.70.9.14'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/6,PRT-MFG-L2,10.70.9.28,MFG-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/6',
+                  device: 'PRT-MFG-L2',
+                  mgmt: '10.70.9.28'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/19,PLC-MFG-L2-3,10.70.9.160,MFG-IDF',
+                select: true,
+                fact: {
+                  port: 'Gi0/19',
+                  device: 'PLC-MFG-L2-3',
+                  mgmt: '10.70.9.160'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The HMI panel and line printer both resolve directly via LLDP. The PLC never speaks LLDP; joining its MAC-table entry on Gi0/19 against the ARP table resolves it.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/2__ip',
+              label: 'Reconciled management IP — Gi0/2',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.70.9.14'
+                },
+                {
+                  id: 'b',
+                  text: '10.70.9.15'
+                },
+                {
+                  id: 'c',
+                  text: '10.70.9.114'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/6__ip',
+              label: 'Reconciled management IP — Gi0/6',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.70.9.28'
+                },
+                {
+                  id: 'b',
+                  text: '10.70.9.29'
+                },
+                {
+                  id: 'c',
+                  text: '10.70.9.128'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/19__ip',
+              label: 'Reconciled management IP — Gi0/19',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.70.9.60'
+                },
+                {
+                  id: 'b',
+                  text: '10.70.9.61'
+                },
+                {
+                  id: 'c',
+                  text: '10.70.9.160'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/2__ip': 'a',
+            'Gi0/6__ip': 'a',
+            'Gi0/19__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The pre-rebuild CSV lists the PLC at 10.70.9.160, but the MAC/ARP join resolves its live address as 10.70.9.60 — the panel rebuild swapped in a different PLC unit on a new address and the documentation was never updated. The HMI and printer rows match.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg3']
+        }
+      }
+    ]
+  },
+
+  {
+    id: 'np-disc-11',
+    cert: 'netplus',
+    archetype: 'discovery',
+    objective: '3.5',
+    topic: 'Network discovery audit — port-mapping reconciliation',
+    title: 'Dorm floor port map audit',
+    estMinutes: 8,
+    scenario: 'Res-life IT is investigating a bandwidth complaint on dorm floor 5 and wants the port map confirmed against live discovery before they start capping ports. The floor’s only documentation is a CSV from the last move-in cycle.',
+    disco: {
+      legacyExcerptId: 'legacy',
+      ports: [
+        {
+          port: 'Gi0/2',
+          device: 'RA-WKS-DORM5',
+          mgmt: '10.90.3.10'
+        },
+        {
+          port: 'Gi0/6',
+          device: 'PRT-DORM5-COMMON',
+          mgmt: '10.90.3.25'
+        },
+        {
+          port: 'Gi0/31',
+          device: 'CONSOLE-DORM5-512',
+          mgmt: '10.90.3.88'
+        }
+      ]
+    },
+    assets: {
+      reference: {
+        kind: 'terminal',
+        host: 'SW-DORM-5',
+        session: 'ssh',
+        reveal: 'tabs',
+        excerpts: [
+          {
+            id: 'lldp',
+            promptLine: 'show lldp neighbors detail',
+            lines: [
+              {
+                id: 'lldp1',
+                text: 'Local Intf: Gi0/2    Port ID: eth0    System Name: RA-WKS-DORM5    Mgmt Address: 10.90.3.10    Capability: S',
+                fact: {
+                  port: 'Gi0/2',
+                  device: 'RA-WKS-DORM5',
+                  mgmt: '10.90.3.10'
+                }
+              },
+              {
+                id: 'lldp2',
+                text: 'Local Intf: Gi0/6    Port ID: eth0    System Name: PRT-DORM5-COMMON    Mgmt Address: 10.90.3.25    Capability: S',
+                fact: {
+                  port: 'Gi0/6',
+                  device: 'PRT-DORM5-COMMON',
+                  mgmt: '10.90.3.25'
+                }
+              }
+            ]
+          },
+          {
+            id: 'mac',
+            promptLine: 'show mac address-table',
+            lines: [
+              {
+                id: 'mac1',
+                text: '  90    f001.ba22.7c9d    DYNAMIC     Gi0/31',
+                fact: {
+                  mac: 'f001.ba22.7c9d',
+                  port: 'Gi0/31'
+                }
+              }
+            ]
+          },
+          {
+            id: 'arp',
+            promptLine: 'show arp',
+            lines: [
+              {
+                id: 'arp1',
+                text: 'Internet  10.90.3.88   26   f001.ba22.7c9d  ARPA   Vlan90',
+                fact: {
+                  ip: '10.90.3.88',
+                  mac: 'f001.ba22.7c9d'
+                }
+              },
+              {
+                id: 'arp2',
+                text: 'Internet  10.90.3.10   7   3300.aabb.ccdd  ARPA   Vlan90',
+                fact: {
+                  ip: '10.90.3.10',
+                  mac: '3300.aabb.ccdd'
+                }
+              }
+            ]
+          },
+          {
+            id: 'legacy',
+            promptLine: 'cat port-map-legacy.csv',
+            lines: [
+              {
+                id: 'leg1',
+                text: 'Gi0/2,RA-WKS-DORM5,10.90.3.10,IDF-5',
+                select: true,
+                fact: {
+                  port: 'Gi0/2',
+                  device: 'RA-WKS-DORM5',
+                  mgmt: '10.90.3.10'
+                }
+              },
+              {
+                id: 'leg2',
+                text: 'Gi0/6,PRT-DORM5-COMMON,10.90.3.25,IDF-5',
+                select: true,
+                fact: {
+                  port: 'Gi0/6',
+                  device: 'PRT-DORM5-COMMON',
+                  mgmt: '10.90.3.25'
+                }
+              },
+              {
+                id: 'leg3',
+                text: 'Gi0/31,CONSOLE-DORM5-512,10.90.3.89,IDF-5',
+                select: true,
+                fact: {
+                  port: 'Gi0/31',
+                  device: 'CONSOLE-DORM5-512',
+                  mgmt: '10.90.3.89'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    steps: [
+      {
+        id: 'rec',
+        type: 'configure',
+        points: 1,
+        prompt: 'Reconcile the true management IP for each port from the discovery output.',
+        explanation: 'The RA workstation and common-area printer both resolve directly via LLDP. The gaming console is silent on LLDP; joining its MAC-table entry on Gi0/31 against the ARP table resolves its address.',
+        payload: {
+          slots: [
+            {
+              id: 'Gi0/2__ip',
+              label: 'Reconciled management IP — Gi0/2',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.90.3.10'
+                },
+                {
+                  id: 'b',
+                  text: '10.90.3.11'
+                },
+                {
+                  id: 'c',
+                  text: '10.90.3.110'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/6__ip',
+              label: 'Reconciled management IP — Gi0/6',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.90.3.25'
+                },
+                {
+                  id: 'b',
+                  text: '10.90.3.26'
+                },
+                {
+                  id: 'c',
+                  text: '10.90.3.125'
+                }
+              ]
+            },
+            {
+              id: 'Gi0/31__ip',
+              label: 'Reconciled management IP — Gi0/31',
+              options: [
+                {
+                  id: 'a',
+                  text: '10.90.3.88'
+                },
+                {
+                  id: 'b',
+                  text: '10.90.3.87'
+                },
+                {
+                  id: 'c',
+                  text: '10.90.3.188'
+                }
+              ]
+            }
+          ]
+        },
+        answer: {
+          slots: {
+            'Gi0/2__ip': 'a',
+            'Gi0/6__ip': 'a',
+            'Gi0/31__ip': 'a'
+          }
+        }
+      },
+      {
+        id: 'aud',
+        type: 'analyze',
+        points: 1,
+        prompt: 'Select the single legacy row that contradicts reconciled reality.',
+        explanation: 'The move-in CSV lists the room-512 console at 10.90.3.89, but the MAC/ARP join resolves its live address as 10.90.3.88 — a lease renewal shifted the last octet and the sheet was never refreshed. The RA workstation and printer rows match reconciled truth.',
+        payload: {
+          multi: false,
+          mode: 'excerptLines'
+        },
+        answer: {
+          selected: ['leg3']
+        }
+      }
+    ]
+  }
 ];

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -331,6 +331,62 @@
     return { ok: errs.length === 0, errors: errs };
   }
 
+  // --- CLI fault-isolation fidelity validator (Wave 2 Task 4) ---
+  // Proves, machine-checkable: (a) the necessary excerpts carry every line-fact the
+  // keyed fault requires; (b) the keyed rootCause/fix configure answers match the
+  // fault; (c) the necessary set is a genuine minimal isolation cover (mutation-checked:
+  // dropping any necessary excerpt must make a required fact unreachable).
+  var _CLI_FAULT_SIG = {
+    duplex:  { needles: [/half-?duplex/i, /late collision/i, /full[ -]?duplex/i], root: /duplex/i, fix: /auto-?negoti|duplex/i },
+    gateway: { needles: [/gateway/i, /request timed out|unreachable/i], root: /gateway/i, fix: /gateway|route/i },
+    dns:     { needles: [/dns/i, /could not|non-existent|can'?t resolve/i], root: /dns/i, fix: /dns|resolver|flushdns/i },
+    vlan:    { needles: [/vlan/i, /native vlan|access vlan/i], root: /vlan/i, fix: /vlan/i }
+  };
+  function _cliExcerptText(ex) {
+    return (ex.lines || []).map(function (l) { return String(l.text || ''); }).join('\n');
+  }
+  function _cliNeedlesMet(excerpts, sig) {
+    var blob = excerpts.map(_cliExcerptText).join('\n');
+    return sig.needles.every(function (rx) { return rx.test(blob); });
+  }
+  function simLabValidateCliFaultFidelity(scn) {
+    var errs = [];
+    var ref = scn && scn.assets && scn.assets.reference;
+    var fault = scn && scn.cliFault && scn.cliFault.fault;
+    if (!ref || ref.kind !== 'terminal' || !Array.isArray(ref.excerpts)) {
+      return { ok: false, errors: ['cli fidelity: terminal reference with excerpts[] required'] };
+    }
+    var sig = _CLI_FAULT_SIG[fault];
+    if (!sig) return { ok: false, errors: ['cli fidelity: unknown cliFault.fault "' + fault + '"'] };
+
+    var necessary = ref.excerpts.filter(function (ex) { return ex.necessary; });
+    if (!necessary.length) errs.push('cli fidelity: no necessary excerpts declared');
+    // (a) the necessary set proves the fault
+    if (!_cliNeedlesMet(necessary, sig)) {
+      errs.push('cli fidelity: necessary excerpts do not carry all "' + fault + '" fault facts');
+    }
+    // (c) minimal cover — every necessary excerpt is load-bearing
+    necessary.forEach(function (drop) {
+      var without = necessary.filter(function (ex) { return ex !== drop; });
+      if (_cliNeedlesMet(without, sig)) {
+        errs.push('cli fidelity: necessary excerpt "' + drop.id + '" is redundant (fault still derivable without it)');
+      }
+    });
+    // (b) keyed diagnosis matches the fault
+    var cfg = (scn.steps || []).filter(function (st) {
+      return st.type === 'configure' && st.answer && st.answer.slots &&
+        (st.answer.slots.rootCause !== undefined || st.answer.slots.fix !== undefined);
+    })[0];
+    if (!cfg) { errs.push('cli fidelity: no configure step with rootCause/fix slots'); }
+    else {
+      var root = _slFidelityResolveSlot(cfg, 'rootCause');
+      var fix = _slFidelityResolveSlot(cfg, 'fix');
+      if (root === undefined || !sig.root.test(root)) errs.push('cli fidelity: keyed rootCause "' + root + '" does not match ' + fault);
+      if (fix === undefined || !sig.fix.test(fix)) errs.push('cli fidelity: keyed fix "' + fix + '" does not match ' + fault);
+    }
+    return { ok: errs.length === 0, errors: errs };
+  }
+
   // --- scoring (Task 2) ---
 
   function _norm(v) {

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -1367,12 +1367,12 @@
     }
     if (scn.assets && scn.assets.reference) {
       var refPanel = _slRenderReference(scn.assets.reference);
-      if (scn.assets && scn.assets.reference && scn.assets.reference.kind === 'terminal') {
-        window.__slTerminalRef = scn.assets.reference;
-        window.__slTerminalPanel = refPanel;
-      } else { window.__slTerminalRef = null; window.__slTerminalPanel = null; }
       if (refPanel) wrap.appendChild(refPanel);
     }
+    if (scn.assets && scn.assets.reference && scn.assets.reference.kind === 'terminal') {
+      window.__slTerminalRef = scn.assets.reference;
+      window.__slTerminalPanel = refPanel;
+    } else { window.__slTerminalRef = null; window.__slTerminalPanel = null; }
     scn.steps.forEach(function (st, i) {
       var stepWrap = _el('div', 'sl-step');
       stepWrap.appendChild(_el('div', 'sl-step-k', 'Step ' + (i + 1) + ' of ' + scn.steps.length));

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -462,6 +462,69 @@
     return { ok: errs.length === 0, errors: errs };
   }
 
+  // --- evidence-triage fidelity validator (Wave 2 Task 6) ---
+  // Proves, machine-checkable: (a) the keyed evidence lines (evidence:true) exist,
+  // are exactly the analyze step's answer.selected, and are diagnostic of the fault;
+  // at least one selectable evidence:false distractor remains (the "Media connected"
+  // trap) so the set can't be trivially all-true; (b) the diagnosis/firstMove keyed
+  // answers follow from the fault signature.
+  var _TRIAGE_FAULT_SIG = {
+    apipa:    { evNeedles: [/169\.254\./, /gateway\s*:?\s*$/i], diag: /apipa|169\.254|no dhcp/i, fix: /renew|dhcp/i },
+    deadDns:  { evNeedles: [/can'?t resolve|dns request timed out|non-existent/i], diag: /dns/i, fix: /dns|renew|flushdns/i },
+    badGw:    { evNeedles: [/unreachable|request timed out/i, /gateway/i], diag: /gateway|route/i, fix: /gateway|route/i }
+    };
+  function _triageEvidenceLines(ref) {
+    var all = [];
+    (ref.excerpts || []).forEach(function (ex) {
+      (ex.lines || []).forEach(function (ln) { all.push(ln); });
+    });
+    return all;
+  }
+  function simLabValidateEvidenceTriageFidelity(scn) {
+    var errs = [];
+    var ref = scn && scn.assets && scn.assets.reference;
+    var fault = scn && scn.triage && scn.triage.fault;
+    if (!ref || ref.kind !== 'terminal' || !Array.isArray(ref.excerpts)) {
+      return { ok: false, errors: ['triage fidelity: terminal reference with excerpts[] required'] };
+    }
+    var sig = _TRIAGE_FAULT_SIG[fault];
+    if (!sig) return { ok: false, errors: ['triage fidelity: unknown triage.fault "' + fault + '"'] };
+
+    var lines = _triageEvidenceLines(ref);
+    var selectable = lines.filter(function (l) { return l.select; });
+    var trueLines = selectable.filter(function (l) { return l.evidence === true; });
+    var falseLines = selectable.filter(function (l) { return l.evidence === false; });
+
+    if (!trueLines.length) errs.push('triage: no evidence:true selectable lines');
+    if (!falseLines.length) errs.push('triage: no evidence:false selectable distractor (set is trivially all-true)');
+
+    // (a) keyed selected == the evidence:true line ids
+    var flag = (scn.steps || []).filter(function (st) { return st.type === 'analyze'; })[0];
+    var keyed = (flag && flag.answer && flag.answer.selected) ? flag.answer.selected.slice().sort() : [];
+    var trueIds = trueLines.map(function (l) { return l.id; }).sort();
+    if (keyed.join(',') !== trueIds.join(',')) {
+      errs.push('triage: keyed selected [' + keyed.join(',') + '] != evidence:true ids [' + trueIds.join(',') + ']');
+    }
+    // diagnostic signature present in the true lines
+    var trueBlob = trueLines.map(function (l) { return String(l.text || ''); }).join('\n');
+    sig.evNeedles.forEach(function (rx) {
+      if (!rx.test(trueBlob)) errs.push('triage: fault "' + fault + '" needle ' + rx + ' not found in flagged evidence');
+    });
+    // (b) keyed diagnosis/firstMove follow from the fault
+    var cfg = (scn.steps || []).filter(function (st) {
+      return st.type === 'configure' && st.answer && st.answer.slots &&
+        (st.answer.slots.diagnosis !== undefined || st.answer.slots.firstMove !== undefined);
+    })[0];
+    if (!cfg) errs.push('triage: no configure step with diagnosis/firstMove slots');
+    else {
+      var diag = _slFidelityResolveSlot(cfg, 'diagnosis');
+      var fix = _slFidelityResolveSlot(cfg, 'firstMove');
+      if (diag === undefined || !sig.diag.test(diag)) errs.push('triage: keyed diagnosis "' + diag + '" does not match ' + fault);
+      if (fix === undefined || !sig.fix.test(fix)) errs.push('triage: keyed firstMove "' + fix + '" does not match ' + fault);
+    }
+    return { ok: errs.length === 0, errors: errs };
+  }
+
   // --- scoring (Task 2) ---
 
   function _norm(v) {

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -71,7 +71,7 @@
         errs.push('reference layered: bad layout');
       }
     }
-    if (s.archetype !== undefined && ['diagram', 'incident', 'defense', 'wireless', 'firewall', 'soho'].indexOf(s.archetype) === -1) {
+    if (s.archetype !== undefined && ['diagram', 'incident', 'defense', 'wireless', 'firewall', 'soho', 'cli', 'discovery', 'triage'].indexOf(s.archetype) === -1) {
       errs.push('bad archetype');
     }
     return { ok: errs.length === 0, errors: errs };

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -472,7 +472,7 @@
     apipa:    { evNeedles: [/169\.254\./, /gateway\s*:?\s*$/i], diag: /apipa|169\.254|no dhcp/i, fix: /renew|dhcp/i },
     deadDns:  { evNeedles: [/can'?t resolve|dns request timed out|non-existent/i], diag: /dns/i, fix: /dns|renew|flushdns/i },
     badGw:    { evNeedles: [/unreachable|request timed out/i, /gateway/i], diag: /gateway|route/i, fix: /gateway|route/i }
-    };
+  };
   function _triageEvidenceLines(ref) {
     var all = [];
     (ref.excerpts || []).forEach(function (ex) {
@@ -500,9 +500,9 @@
 
     // (a) keyed selected == the evidence:true line ids
     var flag = (scn.steps || []).filter(function (st) { return st.type === 'analyze'; })[0];
-    var keyed = (flag && flag.answer && flag.answer.selected) ? flag.answer.selected.slice().sort() : [];
-    var trueIds = trueLines.map(function (l) { return l.id; }).sort();
-    if (keyed.join(',') !== trueIds.join(',')) {
+    var keyed = (flag && flag.answer && flag.answer.selected) ? flag.answer.selected : [];
+    var trueIds = trueLines.map(function (l) { return l.id; });
+    if (!_setEq(keyed, trueIds)) {
       errs.push('triage: keyed selected [' + keyed.join(',') + '] != evidence:true ids [' + trueIds.join(',') + ']');
     }
     // diagnostic signature present in the true lines

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -387,6 +387,81 @@
     return { ok: errs.length === 0, errors: errs };
   }
 
+  // --- discovery-audit fidelity validator (Wave 2 Task 5) ---
+  // Proves, machine-checkable: (a) every keyed port-mapping answer is DERIVABLE from the
+  // terminal excerpts' structured line facts — infra ports from LLDP, the silent
+  // host from a MAC-table<->ARP join; (b) exactly ONE legacy-CSV select:true row
+  // contradicts the reconciled truth and it is the keyed audit line (mutation-safe).
+  function _discoLineFacts(ref) {
+    var by = { lldp: [], mac: [], arp: [], legacy: [] };
+    (ref.excerpts || []).forEach(function (ex) {
+      (ex.lines || []).forEach(function (ln) {
+        if (!ln.fact) return;
+        if (ex.id === 'lldp') by.lldp.push(ln.fact);
+        else if (ex.id === 'mac') by.mac.push(ln.fact);
+        else if (ex.id === 'arp') by.arp.push(ln.fact);
+      });
+    });
+    return by;
+  }
+  function _discoDerivePort(facts, port) {
+    var l = facts.lldp.filter(function (f) { return f.port === port; })[0];
+    if (l) return { device: l.device, mgmt: l.mgmt };
+    var m = facts.mac.filter(function (f) { return f.port === port; })[0];
+    if (m) {
+      var a = facts.arp.filter(function (f) { return f.mac === m.mac; })[0];
+      if (a) return { device: null, mgmt: a.ip };   // silent host: device unknown, IP via join
+    }
+    return null;
+  }
+  function simLabValidateDiscoveryAuditFidelity(scn) {
+    var errs = [];
+    var ref = scn && scn.assets && scn.assets.reference;
+    var disco = scn && scn.disco;
+    if (!ref || ref.kind !== 'terminal' || !Array.isArray(ref.excerpts) || !disco || !Array.isArray(disco.ports)) {
+      return { ok: false, errors: ['disco fidelity: terminal reference + scn.disco.ports[] required'] };
+    }
+    var facts = _discoLineFacts(ref);
+    var cfg = (scn.steps || []).filter(function (st) { return st.type === 'configure'; })[0];
+
+    // (a) every keyed port answer derivable
+    disco.ports.forEach(function (p) {
+      var derived = _discoDerivePort(facts, p.port);
+      if (!derived) { errs.push('disco: port ' + p.port + ' not derivable from excerpts'); return; }
+      if (derived.mgmt !== p.mgmt) errs.push('disco: port ' + p.port + ' mgmt "' + p.mgmt + '" != derived ' + derived.mgmt);
+      if (cfg) {
+        var keyedIp = _slFidelityResolveSlot(cfg, p.port + '__ip');
+        if (keyedIp !== undefined && keyedIp !== derived.mgmt) {
+          errs.push('disco: keyed ' + p.port + '__ip "' + keyedIp + '" != derived ' + derived.mgmt);
+        }
+        var keyedDev = _slFidelityResolveSlot(cfg, p.port + '__dev');
+        if (keyedDev !== undefined && p.device && derived.device && keyedDev !== derived.device) {
+          errs.push('disco: keyed ' + p.port + '__dev "' + keyedDev + '" != derived ' + derived.device);
+        }
+      }
+    });
+
+    // (b) exactly one legacy row contradicts, and it is the keyed audit line
+    var truthByPort = {};
+    disco.ports.forEach(function (p) { truthByPort[p.port] = p; });
+    var legacy = (ref.excerpts.filter(function (ex) { return ex.id === disco.legacyExcerptId; })[0] || { lines: [] }).lines
+      .filter(function (ln) { return ln.select && ln.fact; });
+    var contradicting = legacy.filter(function (ln) {
+      var truth = truthByPort[ln.fact.port];
+      return truth && (ln.fact.mgmt !== truth.mgmt || (ln.fact.device && truth.device && ln.fact.device !== truth.device));
+    });
+    if (contradicting.length !== 1) {
+      errs.push('disco: expected exactly 1 contradicting legacy row, found ' + contradicting.length);
+    } else {
+      var aud = (scn.steps || []).filter(function (st) { return st.type === 'analyze'; })[0];
+      var keyed = aud && aud.answer && aud.answer.selected;
+      if (!keyed || keyed.length !== 1 || keyed[0] !== contradicting[0].id) {
+        errs.push('disco: keyed audit line is not the single contradicting row (' + contradicting[0].id + ')');
+      }
+    }
+    return { ok: errs.length === 0, errors: errs };
+  }
+
   // --- scoring (Task 2) ---
 
   function _norm(v) {

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -22,6 +22,9 @@
         return Array.isArray(p.left) && Array.isArray(p.right) &&
                p.left.length >= 2 && p.left.length === p.right.length && a.pairs && typeof a.pairs === 'object';
       case 'analyze':
+        if (p.mode === 'reveal' || p.mode === 'excerptLines') {
+          return Array.isArray(a.selected) && a.selected.length >= 1;
+        }
         return Array.isArray(p.lines) && p.lines.length >= 2 &&
                Array.isArray(a.selected) && a.selected.length >= 1;
       case 'fillin':
@@ -365,6 +368,14 @@
     return { total: total, correct: correct };
   }
 
+  function _scoreAnalyzeLenient(step, resp) {
+    var want = (step.answer && step.answer.selected) || [];
+    var got = (resp && resp.selected) || [];
+    var total = want.length, correct = 0;
+    want.forEach(function (id) { if (got.indexOf(id) !== -1) correct++; });   // false picks never subtract
+    return { total: total, correct: correct };
+  }
+
   function _scoreStep(step, resp) {
     if (!resp) return false;
     switch (step.type) {
@@ -379,6 +390,10 @@
           return resp.pairs && resp.pairs[l] === step.answer.pairs[l];
         }) && resp.pairs && Object.keys(resp.pairs).length === Object.keys(step.answer.pairs).length;
       case 'analyze':
+        if (step.payload && step.payload.scoring === 'lenient') {
+          var _al = _scoreAnalyzeLenient(step, resp);
+          return _al.total > 0 && _al.correct === _al.total;
+        }
         return _setEq(resp.selected, step.answer.selected);
       case 'fillin':
         return step.payload.fields.every(function (f) {
@@ -401,6 +416,10 @@
         var sc = _scoreConfigureSlots(st, resp);
         perStep[st.id] = sc;            // { total, correct } breakdown for configure
         correct += sc.correct; total += sc.total;
+      } else if (st.type === 'analyze' && st.payload && st.payload.scoring === 'lenient') {
+        var la = _scoreAnalyzeLenient(st, resp);
+        perStep[st.id] = la;            // { total, correct } breakdown for lenient analyze
+        correct += la.correct; total += la.total;
       } else {
         var ok = _scoreStep(st, resp);
         perStep[st.id] = ok;            // boolean for existing types
@@ -604,6 +623,12 @@
 
   // --- analyze renderer ---
   function _slRenderAnalyze(step, onChange, initial) {
+    // Wave 2: mode steps bind targets from the terminal reference (single source of
+    // truth) instead of building their own .sl-analyze-block. Default (no mode) below is UNCHANGED.
+    var mode = step.payload.mode;
+    if (mode === 'reveal' || mode === 'excerptLines') {
+      return _slRenderAnalyzeMode(step, onChange, initial, mode);
+    }
     // Default to multi-select unless a step opts OUT explicitly (`multi:
     // false`). Every pre-Wave-1 analyze step across every bank already
     // declares `multi: false` when it wants single-select, so this default
@@ -653,6 +678,54 @@
       });
     }
     onChange({ selected: selected.slice() });
+    return root;
+  }
+
+  function _slRenderAnalyzeMode(step, onChange, initial, mode) {
+    var multi = step.payload.multi !== false;
+    var selected = (initial && Array.isArray(initial.selected)) ? initial.selected.slice() : [];
+    var root = _el('div', 'sl-analyze sl-analyze-mode');
+    root.appendChild(_el('p', 'sl-prompt', _esc(step.prompt)));
+
+    function emit() { onChange({ selected: selected.slice() }); }
+    function toggle(id) {
+      var idx = selected.indexOf(id);
+      if (multi) { if (idx === -1) selected.push(id); else selected.splice(idx, 1); }
+      else { selected = (idx === -1) ? [id] : []; }
+      emit();
+    }
+
+    if (mode === 'reveal') {
+      // command menu: one button per reveal-keyed excerpt; running reveals + marks it ran (advisory)
+      var ref = (window.__slTerminalRef) || null;
+      var menu = _el('div', 'sl-cmd-menu');
+      var excerpts = (ref && Array.isArray(ref.excerpts)) ? ref.excerpts : [];
+      excerpts.filter(function (ex) { return ex.reveal; }).forEach(function (ex) {
+        var b = _el('button', 'sl-cmd', _esc(ex.promptLine || ex.id));
+        b.setAttribute('type', 'button'); b.setAttribute('data-cmd', ex.id);
+        b.addEventListener('click', function () {
+          if (b.classList) b.classList.add('used');
+          if (window.__slRevealExcerpt) window.__slRevealExcerpt(ex.reveal);
+          if (selected.indexOf(ex.id) === -1) { selected.push(ex.id); emit(); }
+        });
+        menu.appendChild(b);
+      });
+      root.appendChild(menu);
+    } else {
+      // excerptLines: bind the terminal's already-rendered select:true line buttons
+      var host = (window.__slTerminalPanel) || null;
+      var btns = host ? host.querySelectorAll('button') : [];
+      btns.forEach(function (btn) {
+        if (!btn.className || btn.className.split(' ').indexOf('term-line') === -1) return;
+        var id = btn.getAttribute('data-line');
+        btn.addEventListener('click', function () {
+          toggle(id);
+          if (btn.classList) btn.classList.toggle('sl-sel', selected.indexOf(id) !== -1);
+        });
+        if (selected.indexOf(id) !== -1 && btn.classList) btn.classList.add('sl-sel');
+      });
+    }
+    emit();
     return root;
   }
 
@@ -1294,6 +1367,10 @@
     }
     if (scn.assets && scn.assets.reference) {
       var refPanel = _slRenderReference(scn.assets.reference);
+      if (scn.assets && scn.assets.reference && scn.assets.reference.kind === 'terminal') {
+        window.__slTerminalRef = scn.assets.reference;
+        window.__slTerminalPanel = refPanel;
+      } else { window.__slTerminalRef = null; window.__slTerminalPanel = null; }
       if (refPanel) wrap.appendChild(refPanel);
     }
     scn.steps.forEach(function (st, i) {

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -62,11 +62,14 @@
       });
     }
     if (s.assets && s.assets.reference) {
-      var ref = s.assets.reference, kinds = ['network', 'timeline', 'layered'];
+      var ref = s.assets.reference, kinds = ['network', 'timeline', 'layered', 'terminal'];
       if (kinds.indexOf(ref.kind) === -1) errs.push('reference: bad kind');
       else if (ref.kind === 'network' && !Array.isArray(ref.devices)) errs.push('reference network: devices[] required');
       else if (ref.kind === 'timeline' && !Array.isArray(ref.stages)) errs.push('reference timeline: stages[] required');
       else if (ref.kind === 'layered' && !Array.isArray(ref.layers)) errs.push('reference layered: layers[] required');
+      else if (ref.kind === 'terminal' && (!Array.isArray(ref.excerpts) || !ref.excerpts.every(function (ex) {
+        return ex && _isNonEmptyStr(ex.id) && Array.isArray(ex.lines);
+      }))) errs.push('reference terminal: excerpts[] with id+lines[] required');
       if (ref.kind === 'layered' && ref.layout !== undefined && ['nested', 'stacked'].indexOf(ref.layout) === -1) {
         errs.push('reference layered: bad layout');
       }
@@ -1167,6 +1170,95 @@
     return _el('div', 'sl-stacked', svgStr);
   }
 
+  // --- terminal / output-excerpt reference renderer (Wave 2 Task 2) ---
+  // The ONE new Wave 2 renderer. Three data-driven expressions off ref.reveal:
+  //   'tabs'     -> internal source-tab bar, one excerpt visible at a time (discovery)
+  //   'external' -> keyed excerpts start hidden; an external step calls revealExcerpt (cli)
+  //   undefined  -> all excerpts visible (triage)
+  // Escape-THEN-highlight per line/prompt (excerpt text is untrusted scenario data).
+  // Selectable lines are real <button>s so an analyze step can bind them (single
+  // source of truth for line text, so the fidelity validators' cross-checks are exact).
+  function _termLineHtml(line) {
+    var esc = _esc(line.text);                       // escape FIRST
+    var cls = (line.highlight === 'hot' || line.highlight === 'good' || line.highlight === 'k') ? line.highlight : '';
+    return cls ? '<span class="' + cls + '">' + esc + '</span>' : esc;
+  }
+  function _termPromptHtml(promptLine) {
+    var esc = _esc(promptLine || '');                // escape FIRST, then span the leading token
+    var sp = esc.indexOf(' ');
+    return sp > 0 ? '<span class="pmt">' + esc.slice(0, sp) + '</span>' + esc.slice(sp) : esc;
+  }
+  function _slRenderRefTerminal(ref) {
+    var root = _el('div', 'term');
+    var head = _el('div', 'term-head');
+    var hostBox = _el('div', 'term-host', '<span class="lamp"><i></i><i></i><i></i></span>');
+    hostBox.appendChild(_el('span', 'term-host-name', _esc(ref.host || '')));
+    head.appendChild(hostBox);
+    head.appendChild(_el('div', 'term-sess', _esc(ref.session || '')));
+    root.appendChild(head);
+
+    var excerpts = (ref && Array.isArray(ref.excerpts)) ? ref.excerpts : [];
+    var mode = ref ? ref.reveal : undefined;         // 'tabs' | 'external' | undefined
+    var reduce = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    var body = _el('div', 'term-body');
+    var blockById = {};
+
+    excerpts.forEach(function (ex, i) {
+      var block = _el('div', 'term-block');
+      block.setAttribute('data-excerpt', ex.id);
+      var scroll = _el('div', 'term-scroll');
+      scroll.appendChild(_el('div', 'term-cmd', _termPromptHtml(ex.promptLine)));
+      var out = _el('div', 'term-out');
+      (ex.lines || []).forEach(function (ln) {
+        if (ln.select) {
+          var btn = _el('button', 'term-line' + (ln.evidence ? ' is-ev' : ''), _termLineHtml(ln));
+          btn.setAttribute('type', 'button');
+          btn.setAttribute('data-line', ln.id);
+          out.appendChild(btn);
+        } else {
+          out.appendChild(_el('div', 'term-ln' + (ln.ctx ? ' term-ctx' : ''), _termLineHtml(ln)));
+        }
+      });
+      scroll.appendChild(out);
+      block.appendChild(scroll);
+      var hide = (mode === 'tabs') ? (i !== 0) : (mode === 'external') ? !!ex.reveal : false;
+      if (hide) block.setAttribute('hidden', '');
+      body.appendChild(block);
+      blockById[ex.id] = block;
+    });
+
+    function revealExcerpt(key) {
+      var target = null;
+      excerpts.forEach(function (ex) { if (ex.reveal === key || ex.id === key) target = ex; });
+      if (!target || !blockById[target.id]) return;
+      var block = blockById[target.id];
+      block.removeAttribute('hidden');
+      if (!reduce && block.classList) block.classList.add('term-anim');
+    }
+
+    if (mode === 'tabs') {
+      var tabs = _el('div', 'term-tabs');
+      excerpts.forEach(function (ex, i) {
+        var tab = _el('button', 'term-tab' + (i === 0 ? ' on' : ''), _esc(ex.tab || ex.id));
+        tab.setAttribute('type', 'button');
+        tab.setAttribute('data-tab', ex.id);
+        tab.addEventListener('click', function () {
+          revealExcerpt(ex.id);
+          (tabs._children || []).forEach(function (t) {
+            if (t.classList) { t.classList.toggle('on', t.getAttribute('data-tab') === ex.id); t.classList.add('seen'); }
+          });
+        });
+        tabs.appendChild(tab);
+      });
+      root.appendChild(tabs);
+    }
+    root.appendChild(body);
+
+    root.revealExcerpt = revealExcerpt;
+    window.__slRevealExcerpt = revealExcerpt;
+    return root;
+  }
+
   function _slRenderReference(ref) {
     if (!ref || !ref.kind) return null;
     var panel = _el('div', 'sl-ref');
@@ -1174,6 +1266,11 @@
     else if (ref.kind === 'timeline') panel.appendChild(_slRenderRefTimeline(ref));
     else if (ref.kind === 'layered') {
       panel.appendChild(ref.layout === 'stacked' ? _slRenderRefLayeredStacked(ref) : _slRenderRefLayered(ref));
+    }
+    else if (ref.kind === 'terminal') {
+      var termNode = _slRenderRefTerminal(ref);
+      panel.appendChild(termNode);
+      panel.revealExcerpt = termNode.revealExcerpt;
     }
     return panel;
   }

--- a/index.html
+++ b/index.html
@@ -772,7 +772,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.62.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.63.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.61.2">
+<link rel="stylesheet" href="dg-system.css?v=7.61.3">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certanvil",
-  "version": "7.62.0",
+  "version": "7.63.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.62.0
+   Network+ AI Quiz — styles.css  v7.63.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.62.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.62.0';
+// Service Worker v7.63.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.63.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23439,6 +23439,121 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Wave 2 Task 10: A+ Core 1 Command-Output Evidence Triage seed-bank
+// validation ──
+// The 12 consensus-approved (two-agent gated) A+ Core 1 Command-Output
+// Evidence Triage scenarios now live for real in
+// features/sim-lab-seed-aplus-core1.js (window.SIM_LAB_SEED_APLUS_CORE1,
+// archetype 'triage'). This proves every one of them is real,
+// production-ready content: each passes the same pure validators that gate
+// the dev fixtures above (simLabValidateScenario +
+// simLabValidateEvidenceTriageFidelity), extracted from features/sim-lab.js
+// the same way the Task 6/7 dev-fixture block above does.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: A+ Core 1 Command-Output Evidence Triage seed-bank validation (Wave 2 Task 10) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+    function assert(cond, msg) { test(msg, !!cond); }
+
+    var grab = function (name) { return _fnBody(js, name); };
+
+    // ── Extract the REAL pure validators from features/sim-lab.js, exactly
+    // as the Task 6/7 dev-fixture triage block above does ──
+    var isNonEmptyStrBody    = grab('_isNonEmptyStr');
+    var validatePayloadBody  = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    var resolveSlotBody = grab('_slFidelityResolveSlot');
+    var arrEqBody        = grab('_arrEq');
+    var setEqBody        = grab('_setEq');
+    var sigVar           = (js.match(/var _TRIAGE_FAULT_SIG = \{[\s\S]*?\n\s*\};/) || [''])[0];
+    var evidenceLinesBody = grab('_triageEvidenceLines');
+    var triageFidelityBody = grab('simLabValidateEvidenceTriageFidelity');
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody ||
+        !resolveSlotBody || !sigVar || !evidenceLinesBody || !triageFidelityBody) {
+      test('A+ Core 1 Triage bank: validator helper extraction succeeded', false);
+      results.errors.push('could not extract validator helpers for Wave 2 Task 10 bank test; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext(resolveSlotBody, vCtx);
+    if (arrEqBody) vm.runInContext(arrEqBody, vCtx);
+    if (setEqBody) vm.runInContext(setEqBody, vCtx);
+    vm.runInContext(sigVar, vCtx);
+    vm.runInContext(evidenceLinesBody, vCtx);
+    vm.runInContext(triageFidelityBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario; globalThis.__triFidelity = simLabValidateEvidenceTriageFidelity;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+    var simLabValidateEvidenceTriageFidelity = vCtx.__triFidelity;
+
+    // ── Load the real seed bank: eval features/sim-lab-seed-aplus-core1.js
+    // in a sandbox with `var window = {}` so window.SIM_LAB_SEED_APLUS_CORE1
+    // populates ──
+    var seedSrc = read('features/sim-lab-seed-aplus-core1.js');
+    var seedCtx = {};
+    vm.createContext(seedCtx);
+    vm.runInContext('var window = {};\n' + seedSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_APLUS_CORE1;', seedCtx);
+    var seedBank = seedCtx.__seed;
+
+    test('A+ Core 1 Triage bank: window.SIM_LAB_SEED_APLUS_CORE1 loaded as an array',
+      Array.isArray(seedBank));
+    if (!Array.isArray(seedBank)) {
+      results.errors.push('could not load window.SIM_LAB_SEED_APLUS_CORE1 from features/sim-lab-seed-aplus-core1.js');
+      return;
+    }
+
+    var bankTriage = seedBank.filter(function (s) { return s && s.archetype === 'triage'; });
+    test('A+ Core 1 Triage bank: at least 10 triage-archetype scenarios present',
+      bankTriage.length >= 10);
+
+    var allValidateOk = true, allFidelityOk = true, allCertOk = true;
+    bankTriage.forEach(function (s) {
+      var vr = simLabValidateScenario(s);
+      if (!vr || vr.ok !== true) {
+        allValidateOk = false;
+        results.errors.push('A+ Core 1 Triage bank: ' + (s && s.id) + ' failed simLabValidateScenario: ' + JSON.stringify(vr && vr.errors));
+      }
+      var fr = simLabValidateEvidenceTriageFidelity(s);
+      if (!fr || fr.ok !== true) {
+        allFidelityOk = false;
+        results.errors.push('A+ Core 1 Triage bank: ' + (s && s.id) + ' failed simLabValidateEvidenceTriageFidelity: ' + JSON.stringify(fr && fr.errors));
+      }
+      if (s.cert !== 'aplus-core1') {
+        allCertOk = false;
+        results.errors.push('A+ Core 1 Triage bank: ' + (s && s.id) + ' has cert ' + s.cert + ', expected aplus-core1');
+      }
+    });
+
+    test('A+ Core 1 Triage bank: every triage scenario passes simLabValidateScenario',
+      allValidateOk);
+    test('A+ Core 1 Triage bank: every triage scenario passes simLabValidateEvidenceTriageFidelity',
+      allFidelityOk);
+    test('A+ Core 1 Triage bank: every triage scenario has cert === "aplus-core1"',
+      allCertOk);
+
+    // ── Extra cross-check: every triage scenario keeps a scored
+    // evidence:false distractor line among its selectable reference lines ──
+    bankTriage.forEach(function (s) {
+      var lines = []; s.assets.reference.excerpts.forEach(function (ex) { (ex.lines || []).forEach(function (l) { lines.push(l); }); });
+      var hasFalse = lines.some(function (l) { return l.select && l.evidence === false; });
+      test('triage ' + s.id + ': keeps a scored evidence:false distractor', hasFalse);
+    });
+
+  } catch (err) {
+    test('A+ Core 1 Triage bank: vm smoke test (threw)', false);
+    results.errors.push('A+ Core 1 Triage bank smoke test threw: ' + err.message);
+  }
+})();
+
 // The 20 consensus-approved Sec+ Incident Response scenarios now live for real
 // in features/sim-lab-seed-secplus.js (window.SIM_LAB_SEED_SECPLUS). This
 // proves every one of them is real, production-ready content: each passes the

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -20996,6 +20996,16 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
     test('archetype validation: unknown archetype "printer" still rejected',
       simLabValidateScenario(_sx).ok === false);
 
+    // 11. New archetype tags ('cli'/'discovery'/'triage') accepted; unknown still rejected.
+    ['cli', 'discovery', 'triage'].forEach(function (tag) {
+      var _s2 = _baseScn(); _s2.archetype = tag;
+      test('archetype validation: archetype ' + tag + ' accepted',
+        simLabValidateScenario(_s2).ok === true);
+    });
+    var _sx2 = _baseScn(); _sx2.archetype = 'logscan';
+    test('archetype validation: unknown archetype "logscan" still rejected',
+      simLabValidateScenario(_sx2).ok === false);
+
     // ── Mount test — vm-sandbox + DOM shim ──
     var elBody            = grab('_el');
     var escBody           = grabLine('_esc');

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21006,6 +21006,15 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
     test('archetype validation: unknown archetype "logscan" still rejected',
       simLabValidateScenario(_sx2).ok === false);
 
+    // ── Wave 2 Task 3: analyze mode step validates without payload.lines ──
+    var _modeStep = { id: 'm', type: 'analyze', prompt: 'p', explanation: 'e', points: 1,
+      payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' }, answer: { selected: ['l1'] } };
+    var _modeScn = _baseScn(); _modeScn.steps = [_modeStep];
+    _modeScn.assets = { reference: { kind: 'terminal', host: 'h', session: 's',
+      excerpts: [{ id: 'e', promptLine: 'p', lines: [{ id: 'l1', text: 't', select: true, evidence: true }, { id: 'l2', text: 'u', select: false }] }] } };
+    test('analyze mode step validates without payload.lines',
+      simLabValidateScenario(_modeScn).ok === true);
+
     // ── Mount test — vm-sandbox + DOM shim ──
     var elBody            = grab('_el');
     var escBody           = grabLine('_esc');
@@ -21252,6 +21261,35 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
     blocks[0].getAttribute('hidden') === null && blocks[1].getAttribute('hidden') !== null);
   test('terminal: revealExcerpt is also published on window.__slRevealExcerpt',
     typeof mCtx.window.__slRevealExcerpt === 'function');
+})();
+
+// ── Wave 2 Task 3: guarded analyze extension — mode branch + lenient scoring ──
+(function () {
+  var vm = require('vm');
+  var grab = function (n) { return _fnBody(js, n); };
+  var pieces = [grab('_arrEq'), grab('_setEq'), grab('_scoreConfigureSlots'), grab('_scoreAnalyzeLenient'), grab('_scoreStep'), grab('_simLabNormalizeMatch') || '', grab('simLabScoreScenario')].join('\n');
+  var sCtx = {}; vm.createContext(sCtx); vm.runInContext(pieces, sCtx);
+  vm.runInContext('globalThis.__score = simLabScoreScenario;', sCtx);
+  var score = sCtx.__score;
+
+  // lenient analyze: partial credit, false picks never subtract
+  var lenientScn = { steps: [ { id: 'ev', type: 'analyze', points: 1,
+    payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+    answer: { selected: ['l1', 'l2', 'l3'] } } ] };
+  test('analyze lenient: all-correct scores total===correct',
+    score(lenientScn, { ev: { selected: ['l1', 'l2', 'l3'] } }).correct === 3);
+  test('analyze lenient: partial scores correct<total, no negative',
+    (function () { var r = score(lenientScn, { ev: { selected: ['l1'] } }); return r.correct === 1 && r.total === 3; })());
+  test('analyze lenient: a FALSE pick does not subtract earned credit',
+    (function () { var r = score(lenientScn, { ev: { selected: ['l1', 'l2', 'l3', 'lX'] } }); return r.correct === 3 && r.total === 3; })());
+
+  // regression: an analyze step WITHOUT scoring flag stays exact-set boolean
+  var exactScn = { steps: [ { id: 'a', type: 'analyze', points: 1,
+    payload: { multi: false, lines: [{ id: 'x' }, { id: 'y' }] }, answer: { selected: ['x'] } } ] };
+  test('analyze default: exact-set match still scores 1/1',
+    score(exactScn, { a: { selected: ['x'] } }).correct === 1);
+  test('analyze default: wrong exact-set still scores 0/1',
+    score(exactScn, { a: { selected: ['y'] } }).correct === 0);
 })();
 
 // ── Task 9: subnetting/CIDR fidelity validator ──

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21679,8 +21679,8 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
 
 (function () {
   var grab = function (n) { return _fnBody(js, n); };
-  var sigVar = (js.match(/var _TRIAGE_FAULT_SIG = \{[\s\S]*?\n  \};/) || [''])[0];
-  var body = [grab('_slFidelityResolveSlot'), sigVar, grab('_triageEvidenceLines'), grab('simLabValidateEvidenceTriageFidelity')].join('\n');
+  var sigVar = (js.match(/var _TRIAGE_FAULT_SIG = \{[\s\S]*?\n\s*\};/) || [''])[0];
+  var body = [grab('_slFidelityResolveSlot'), grab('_arrEq'), grab('_setEq'), sigVar, grab('_triageEvidenceLines'), grab('simLabValidateEvidenceTriageFidelity')].join('\n');
   if (!sigVar || body.indexOf('simLabValidateEvidenceTriageFidelity') === -1) { results.errors.push('could not extract triage validator'); return; }
   var vm = require('vm');
   var tCtx = {}; vm.createContext(tCtx); vm.runInContext(body, tCtx);

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23107,6 +23107,111 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Wave 2 Task 8: Net+ CLI Fault Isolation seed-bank validation ──
+// The 12 consensus-approved (two-agent gated) Net+ CLI scenarios now live for
+// real in features/sim-lab-seed-netplus.js (window.SIM_LAB_SEED_NETPLUS).
+// This proves every one of them is real, production-ready content: each
+// passes the same pure validators that gate the dev fixtures above
+// (simLabValidateScenario + simLabValidateCliFaultFidelity), extracted from
+// features/sim-lab.js the same way the Wave 1 bank blocks do. Mirrors the
+// Wave 1 Task 6/7 bank-block structure, swapping in the CLI fault oracle.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: Net+ CLI Fault Isolation seed-bank validation (Wave 2 Task 8) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+    function assert(cond, msg) { test(msg, !!cond); }
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── Extract the REAL pure validators from features/sim-lab.js, exactly
+    // as the Wave 1 bank blocks do ──
+    var isNonEmptyStrBody    = grab('_isNonEmptyStr');
+    var validatePayloadBody  = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    var resolveSlotBody = grab('_slFidelityResolveSlot');
+    var sigVar = (js.match(/var _CLI_FAULT_SIG = \{[\s\S]*?\n\s*\};/) || [''])[0];
+    var cliExcerptTextBody = grab('_cliExcerptText');
+    var cliNeedlesMetBody  = grab('_cliNeedlesMet');
+    var cliFidelityBody    = grab('simLabValidateCliFaultFidelity');
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody ||
+        !resolveSlotBody || !sigVar || !cliExcerptTextBody || !cliNeedlesMetBody || !cliFidelityBody) {
+      test('Net+ CLI bank: validator helper extraction succeeded', false);
+      results.errors.push('could not extract validator helpers for Wave 2 Task 8 bank test; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext(resolveSlotBody, vCtx);
+    vm.runInContext(sigVar, vCtx);
+    vm.runInContext(cliExcerptTextBody, vCtx);
+    vm.runInContext(cliNeedlesMetBody, vCtx);
+    vm.runInContext(cliFidelityBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario; globalThis.__cliFidelity = simLabValidateCliFaultFidelity;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+    var simLabValidateCliFaultFidelity = vCtx.__cliFidelity;
+
+    // ── Load the real seed bank: eval features/sim-lab-seed-netplus.js in a
+    // sandbox with `var window = {}` so window.SIM_LAB_SEED_NETPLUS populates ──
+    var seedSrc = read('features/sim-lab-seed-netplus.js');
+    var seedCtx = {};
+    vm.createContext(seedCtx);
+    vm.runInContext('var window = {};\n' + seedSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_NETPLUS;', seedCtx);
+    var seedBank = seedCtx.__seed;
+
+    test('Net+ CLI bank: window.SIM_LAB_SEED_NETPLUS loaded as an array',
+      Array.isArray(seedBank));
+    if (!Array.isArray(seedBank)) {
+      results.errors.push('could not load window.SIM_LAB_SEED_NETPLUS from features/sim-lab-seed-netplus.js');
+      return;
+    }
+
+    var cliScenarios = seedBank.filter(function (s) { return s && s.archetype === 'cli'; });
+    test('Net+ CLI bank: at least 10 cli-archetype scenarios present',
+      cliScenarios.length >= 10);
+
+    var allValidateOk = true, allFidelityOk = true, allCertOk = true;
+    cliScenarios.forEach(function (s) {
+      var vr = simLabValidateScenario(s);
+      if (!vr || vr.ok !== true) {
+        allValidateOk = false;
+        results.errors.push('Net+ CLI bank: ' + (s && s.id) + ' failed simLabValidateScenario: ' + JSON.stringify(vr && vr.errors));
+      }
+      var fr = simLabValidateCliFaultFidelity(s);
+      if (!fr || fr.ok !== true) {
+        allFidelityOk = false;
+        results.errors.push('Net+ CLI bank: ' + (s && s.id) + ' failed simLabValidateCliFaultFidelity: ' + JSON.stringify(fr && fr.errors));
+      }
+      if (!s || s.cert !== 'netplus') {
+        allCertOk = false;
+        results.errors.push('Net+ CLI bank: ' + (s && s.id) + ' has cert !== netplus: ' + JSON.stringify(s && s.cert));
+      }
+    });
+
+    test('Net+ CLI bank: every cli scenario passes simLabValidateScenario',
+      allValidateOk);
+    test('Net+ CLI bank: every cli scenario passes simLabValidateCliFaultFidelity',
+      allFidelityOk);
+    test('Net+ CLI bank: every cli scenario has cert === netplus',
+      allCertOk);
+
+  } catch (err) {
+    test('Net+ CLI bank: vm smoke test (threw)', false);
+    results.errors.push('Net+ CLI bank smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Wave 1 Task 8: A+ Core 1 SOHO Router seed-bank validation ──
 // The 12 consensus-approved A+ Core 1 SOHO Router scenarios now live for real
 // in features/sim-lab-seed-aplus-core1.js (window.SIM_LAB_SEED_APLUS_CORE1).

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21159,6 +21159,101 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+(function () {
+  var grab = function (name) { return _fnBody(js, name); };
+  var grabLine = function (name) {
+    var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+    return (js.match(re) || [''])[0];
+  };
+  var elBody       = grab('_el');
+  var escBody      = grabLine('_esc');
+  var termLineBody = grab('_termLineHtml');
+  var termPmtBody  = grab('_termPromptHtml');
+  var termBody     = grab('_slRenderRefTerminal');
+  var dispBody     = grab('_slRenderReference');
+  if (!termBody || !dispBody) { results.errors.push('could not extract _slRenderRefTerminal/_slRenderReference'); return; }
+
+  var htmlEsc = function (s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  };
+  var makeEl = function (tag) {
+    var attrs = {}, listeners = {}, children = [], cls = '', inner = '';
+    var clsSet = {};
+    var el = {
+      tagName: tag.toUpperCase(),
+      get className() { return cls; }, set className(v) { cls = v; },
+      get innerHTML() { return inner; }, set innerHTML(v) { inner = v; children = []; },
+      get textContent() { return ''; }, set textContent(v) { inner = htmlEsc(v); },
+      style: {},
+      get _children() { return children; },
+      classList: {
+        add: function (c) { clsSet[c] = true; cls = (cls ? cls + ' ' : '') + c; },
+        remove: function (c) { delete clsSet[c]; },
+        toggle: function (c, on) { if (on) clsSet[c] = true; else delete clsSet[c]; },
+        contains: function (c) { return !!clsSet[c]; }
+      },
+      setAttribute: function (k, v) { attrs[k] = v; },
+      getAttribute: function (k) { return (k in attrs) ? attrs[k] : null; },
+      removeAttribute: function (k) { delete attrs[k]; },
+      appendChild: function (c) { children.push(c); return c; },
+      insertBefore: function (c) { children.unshift(c); return c; },
+      querySelectorAll: function (sel) {
+        var hits = [], want = sel.replace(/^\./, '');
+        var walk = function (n) { (n._children || []).forEach(function (c) {
+          if (!c || !c.tagName) return;
+          if (want.toUpperCase() === c.tagName || (c.className && c.className.split(' ').indexOf(want) !== -1)) hits.push(c);
+          walk(c);
+        }); };
+        walk(el); return hits;
+      },
+      addEventListener: function (ev, fn) { (listeners[ev] = listeners[ev] || []).push(fn); },
+      _fire: function (ev) { (listeners[ev] || []).forEach(function (fn) { fn({}); }); }
+    };
+    return el;
+  };
+  var mCtx = { document: { createElement: makeEl },
+    window: { matchMedia: function () { return { matches: false }; } },
+    Object: Object, Array: Array, String: String };
+  vm.createContext(mCtx);
+  vm.runInContext(elBody + '\n' + escBody + '\n' + termLineBody + '\n' + termPmtBody + '\n' + termBody + '\n' + dispBody, mCtx);
+
+  var ref = { kind: 'terminal', host: 'WS-14 · admin', session: 'read-only', reveal: 'external',
+    excerpts: [
+      { id: 'a', promptLine: 'C:\\> ipconfig', reveal: 'a', necessary: true,
+        lines: [ { id: 'l1', text: '169.254.1.1 <script>x</script>', highlight: 'hot', select: true, evidence: true },
+                 { id: 'l2', text: 'Media connected', select: false, ctx: true } ] },
+      { id: 'b', promptLine: 'C:\\> ping 1.1.1.1', reveal: 'b',
+        lines: [ { id: 'l3', text: 'timeout', select: true, evidence: false } ] }
+    ] };
+  mCtx.ref = ref;
+  vm.runInContext('globalThis.__panel = _slRenderReference(ref);', mCtx);
+  var panel = mCtx.__panel;
+
+  test('terminal: _slRenderReference returns a .sl-ref panel for kind terminal',
+    !!panel && panel.className === 'sl-ref');
+  var termNode = panel._children.filter(function (c) { return c.className && c.className.split(' ').indexOf('term') !== -1; })[0];
+  test('terminal: panel contains a .term component', !!termNode);
+  var lineBtns = panel.querySelectorAll('button');
+  var termLines = lineBtns.filter(function (b) { return b.className && b.className.split(' ').indexOf('term-line') !== -1; });
+  test('terminal: select:true lines render as focusable BUTTONs with data-line',
+    termLines.length === 2 && termLines[0].getAttribute('data-line') === 'l1');
+  var l1html = termLines[0].innerHTML;
+  test('terminal: line text is ESCAPED (no raw <script>)', l1html.indexOf('<script>') === -1 && l1html.indexOf('&lt;script&gt;') !== -1);
+  test('terminal: highlight wraps the ESCAPED text in a .hot span', l1html.indexOf('class="hot"') !== -1);
+  var scrolls = panel.querySelectorAll('.term-scroll');
+  test('terminal: each excerpt body is inside a .term-scroll container', scrolls.length === 2);
+  // external reveal: keyed excerpts start hidden; revealExcerpt unhides
+  var blocks = panel.querySelectorAll('.term-block');
+  test('terminal: external-mode keyed excerpts start [hidden]',
+    blocks.length === 2 && blocks[0].getAttribute('hidden') !== null && blocks[1].getAttribute('hidden') !== null);
+  panel.revealExcerpt('a');
+  test('terminal: revealExcerpt(key) unhides its excerpt block',
+    blocks[0].getAttribute('hidden') === null && blocks[1].getAttribute('hidden') !== null);
+  test('terminal: revealExcerpt is also published on window.__slRevealExcerpt',
+    typeof mCtx.window.__slRevealExcerpt === 'function');
+})();
+
 // ── Task 9: subnetting/CIDR fidelity validator ──
 // Pure-logic check: given a `network` reference model + a `configure` step,
 // confirm the flagged device is out-of-subnet and the step's correct answer

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21633,6 +21633,50 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   assert(cli(bad3).ok === false, 'cli: a redundant excerpt marked necessary breaks minimal-cover');
 })();
 
+(function () {
+  var grab = function (n) { return _fnBody(js, n); };
+  var body = [grab('_isNonEmptyStr'), grab('_slFidelityResolveSlot'),
+    grab('_discoLineFacts'), grab('_discoDerivePort'), grab('simLabValidateDiscoveryAuditFidelity')].join('\n');
+  if (body.indexOf('simLabValidateDiscoveryAuditFidelity') === -1) { results.errors.push('could not extract discovery validator'); return; }
+  var vm = require('vm');
+  var dCtx = {}; vm.createContext(dCtx); vm.runInContext(body, dCtx);
+  vm.runInContext('globalThis.__disco = simLabValidateDiscoveryAuditFidelity;', dCtx);
+  var disco = dCtx.__disco;
+  var assert = function (cond, msg) { test(msg, !!cond); };
+
+  var scn = {
+    disco: { legacyExcerptId: 'csv',
+      ports: [ { port: 'Gi0/1', device: 'AP-2', mgmt: '10.0.0.12', source: 'lldp' },
+               { port: 'Gi0/5', device: 'silent-host', mgmt: '10.0.0.30', source: 'macarp' } ] },
+    assets: { reference: { kind: 'terminal', host: 'SW', session: 's', reveal: 'tabs',
+      excerpts: [
+        { id: 'lldp', promptLine: 'SW# show lldp', tab: 'lldp', lines: [
+          { id: 'll1', text: 'Gi0/1  AP-2  10.0.0.12', select: false, fact: { port: 'Gi0/1', device: 'AP-2', mgmt: '10.0.0.12' } } ] },
+        { id: 'mac', promptLine: 'SW# show mac', tab: 'mac', lines: [
+          { id: 'm1', text: 'e8ff.1e44.2b90  Gi0/5', select: false, fact: { mac: 'e8ff.1e44.2b90', port: 'Gi0/5' } } ] },
+        { id: 'arp', promptLine: 'SW# show arp', tab: 'arp', lines: [
+          { id: 'a1', text: '10.0.0.30  e8ff.1e44.2b90', select: false, fact: { ip: '10.0.0.30', mac: 'e8ff.1e44.2b90' } } ] },
+        { id: 'csv', promptLine: 'legacy asset CSV', tab: 'csv', lines: [
+          { id: 'c1', text: 'Gi0/1,AP-2,10.0.0.12', select: true, fact: { port: 'Gi0/1', device: 'AP-2', mgmt: '10.0.0.12' } },
+          { id: 'c2', text: 'Gi0/5,PrintSrv,10.0.0.99', select: true, fact: { port: 'Gi0/5', device: 'PrintSrv', mgmt: '10.0.0.99' } } ] }
+      ] } },
+    steps: [
+      { id: 'rec', type: 'configure', points: 1, payload: { slots: [
+        { id: 'Gi0/1__dev', label: 'Gi0/1 dev', options: [{ id: 'a', text: 'AP-2' }, { id: 'b', text: 'PC-9' }] },
+        { id: 'Gi0/1__ip', label: 'Gi0/1 ip', options: [{ id: 'a', text: '10.0.0.12' }, { id: 'b', text: '10.0.0.99' }] },
+        { id: 'Gi0/5__ip', label: 'Gi0/5 ip', options: [{ id: 'a', text: '10.0.0.30' }, { id: 'b', text: '10.0.0.99' }] } ] },
+        answer: { slots: { 'Gi0/1__dev': 'a', 'Gi0/1__ip': 'a', 'Gi0/5__ip': 'a' } } },
+      { id: 'aud', type: 'analyze', points: 1, payload: { multi: false, mode: 'excerptLines' },
+        answer: { selected: ['c2'] } } ] };
+  assert(disco(scn).ok === true, 'disco: sound cross-referenced scenario passes');
+  var bad1 = JSON.parse(JSON.stringify(scn)); bad1.steps[0].answer.slots['Gi0/5__ip'] = 'b';   // 10.0.0.99, not the ARP join
+  assert(disco(bad1).ok === false, 'disco: keyed silent-host IP not derivable from MAC×ARP rejected');
+  var bad2 = JSON.parse(JSON.stringify(scn)); bad2.steps[1].answer.slots = undefined; bad2.steps[1].answer.selected = ['c1'];  // wrong contradicting row
+  assert(disco(bad2).ok === false, 'disco: keyed audit line is not the contradicting row rejected');
+  var bad3 = JSON.parse(JSON.stringify(scn)); bad3.assets.reference.excerpts[3].lines[1].fact = { port: 'Gi0/5', device: 'silent-host', mgmt: '10.0.0.30' };  // now consistent → zero contradictions
+  assert(disco(bad3).ok === false, 'disco: exactly-one-contradiction invariant enforced (zero contradictions rejected)');
+})();
+
 // ── Sim Lab: network reference renderer (Task 6) ──
 // The renderer builds SVG as a STRING mounted via _el('div','sl-net', svg), so
 // assertions run against that string (read from the .sl-net child's innerHTML),

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21594,6 +21594,45 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+(function () {
+  var grab = function (n) { return _fnBody(js, n); };
+  var cliBody = grab('simLabValidateCliFaultFidelity');
+  var sigVar = (js.match(/var _CLI_FAULT_SIG = \{[\s\S]*?\n\s*\};/) || [''])[0];
+  if (!cliBody || !sigVar) { results.errors.push('could not extract simLabValidateCliFaultFidelity/_CLI_FAULT_SIG'); return; }
+  var vm = require('vm');
+  var cCtx = {}; vm.createContext(cCtx);
+  vm.runInContext(grab('_isNonEmptyStr') + '\n' + grab('_slFidelityResolveSlot') + '\n' + sigVar + '\n' + grab('_cliExcerptText') + '\n' + grab('_cliNeedlesMet') + '\n' + cliBody, cCtx);
+  vm.runInContext('globalThis.__cli = simLabValidateCliFaultFidelity;', cCtx);
+  var cli = cCtx.__cli;
+  var assert = function (cond, msg) { test(msg, !!cond); };
+
+  var scn = { cliFault: { fault: 'duplex' },
+    assets: { reference: { kind: 'terminal', host: 'h', session: 's', reveal: 'external',
+      excerpts: [
+        { id: 'ipconfig', promptLine: 'C:\\> ipconfig', reveal: 'ipconfig', necessary: true,
+          lines: [ { id: 'i1', text: 'Link Speed: 1.0 Gbps / Full Duplex', highlight: 'good', select: false } ] },
+        { id: 'showint', promptLine: 'SW-2# show interfaces Gi0/14', reveal: 'showint', necessary: true,
+          lines: [ { id: 's1', text: 'Half-duplex, 100Mb/s', highlight: 'hot', select: false },
+                   { id: 's2', text: '2471 late collisions', highlight: 'hot', select: false } ] },
+        { id: 'tracert', promptLine: 'C:\\> tracert 8.8.8.8', reveal: 'tracert', necessary: false,
+          lines: [ { id: 't1', text: 'path intact', select: false } ] }
+      ] } },
+    steps: [ { id: 'dx', type: 'configure', points: 1,
+      payload: { slots: [
+        { id: 'rootCause', label: 'Root cause', options: [{ id: 'a', text: 'Duplex mismatch' }, { id: 'b', text: 'DNS failure' }] },
+        { id: 'fix', label: 'Fix', options: [{ id: 'a', text: 'Set both ends to auto-negotiate duplex' }, { id: 'b', text: 'Flush DNS cache' }] } ] },
+      answer: { slots: { rootCause: 'a', fix: 'a' } } } ] };
+  assert(cli(scn).ok === true, 'cli: sound duplex scenario passes');
+  var bad1 = JSON.parse(JSON.stringify(scn)); bad1.steps[0].answer.slots.rootCause = 'b';
+  assert(cli(bad1).ok === false, 'cli: rootCause not matching fault signature rejected');
+  var bad2 = JSON.parse(JSON.stringify(scn));
+  bad2.assets.reference.excerpts[1].lines = [{ id: 's1', text: 'Full-duplex, 1000Mb/s', select: false }];
+  assert(cli(bad2).ok === false, 'cli: necessary excerpt missing the fault signature fact rejected');
+  var bad3 = JSON.parse(JSON.stringify(scn)); bad3.assets.reference.excerpts[0].necessary = true;
+  bad3.assets.reference.excerpts[2].necessary = true;   // tracert (redundant) marked necessary
+  assert(cli(bad3).ok === false, 'cli: a redundant excerpt marked necessary breaks minimal-cover');
+})();
+
 // ── Sim Lab: network reference renderer (Task 6) ──
 // The renderer builds SVG as a STRING mounted via _el('div','sl-net', svg), so
 // assertions run against that string (read from the .sl-net child's innerHTML),

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -23212,6 +23212,122 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Wave 2 Task 9: Net+ Network Discovery Audit seed-bank validation ──
+// The 11 consensus-approved (two-agent gated) Net+ Network Discovery Audit
+// scenarios now live for real in features/sim-lab-seed-netplus.js
+// (window.SIM_LAB_SEED_NETPLUS). This proves every one of them is real,
+// production-ready content: each passes the same pure validators that gate
+// the dev fixtures above (simLabValidateScenario +
+// simLabValidateDiscoveryAuditFidelity), extracted from features/sim-lab.js
+// the same way the Wave 2 Task 8 CLI bank block does.
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: Net+ Network Discovery Audit seed-bank validation (Wave 2 Task 9) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+    function assert(cond, msg) { test(msg, !!cond); }
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── Extract the REAL pure validators from features/sim-lab.js, exactly
+    // as the Wave 2 Task 8 CLI bank block does ──
+    var isNonEmptyStrBody    = grab('_isNonEmptyStr');
+    var validatePayloadBody  = grab('_validateStepPayload');
+    var validateScenarioBody = grab('simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
+
+    var resolveSlotBody     = grab('_slFidelityResolveSlot');
+    var discoLineFactsBody  = grab('_discoLineFacts');
+    var discoDerivePortBody = grab('_discoDerivePort');
+    var discoFidelityBody   = grab('simLabValidateDiscoveryAuditFidelity');
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody ||
+        !resolveSlotBody || !discoLineFactsBody || !discoDerivePortBody || !discoFidelityBody) {
+      test('Net+ Discovery bank: validator helper extraction succeeded', false);
+      results.errors.push('could not extract validator helpers for Wave 2 Task 9 bank test; check names/indenting');
+      return;
+    }
+
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(isNonEmptyStrBody, vCtx);
+    vm.runInContext(validatePayloadBody, vCtx);
+    vm.runInContext(validateScenarioBody, vCtx);
+    vm.runInContext(resolveSlotBody, vCtx);
+    vm.runInContext(discoLineFactsBody, vCtx);
+    vm.runInContext(discoDerivePortBody, vCtx);
+    vm.runInContext(discoFidelityBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario; globalThis.__discoFidelity = simLabValidateDiscoveryAuditFidelity;', vCtx);
+    var simLabValidateScenario = vCtx.__validate;
+    var simLabValidateDiscoveryAuditFidelity = vCtx.__discoFidelity;
+
+    // ── Load the real seed bank: eval features/sim-lab-seed-netplus.js in a
+    // sandbox with `var window = {}` so window.SIM_LAB_SEED_NETPLUS populates ──
+    var seedSrc = read('features/sim-lab-seed-netplus.js');
+    var seedCtx = {};
+    vm.createContext(seedCtx);
+    vm.runInContext('var window = {};\n' + seedSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_NETPLUS;', seedCtx);
+    var seedBank = seedCtx.__seed;
+
+    test('Net+ Discovery bank: window.SIM_LAB_SEED_NETPLUS loaded as an array',
+      Array.isArray(seedBank));
+    if (!Array.isArray(seedBank)) {
+      results.errors.push('could not load window.SIM_LAB_SEED_NETPLUS from features/sim-lab-seed-netplus.js');
+      return;
+    }
+
+    var discoScenarios = seedBank.filter(function (s) { return s && s.archetype === 'discovery'; });
+    test('Net+ Discovery bank: at least 10 discovery-archetype scenarios present',
+      discoScenarios.length >= 10);
+
+    var allValidateOk = true, allFidelityOk = true, allCertOk = true;
+    discoScenarios.forEach(function (s) {
+      var vr = simLabValidateScenario(s);
+      if (!vr || vr.ok !== true) {
+        allValidateOk = false;
+        results.errors.push('Net+ Discovery bank: ' + (s && s.id) + ' failed simLabValidateScenario: ' + JSON.stringify(vr && vr.errors));
+      }
+      var fr = simLabValidateDiscoveryAuditFidelity(s);
+      if (!fr || fr.ok !== true) {
+        allFidelityOk = false;
+        results.errors.push('Net+ Discovery bank: ' + (s && s.id) + ' failed simLabValidateDiscoveryAuditFidelity: ' + JSON.stringify(fr && fr.errors));
+      }
+      if (!s || s.cert !== 'netplus') {
+        allCertOk = false;
+        results.errors.push('Net+ Discovery bank: ' + (s && s.id) + ' has cert !== netplus: ' + JSON.stringify(s && s.cert));
+      }
+    });
+
+    test('Net+ Discovery bank: every discovery scenario passes simLabValidateScenario',
+      allValidateOk);
+    test('Net+ Discovery bank: every discovery scenario passes simLabValidateDiscoveryAuditFidelity',
+      allFidelityOk);
+    test('Net+ Discovery bank: every discovery scenario has cert === netplus',
+      allCertOk);
+
+    // ── Extra cross-check: every records-audit answer.selected has length 1,
+    // and the reconcile configure step defines a <port>__ip slot for every
+    // scn.disco.ports[*].port ──
+    discoScenarios.forEach(function (s) {
+      var cfg = s.steps.filter(function (st) { return st.type === 'configure'; })[0];
+      var aud = s.steps.filter(function (st) { return st.type === 'analyze'; })[0];
+      var haveIpSlots = s.disco.ports.every(function (p) {
+        return cfg.payload.slots.some(function (sl) { return sl.id === p.port + '__ip'; });
+      });
+      test('disco ' + s.id + ': every port has an __ip reconcile slot + single audit pick',
+        haveIpSlots && aud && aud.answer.selected.length === 1);
+    });
+
+  } catch (err) {
+    test('Net+ Discovery bank: vm smoke test (threw)', false);
+    results.errors.push('Net+ Discovery bank smoke test threw: ' + err.message);
+  }
+})();
+
 // ── Wave 1 Task 8: A+ Core 1 SOHO Router seed-bank validation ──
 // The 12 consensus-approved A+ Core 1 SOHO Router scenarios now live for real
 // in features/sim-lab-seed-aplus-core1.js (window.SIM_LAB_SEED_APLUS_CORE1).

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -21677,6 +21677,42 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   assert(disco(bad3).ok === false, 'disco: exactly-one-contradiction invariant enforced (zero contradictions rejected)');
 })();
 
+(function () {
+  var grab = function (n) { return _fnBody(js, n); };
+  var sigVar = (js.match(/var _TRIAGE_FAULT_SIG = \{[\s\S]*?\n  \};/) || [''])[0];
+  var body = [grab('_slFidelityResolveSlot'), sigVar, grab('_triageEvidenceLines'), grab('simLabValidateEvidenceTriageFidelity')].join('\n');
+  if (!sigVar || body.indexOf('simLabValidateEvidenceTriageFidelity') === -1) { results.errors.push('could not extract triage validator'); return; }
+  var vm = require('vm');
+  var tCtx = {}; vm.createContext(tCtx); vm.runInContext(body, tCtx);
+  vm.runInContext('globalThis.__tri = simLabValidateEvidenceTriageFidelity;', tCtx);
+  var tri = tCtx.__tri;
+  var assert = function (cond, msg) { test(msg, !!cond); };
+
+  var scn = { triage: { fault: 'apipa' },
+    assets: { reference: { kind: 'terminal', host: 'LAPTOP', session: 's',
+      excerpts: [ { id: 'ipcfg', promptLine: 'C:\\> ipconfig /all', lines: [
+        { id: 'e1', text: 'Media State: Media connected', select: true, evidence: false },
+        { id: 'e2', text: 'IPv4 Address: 169.254.83.12(Preferred)', select: true, evidence: true },
+        { id: 'e3', text: 'Default Gateway:', select: true, evidence: true },
+        { id: 'e4', text: 'Description: Intel Wi-Fi 6', select: false, ctx: true } ] } ] } },
+    steps: [
+      { id: 'flag', type: 'analyze', points: 1, payload: { multi: true, mode: 'excerptLines', scoring: 'lenient' },
+        answer: { selected: ['e2', 'e3'] } },
+      { id: 'dx', type: 'configure', points: 1, payload: { slots: [
+        { id: 'diagnosis', label: 'Diagnosis', options: [{ id: 'a', text: 'APIPA — no DHCP lease' }, { id: 'b', text: 'Bad DNS server' }] },
+        { id: 'firstMove', label: 'First move', options: [{ id: 'a', text: 'Run ipconfig /renew' }, { id: 'b', text: 'Replace the NIC' }] } ] },
+        answer: { slots: { diagnosis: 'a', firstMove: 'a' } } } ] };
+  assert(tri(scn).ok === true, 'triage: sound APIPA scenario passes');
+  var bad1 = JSON.parse(JSON.stringify(scn)); bad1.steps[0].answer.selected = ['e1', 'e2', 'e3'];  // includes the false trap
+  assert(tri(bad1).ok === false, 'triage: keyed selected including an evidence:false trap rejected');
+  var bad2 = JSON.parse(JSON.stringify(scn));
+  bad2.assets.reference.excerpts[0].lines[0].evidence = true;   // no false distractor left among selectable lines
+  bad2.steps[0].answer.selected = ['e1', 'e2', 'e3'];
+  assert(tri(bad2).ok === false, 'triage: all-true selectable set (no scored distractor) rejected');
+  var bad3 = JSON.parse(JSON.stringify(scn)); bad3.steps[1].answer.slots.firstMove = 'b';
+  assert(tri(bad3).ok === false, 'triage: firstMove not following from evidence rejected');
+})();
+
 // ── Sim Lab: network reference renderer (Task 6) ──
 // The renderer builds SVG as a STRING mounted via _el('div','sl-net', svg), so
 // assertions run against that string (read from the .sl-net child's innerHTML),

--- a/tests/uat.js
+++ b/tests/uat.js
@@ -24510,6 +24510,398 @@ console.log('\n\x1b[1m── T7: DRILLS ANALYTICS GROUP + FINAL COPY + BRONZE TO
   }
 })();
 
+// ── Wave 2 Task 11: archetype vertical-slice mount + score, through the REAL
+// terminal-reference + guarded-analyze-mode Practice path ──
+// Proves the three NEW Wave 2 archetypes (cli, discovery, triage) actually
+// mount and score through _slMountScenario end to end — including the
+// terminal reference renderer (Wave 2 Task 2), the reveal-mode command menu
+// and excerptLines mode (Wave 2 Task 3's guarded analyze extension), and
+// lenient evidence scoring — against the REAL shipped bank scenarios, not a
+// hand-authored fixture. Mirrors the Task 9 (Wave 1) vertical-slice pattern
+// (grab() extraction + guard clauses), but the DOM shim additionally needs
+// the Task 2 terminal-renderer shim's stateful classList/removeAttribute/
+// _fire (Task 9's shim never exercised a terminal ref so it lacked both —
+// revealExcerpt calls block.removeAttribute('hidden')).
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: Wave 2 archetype vertical slices — cli/discovery/triage (Task 11) ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    var elBody               = grab('_el');
+    var escBody               = grabLine('_esc');
+    var slAttrBody            = grabLine('_slAttr');
+    var renderCfgBody         = grab('_slRenderConfigure');
+    var renderAnalyzeModeBody = grab('_slRenderAnalyzeMode');
+    var renderAnalyzeBody     = grab('_slRenderAnalyze');
+    var renderStepBody        = grab('simLabRenderStep');
+    var refNetBody            = grab('_slRenderRefNetwork');
+    var refTimeBody           = grab('_slRenderRefTimeline');
+    var refLayBody            = grab('_slRenderRefLayered');
+    var termLineBody          = grab('_termLineHtml');
+    var termPmtBody           = grab('_termPromptHtml');
+    var refTermBody           = grab('_slRenderRefTerminal');
+    var refDispBody           = grab('_slRenderReference');
+    var mountBody             = grab('_slMountScenario');
+    var scoreSlotsBody          = grab('_scoreConfigureSlots');
+    var scoreAnalyzeLenientBody = grab('_scoreAnalyzeLenient');
+    var scoreStepBody           = grab('_scoreStep');
+    var scoreScenarioBody       = grab('simLabScoreScenario');
+    var normBody           = grab('_norm');
+    var normalizeMatchBody = grab('_simLabNormalizeMatch');
+    var arrEqBody          = grab('_arrEq');
+    var setEqBody          = grab('_setEq');
+
+    if (!elBody || !escBody || !mountBody || !refDispBody || !refTermBody ||
+        !renderCfgBody || !renderAnalyzeBody || !renderAnalyzeModeBody || !renderStepBody ||
+        !scoreScenarioBody || !scoreSlotsBody || !scoreStepBody || !scoreAnalyzeLenientBody ||
+        !termLineBody || !termPmtBody) {
+      test('Task 11 (Wave 2): mount/score vm extraction succeeded', false);
+      results.errors.push('could not extract _slMountScenario/render/score/terminal helpers for Wave 2 Task 11 archetype vertical slices; check names/indenting');
+      return;
+    }
+
+    // ── Load the REAL seed banks (same vm-eval approach as the Task 9/10
+    // Wave 2 bank tests) — resolve the target scenarios from the ACTUAL
+    // shipped content, never a hand-typed literal. ──
+    var netplusSrc = read('features/sim-lab-seed-netplus.js');
+    var netplusCtx = {};
+    vm.createContext(netplusCtx);
+    vm.runInContext('var window = {};\n' + netplusSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_NETPLUS;', netplusCtx);
+    var netplusBank = netplusCtx.__seed;
+
+    var aplusCore1Src = read('features/sim-lab-seed-aplus-core1.js');
+    var aplusCore1Ctx = {};
+    vm.createContext(aplusCore1Ctx);
+    vm.runInContext('var window = {};\n' + aplusCore1Src + '\nglobalThis.__seed = window.SIM_LAB_SEED_APLUS_CORE1;', aplusCore1Ctx);
+    var aplusCore1Bank = aplusCore1Ctx.__seed;
+
+    test('Task 11 (Wave 2): both real seed banks loaded as arrays',
+      Array.isArray(netplusBank) && Array.isArray(aplusCore1Bank));
+    if (!Array.isArray(netplusBank) || !Array.isArray(aplusCore1Bank)) {
+      results.errors.push('Task 11 (Wave 2): could not load real seed banks (SIM_LAB_SEED_NETPLUS / SIM_LAB_SEED_APLUS_CORE1)');
+      return;
+    }
+
+    var cliScn       = netplusBank.filter(function (s) { return s && s.archetype === 'cli'; })[0];
+    var discoveryScn = netplusBank.filter(function (s) { return s && s.archetype === 'discovery'; })[0];
+    var triageScn    = aplusCore1Bank.filter(function (s) { return s && s.archetype === 'triage'; })[0];
+
+    test('Task 11 (Wave 2): first cli-archetype scenario resolved from the real bank (np-cli-01)',
+      cliScn && cliScn.id === 'np-cli-01');
+    test('Task 11 (Wave 2): first discovery-archetype scenario resolved from the real bank (np-disc-01)',
+      discoveryScn && discoveryScn.id === 'np-disc-01');
+    test('Task 11 (Wave 2): first triage-archetype scenario resolved from the real bank (a1-cot-01)',
+      triageScn && triageScn.id === 'a1-cot-01');
+
+    if (!cliScn || !discoveryScn || !triageScn) {
+      results.errors.push('Task 11 (Wave 2): could not resolve one or more archetype scenarios from the real banks; check archetype tagging');
+      return;
+    }
+
+    // ── DOM shim: the Task 9 select/change-driving surface merged with the
+    // Task 2 terminal-renderer shim's stateful classList + removeAttribute +
+    // _fire. ──
+    var htmlEsc = function (s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    };
+    var makeEl = function (tag) {
+      var attrs = {}, listeners = {}, children = [], cls = '', inner = '', val = '';
+      var clsSet = {};
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; }, set className(v) { cls = v; },
+        get innerHTML() { return inner; }, set innerHTML(v) { inner = v; children = []; },
+        get textContent() { return ''; }, set textContent(v) { inner = htmlEsc(v); },
+        get value() { return val; }, set value(v) { val = v; },
+        selected: false,
+        style: {},
+        get _children() { return children; },
+        classList: {
+          add: function (c) { clsSet[c] = true; },
+          remove: function (c) { delete clsSet[c]; },
+          toggle: function (c, on) { if (on) clsSet[c] = true; else delete clsSet[c]; },
+          contains: function (c) { return !!clsSet[c]; }
+        },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return (k in attrs) ? attrs[k] : null; },
+        removeAttribute: function (k) { delete attrs[k]; },
+        appendChild: function (c) { children.push(c); return c; },
+        insertBefore: function (c) { children.unshift(c); return c; },
+        querySelector: function (sel) {
+          var want = sel.replace(/^\./, '');
+          var hit = null;
+          var walk = function (n) {
+            if (hit || !n || !n._children) return;
+            n._children.forEach(function (c) {
+              if (hit || !c || !c.tagName) return;
+              if (want.toUpperCase() === c.tagName || (c.className && c.className.split(' ').indexOf(want) !== -1)) { hit = c; return; }
+              walk(c);
+            });
+          };
+          walk(el);
+          return hit;
+        },
+        querySelectorAll: function (sel) {
+          var hits = [], want = sel.replace(/^\./, '');
+          var walk = function (n) { (n._children || []).forEach(function (c) {
+            if (!c || !c.tagName) return;
+            if (want.toUpperCase() === c.tagName || (c.className && c.className.split(' ').indexOf(want) !== -1)) hits.push(c);
+            walk(c);
+          }); };
+          walk(el); return hits;
+        },
+        addEventListener: function (ev, fn) { (listeners[ev] = listeners[ev] || []).push(fn); },
+        dispatchEvent: function (evObj) { (listeners[evObj.type] || []).forEach(function (fn) { fn(evObj); }); },
+        _fire: function (ev) { (listeners[ev] || []).forEach(function (fn) { fn({}); }); },
+        closest: function () { return null; },
+        remove: function () {}
+      };
+      return el;
+    };
+
+    var docShim = {
+      createElement: function (tag) { return makeEl(tag); },
+      createTextNode: function (t) { return { textContent: t, tagName: '#text' }; }
+    };
+    var windowShim = { CSS: null, matchMedia: function () { return { matches: false }; } };
+
+    var mCtx = { document: docShim, window: windowShim, Object: Object, Array: Array, String: String, JSON: JSON };
+    vm.createContext(mCtx);
+    vm.runInContext(elBody, mCtx);
+    vm.runInContext(escBody, mCtx);
+    vm.runInContext(slAttrBody, mCtx);
+    vm.runInContext(renderCfgBody, mCtx);
+    vm.runInContext(renderAnalyzeModeBody, mCtx);
+    vm.runInContext(renderAnalyzeBody, mCtx);
+    vm.runInContext(renderStepBody, mCtx);
+    vm.runInContext(refNetBody, mCtx);
+    if (refTimeBody) vm.runInContext(refTimeBody, mCtx);
+    if (refLayBody) vm.runInContext(refLayBody, mCtx);
+    vm.runInContext(termLineBody, mCtx);
+    vm.runInContext(termPmtBody, mCtx);
+    vm.runInContext(refTermBody, mCtx);
+    vm.runInContext(refDispBody, mCtx);
+    vm.runInContext(mountBody, mCtx);
+    vm.runInContext(normBody, mCtx);
+    vm.runInContext(normalizeMatchBody, mCtx);
+    vm.runInContext(arrEqBody, mCtx);
+    vm.runInContext(setEqBody, mCtx);
+    vm.runInContext(scoreSlotsBody, mCtx);
+    vm.runInContext(scoreAnalyzeLenientBody, mCtx);
+    vm.runInContext(scoreStepBody, mCtx);
+    vm.runInContext(scoreScenarioBody, mCtx);
+
+    function stepWraps(wrap) {
+      return (wrap ? wrap._children : []).filter(function (c) { return c && c.className === 'sl-step'; });
+    }
+    function firstConfigureStepIndex(scn) {
+      for (var i = 0; i < scn.steps.length; i++) { if (scn.steps[i].type === 'configure') return i; }
+      return -1;
+    }
+    function expectedSelectCount(scn) {
+      return scn.steps.filter(function (s) { return s.type === 'configure'; })
+        .reduce(function (sum, s) { return sum + s.payload.slots.length; }, 0);
+    }
+    function mountOnly(scn) {
+      var host = makeEl('div');
+      mCtx.__host = host;
+      mCtx.__scn = scn;
+      var result = null;
+      mCtx.__onSubmit = function (r) { result = r; };
+      vm.runInContext('globalThis.__opts = { onSubmit: __onSubmit }; _slMountScenario(__host, __scn, __opts);', mCtx);
+      return { wrap: host._children[0], getResult: function () { return result; } };
+    }
+    function submitActive() { vm.runInContext('window.__slActiveSubmit();', mCtx); }
+
+    // Drive every configure step to its keyed-correct slots, except
+    // wrongSlot { stepIndex, slotId } (optional) which is driven to any
+    // OTHER option — the negative control.
+    function driveConfigureCorrectly(wrap, scn, wrongSlot) {
+      var wraps = stepWraps(wrap);
+      scn.steps.forEach(function (st, i) {
+        if (st.type !== 'configure') return;
+        var selects = wraps[i].querySelectorAll('select');
+        selects.forEach(function (sel) {
+          var slotId = sel.getAttribute('data-slot');
+          var correctVal = st.answer.slots[slotId];
+          var v = correctVal;
+          if (wrongSlot && wrongSlot.stepIndex === i && wrongSlot.slotId === slotId) {
+            var slotDef = st.payload.slots.filter(function (s) { return s.id === slotId; })[0];
+            var wrongOpt = slotDef.options.filter(function (o) { return o.id !== correctVal; })[0];
+            v = wrongOpt.id;
+          }
+          sel.value = v;
+          sel.dispatchEvent({ type: 'change' });
+        });
+      });
+    }
+
+    // Drive every guarded analyze-mode step ('reveal' or 'excerptLines') to
+    // its keyed-correct picks, through the REAL DOM interaction each mode
+    // exposes: 'reveal' clicks the .sl-cmd command-menu buttons (which is
+    // what actually invokes window.__slRevealExcerpt + unhides the target
+    // excerpt block); 'excerptLines' clicks the terminal's own rendered
+    // .term-line buttons. extraFalsePickByStepId (optional, per stepId)
+    // adds one extra line click on top of the keyed-correct set — the
+    // lenient-scoring leniency contract under test.
+    function driveAnalyzeModeCorrectly(wrap, scn, extraFalsePickByStepId) {
+      scn.steps.forEach(function (st) {
+        if (st.type !== 'analyze') return;
+        var mode = st.payload && st.payload.mode;
+        if (mode !== 'reveal' && mode !== 'excerptLines') return;
+        var selector = (mode === 'reveal') ? '.sl-cmd' : '.term-line';
+        var attr = (mode === 'reveal') ? 'data-cmd' : 'data-line';
+        var btns = wrap.querySelectorAll(selector);
+        var toClick = st.answer.selected.slice();
+        if (extraFalsePickByStepId && extraFalsePickByStepId[st.id]) {
+          toClick = toClick.concat([extraFalsePickByStepId[st.id]]);
+        }
+        toClick.forEach(function (id) {
+          var btn = btns.filter(function (b) { return b.getAttribute(attr) === id; })[0];
+          if (btn) btn._fire('click');
+        });
+      });
+    }
+
+    // Find a real FALSE-evidence line id for an excerptLines analyze step
+    // (a select:true line NOT in answer.selected, i.e. keyed `evidence:
+    // false`) so the leniency negative pick exercises a genuine keyed line,
+    // not a synthetic id.
+    function findFalseEvidenceLine(scn, stepId) {
+      var st = scn.steps.filter(function (s) { return s.id === stepId; })[0];
+      var ref = scn.assets && scn.assets.reference;
+      if (!st || !ref || !Array.isArray(ref.excerpts)) return null;
+      var falseLine = null;
+      ref.excerpts.forEach(function (ex) {
+        (ex.lines || []).forEach(function (ln) {
+          if (falseLine) return;
+          if (ln.select && st.answer.selected.indexOf(ln.id) === -1) falseLine = ln.id;
+        });
+      });
+      return falseLine;
+    }
+
+    // ── CLI (np-cli-01): terminal ref (external reveal) + mode:'reveal'
+    // LENIENT analyze step + configure step. ──
+    var cMount = mountOnly(cliScn);
+    var cWrap = cMount.wrap;
+    test('Task 11 (Wave 2) cli: mounted DOM contains a .term terminal component and every configure <select>',
+      !!cWrap.querySelector('.term') && cWrap.querySelectorAll('select').length === expectedSelectCount(cliScn));
+
+    // (b) CLI reveal path — fire ONE real .sl-cmd button click and prove the
+    // reveal wiring actually ran end to end: window.__slRevealExcerpt was
+    // invoked AND the target excerpt block transitioned from hidden to
+    // unhidden. A spy wraps the REAL published handle so this proves the
+    // click handler calls the actual function, not merely that scoring ends
+    // up correct some other way.
+    var cCmdBtns = cWrap.querySelectorAll('.sl-cmd');
+    var cFirstCmdId = cliScn.steps[0].answer.selected[0];
+    var cFirstCmdBtn = cCmdBtns.filter(function (b) { return b.getAttribute('data-cmd') === cFirstCmdId; })[0];
+    var cExcerpt = cliScn.assets.reference.excerpts.filter(function (ex) { return ex.id === cFirstCmdId; })[0];
+    var cBlock = cWrap.querySelectorAll('.term-block').filter(function (b) { return b.getAttribute('data-excerpt') === cFirstCmdId; })[0];
+    var cWasHidden = !!cBlock && cBlock.getAttribute('hidden') !== null;
+    var cRevealCalledSpy = false;
+    var cRealReveal = mCtx.window.__slRevealExcerpt;
+    mCtx.window.__slRevealExcerpt = function (key) { cRevealCalledSpy = true; return cRealReveal(key); };
+    if (cFirstCmdBtn) cFirstCmdBtn._fire('click');
+    test('Task 11 (Wave 2) cli: firing a real .sl-cmd command-button click invokes window.__slRevealExcerpt AND unhides its target excerpt block',
+      !!cFirstCmdBtn && !!cExcerpt && cExcerpt.reveal === cFirstCmdId && cWasHidden && cRevealCalledSpy &&
+      !!cBlock && cBlock.getAttribute('hidden') === null);
+    mCtx.window.__slRevealExcerpt = cRealReveal;
+
+    driveAnalyzeModeCorrectly(cWrap, cliScn);
+    driveConfigureCorrectly(cWrap, cliScn);
+    submitActive();
+    var cResult = cMount.getResult();
+    test('Task 11 (Wave 2) cli: simLabScoreScenario reports correct === total after every keyed-correct reveal pick + configure answer',
+      cResult && cResult.total > 0 && cResult.correct === cResult.total);
+
+    var cliClone = JSON.parse(JSON.stringify(cliScn));
+    var cCfgIdx = firstConfigureStepIndex(cliClone);
+    var cMount2 = mountOnly(cliClone);
+    driveAnalyzeModeCorrectly(cMount2.wrap, cliClone);
+    driveConfigureCorrectly(cMount2.wrap, cliClone,
+      { stepIndex: cCfgIdx, slotId: cliClone.steps[cCfgIdx].payload.slots[0].id });
+    submitActive();
+    var cResult2 = cMount2.getResult();
+    test('Task 11 (Wave 2) cli negative control: one wrong root-cause/fix slot scores correct < total',
+      cResult2 && cResult2.correct < cResult2.total);
+
+    // ── Discovery (np-disc-01): terminal ref (tabs reveal) + configure step
+    // + EXACT-SET excerptLines analyze step. ──
+    var dMount = mountOnly(discoveryScn);
+    var dWrap = dMount.wrap;
+    test('Task 11 (Wave 2) discovery: mounted DOM contains a .term terminal component and every configure <select>',
+      !!dWrap.querySelector('.term') && dWrap.querySelectorAll('select').length === expectedSelectCount(discoveryScn));
+    driveAnalyzeModeCorrectly(dWrap, discoveryScn);
+    driveConfigureCorrectly(dWrap, discoveryScn);
+    submitActive();
+    var dResult = dMount.getResult();
+    test('Task 11 (Wave 2) discovery: simLabScoreScenario reports correct === total after every keyed-correct answer',
+      dResult && dResult.total > 0 && dResult.correct === dResult.total);
+
+    var discoveryClone = JSON.parse(JSON.stringify(discoveryScn));
+    var dCfgIdx = firstConfigureStepIndex(discoveryClone);
+    var dMount2 = mountOnly(discoveryClone);
+    driveAnalyzeModeCorrectly(dMount2.wrap, discoveryClone);
+    driveConfigureCorrectly(dMount2.wrap, discoveryClone,
+      { stepIndex: dCfgIdx, slotId: discoveryClone.steps[dCfgIdx].payload.slots[0].id });
+    submitActive();
+    var dResult2 = dMount2.getResult();
+    test('Task 11 (Wave 2) discovery negative control: one wrong reconciled-IP slot scores correct < total',
+      dResult2 && dResult2.correct < dResult2.total);
+
+    // ── Triage (a1-cot-01): terminal ref (no reveal gating) + configure
+    // step + LENIENT excerptLines analyze step. ──
+    var tMount = mountOnly(triageScn);
+    var tWrap = tMount.wrap;
+    test('Task 11 (Wave 2) triage: mounted DOM contains a .term terminal component and every configure <select>',
+      !!tWrap.querySelector('.term') && tWrap.querySelectorAll('select').length === expectedSelectCount(triageScn));
+
+    var tFlagStep = triageScn.steps.filter(function (s) { return s.type === 'analyze'; })[0];
+    var tFalseLine = findFalseEvidenceLine(triageScn, tFlagStep.id);
+    test('Task 11 (Wave 2) triage: fixture sanity — a real keyed evidence:false line exists to drive the leniency negative pick',
+      !!tFalseLine);
+
+    // (c) Lenient-evidence path: flag every keyed-correct evidence line PLUS
+    // one extra REAL evidence:false line — the false pick must NOT subtract
+    // credit (the Wave 2 Task 3 leniency contract), so the overall score
+    // must still come out full.
+    var tExtra = {}; tExtra[tFlagStep.id] = tFalseLine;
+    driveAnalyzeModeCorrectly(tWrap, triageScn, tExtra);
+    driveConfigureCorrectly(tWrap, triageScn);
+    submitActive();
+    var tResult = tMount.getResult();
+    test('Task 11 (Wave 2) triage: LENIENT scoring still reports correct === total when an extra keyed evidence:false line is flagged alongside every keyed-correct line',
+      tResult && tResult.total > 0 && tResult.correct === tResult.total);
+
+    var triageClone = JSON.parse(JSON.stringify(triageScn));
+    var tCfgIdx = firstConfigureStepIndex(triageClone);
+    var tMount2 = mountOnly(triageClone);
+    driveAnalyzeModeCorrectly(tMount2.wrap, triageClone);
+    driveConfigureCorrectly(tMount2.wrap, triageClone,
+      { stepIndex: tCfgIdx, slotId: triageClone.steps[tCfgIdx].payload.slots[0].id });
+    submitActive();
+    var tResult2 = tMount2.getResult();
+    test('Task 11 (Wave 2) triage negative control: one wrong diagnosis/first-move slot scores correct < total',
+      tResult2 && tResult2.correct < tResult2.total);
+
+  } catch (err) {
+    test('Task 11 (Wave 2): archetype vertical-slice smoke test (threw)', false);
+    results.errors.push('Task 11 (Wave 2) archetype vertical-slice smoke test threw: ' + err.message);
+  }
+})();
+
 // ── v7.61.1: Sim Lab — _slRenderFeedback configure-step partial-credit fix ──
 // Live-browser verification (Task 10, Wave 1 build) caught a real defect:
 // simLabScoreScenario stores perStep[st.id] as an OBJECT {total,correct} for


### PR DESCRIPTION
## Summary
- Ships Wave 2 of the Sim Lab PBQ expansion (Wave 1 = v7.62.0): three new archetypes riding one shared new renderer.
- **Guided CLI Fault Isolation** (Net+ N10-009) and **Network Discovery Audit** (Net+): both use a new `terminal` reference kind — a progressive-reveal output-excerpt panel (`_slRenderRefTerminal`) with `'external'`/`'tabs'`/undefined reveal modes.
- **Command-Output Evidence Triage** (A+ Core 1 220-1201): tap-select evidence lines, all output visible at once.
- One small backward-compatible extension to the existing `analyze` step type (`payload.mode`/`payload.scoring`, both default OFF — every pre-existing analyze scenario is byte-identical).
- Three deterministic content-fidelity validators (`simLabValidateCliFaultFidelity`, `simLabValidateDiscoveryAuditFidelity`, `simLabValidateEvidenceTriageFidelity`), each with negative-control tests proving they're non-vacuous.
- 35 new seed scenarios (12 CLI + 11 Discovery in `sim-lab-seed-netplus.js`, 12 Triage in `sim-lab-seed-aplus-core1.js`), each two-agent domain-gated (network engineer/field-tech + CompTIA examiner, revised until both approved).
- Token-only `.term*` CSS block in `dg-system.css` (zero hardcoded hex).

## Test plan
- [x] `node tests/uat.js` — 4587/4587 ALL PASS
- [x] `node tests/tech-debt.js` — clean, all thresholds within limits
- [x] Live browser verification (localhost:3140): all 3 archetypes mounted, scored, revealed correctly; zero relevant console errors; 375px terminal overflow correctly contained (no page-level horizontal scroll); dark-mode computed styles (`.pmt` accent, `.sl-sel` tint) confirmed
- [x] Every task in the 14-task implementation plan went through per-task spec-compliance + code-quality subagent review during build, including 2 full revision rounds per content bank against independent domain-gate feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)