### PR TITLE
Sim Lab Wave 4: Laser Print Defect Clinic PBQ (v7.66.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@
 | styles.css | 14903 | 551 KB |
 | index.html | 1994 | 128 KB |
 | dg-system.css | 4597 | 447 KB |
-| tests/uat.js + tests/uat/ (25 modules) | 27011 | — |
-UAT checks: 4813 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
+| tests/uat.js + tests/uat/ (25 modules) | 27317 | — |
+UAT checks: 4824 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
 <!-- FACTS:AUTO:END -->
 
 | File | Purpose | Size |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@
 | index.html | 1994 | 128 KB |
 | dg-system.css | 4597 | 447 KB |
 | tests/uat.js + tests/uat/ (25 modules) | 27317 | — |
-UAT checks: 4824 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
+UAT checks: 4824 · E2E `test(` count: 159 · APP_VERSION: 7.66.0 · stamped-at: worktree
 <!-- FACTS:AUTO:END -->
 
 | File | Purpose | Size |
@@ -131,6 +131,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.66.0 | Sim Lab Wave 4: Laser Print Defect Clinic PBQ (swatch reference kind) |
 | v7.65.2 | Fix: light-theme purple residuals in end-of-day recap modal eyebrow/em text (rebrand gap) |
 | v7.65.1 | Fix: Custom Quiz Generate now dismisses the picker so the loading screen shows immediately |
 | v7.65.0 | Sec+ Technical Change Management topic + exemplar-prompt formatter fix + Domain 5 rebalance |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@
 | styles.css | 14903 | 551 KB |
 | index.html | 1994 | 128 KB |
 | dg-system.css | 4549 | 442 KB |
-| tests/uat.js + tests/uat/ (25 modules) | 26669 | — |
-UAT checks: 4729 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
+| tests/uat.js + tests/uat/ (25 modules) | 26707 | — |
+UAT checks: 4734 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
 <!-- FACTS:AUTO:END -->
 
 | File | Purpose | Size |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@
 | styles.css | 14903 | 551 KB |
 | index.html | 1994 | 128 KB |
 | dg-system.css | 4597 | 447 KB |
-| tests/uat.js + tests/uat/ (25 modules) | 26915 | — |
-UAT checks: 4802 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
+| tests/uat.js + tests/uat/ (25 modules) | 27011 | — |
+UAT checks: 4813 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
 <!-- FACTS:AUTO:END -->
 
 | File | Purpose | Size |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@
 | styles.css | 14903 | 551 KB |
 | index.html | 1994 | 128 KB |
 | dg-system.css | 4549 | 442 KB |
-| tests/uat.js + tests/uat/ (25 modules) | 26707 | — |
-UAT checks: 4734 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
+| tests/uat.js + tests/uat/ (25 modules) | 26915 | — |
+UAT checks: 4802 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
 <!-- FACTS:AUTO:END -->
 
 | File | Purpose | Size |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@
 | app.js | 22060 | 1116 KB |
 | styles.css | 14903 | 551 KB |
 | index.html | 1994 | 128 KB |
-| dg-system.css | 4549 | 442 KB |
+| dg-system.css | 4597 | 447 KB |
 | tests/uat.js + tests/uat/ (25 modules) | 26915 | — |
 UAT checks: 4802 · E2E `test(` count: 159 · APP_VERSION: 7.65.2 · stamped-at: worktree
 <!-- FACTS:AUTO:END -->

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.65.2
+// Network+ AI Quiz — app.js  v7.66.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.65.2';
+const APP_VERSION = '7.66.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/dg-system.css
+++ b/dg-system.css
@@ -33,6 +33,7 @@ html:root{
   --correct-text:oklch(0.86 0.13 152);--correct-text2:oklch(0.90 0.10 152);--correct-text3:oklch(0.80 0.13 152);
   --wrong-text:oklch(0.80 0.13 25);--wrong-text2:oklch(0.86 0.10 25);
   --dg-rule-soft:oklch(0.255 0.010 275);
+  --sw-paper:oklch(0.965 0.005 85);--sw-paper-edge:oklch(0.85 0.008 85);--sw-toner:oklch(0.28 0.012 280);
 }
 @media (prefers-color-scheme: light){html:root{
   --bg:oklch(0.975 0.007 85);
@@ -49,6 +50,7 @@ html:root{
   --correct-text:oklch(0.40 0.13 150);--correct-text2:oklch(0.45 0.12 150);--correct-text3:oklch(0.40 0.13 150);
   --wrong-text:oklch(0.45 0.17 25);--wrong-text2:oklch(0.50 0.16 25);
   --dg-rule-soft:oklch(0.90 0.009 85);
+  --sw-paper:oklch(0.99 0.003 85);--sw-paper-edge:oklch(0.88 0.007 85);--sw-toner:oklch(0.30 0.012 280);
 }}
 html[data-theme="dark"]{
   --bg:oklch(0.17 0.008 275);
@@ -66,6 +68,7 @@ html[data-theme="dark"]{
   --correct-text:oklch(0.86 0.13 152);--correct-text2:oklch(0.90 0.10 152);--correct-text3:oklch(0.80 0.13 152);
   --wrong-text:oklch(0.80 0.13 25);--wrong-text2:oklch(0.86 0.10 25);
   --dg-rule-soft:oklch(0.255 0.010 275);
+  --sw-paper:oklch(0.965 0.005 85);--sw-paper-edge:oklch(0.85 0.008 85);--sw-toner:oklch(0.28 0.012 280);
 }
 html[data-theme="light"]{
   --bg:oklch(0.975 0.007 85);
@@ -82,6 +85,7 @@ html[data-theme="light"]{
   --correct-text:oklch(0.40 0.13 150);--correct-text2:oklch(0.45 0.12 150);--correct-text3:oklch(0.40 0.13 150);
   --wrong-text:oklch(0.45 0.17 25);--wrong-text2:oklch(0.50 0.16 25);
   --dg-rule-soft:oklch(0.90 0.009 85);
+  --sw-paper:oklch(0.99 0.003 85);--sw-paper-edge:oklch(0.88 0.007 85);--sw-toner:oklch(0.30 0.012 280);
 }
 
 /* ── de-card primitives over the structural class contract ─────────────────
@@ -4546,3 +4550,47 @@ html[data-theme] body .celebration-toast-sub{color:var(--text-dim,rgba(255,255,2
 .slot-bay-label { font: 700 12px Inter, -apple-system, sans-serif; color: var(--text); }
 .slot-notes { display: flex; flex-wrap: wrap; gap: 6px; padding-top: 10px; }
 .slot-note { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 700; color: var(--text-mid); background: color-mix(in oklab, var(--text) 5%, transparent); border: 1px solid var(--border); border-radius: 999px; padding: 4px 9px; }
+
+/* ── Sim Lab swatch reference (Wave 4) — targets _slRenderRefSwatch's DOM exactly.
+   Sheet children in DOM order: .swatch-hdr (1st), then 14x .swatch-line (2nd..15th),
+   then any defect overlay. nth-of-type counts by element TYPE (all divs), so hdr
+   occupies slot 1 and the first .swatch-line is :nth-of-type(2) — verified against
+   the committed renderer (features/sim-lab.js _slRenderRefSwatch), not eyeballed.
+   Overlay classes for streak/smear are named 'swatch-streak-band'/'swatch-smear-wash'
+   (not the bare defect name) because the sheet itself already carries that exact
+   token as its defect modifier ('swatch-sheet swatch-' + defect) — a bare-name
+   selector here would also repaint the sheet. */
+.swatch-wrap { display: flex; flex-direction: column; align-items: center; padding: 14px 16px 6px; }
+.swatch-sheet { position: relative; width: 100%; max-width: 320px; margin-right: 46px; aspect-ratio: 210 / 280; background: var(--sw-paper); border: 1px solid var(--sw-paper-edge); border-radius: 4px; box-shadow: 0 1px 2px color-mix(in oklab, var(--text) 10%, transparent), 0 10px 26px -14px color-mix(in oklab, var(--text) 28%, transparent); }
+.swatch-hdr { position: absolute; left: 11%; top: 7%; width: 42%; height: 4%; border-radius: 2px; background: color-mix(in oklab, var(--sw-toner) 88%, var(--sw-paper)); }
+.swatch-line { position: absolute; left: 11%; height: 2.6%; border-radius: 2px; background: color-mix(in oklab, var(--sw-toner) 78%, var(--sw-paper)); }
+.swatch-line.dim { background: color-mix(in oklab, var(--sw-toner) 62%, var(--sw-paper)); }
+/* 14 lines, 4.5% vertical rhythm from 15%, ragged widths */
+.swatch-line:nth-of-type(2)  { top: 15%;   width: 78%; } .swatch-line:nth-of-type(3)  { top: 19.5%; width: 72%; }
+.swatch-line:nth-of-type(4)  { top: 24%;   width: 76%; } .swatch-line:nth-of-type(5)  { top: 28.5%; width: 64%; }
+.swatch-line:nth-of-type(6)  { top: 33%;   width: 77%; } .swatch-line:nth-of-type(7)  { top: 37.5%; width: 70%; }
+.swatch-line:nth-of-type(8)  { top: 42%;   width: 74%; } .swatch-line:nth-of-type(9)  { top: 46.5%; width: 67%; }
+.swatch-line:nth-of-type(10) { top: 51%;   width: 78%; } .swatch-line:nth-of-type(11) { top: 55.5%; width: 60%; }
+.swatch-line:nth-of-type(12) { top: 60%;   width: 75%; } .swatch-line:nth-of-type(13) { top: 64.5%; width: 71%; }
+.swatch-line:nth-of-type(14) { top: 69%;   width: 77%; } .swatch-line:nth-of-type(15) { top: 73.5%; width: 56%; }
+/* spots */
+.swatch-spot { position: absolute; left: 62%; width: 4.6%; aspect-ratio: 1; border-radius: 50%; background: radial-gradient(circle at 42% 40%, var(--sw-toner) 58%, color-mix(in oklab, var(--sw-toner) 55%, var(--sw-paper)) 78%, transparent 88%); }
+.swatch-spot-1 { top: 12%; } .swatch-spot-2 { top: 39%; transform: scale(0.92) rotate(14deg); } .swatch-spot-3 { top: 66%; transform: scale(1.05) rotate(-9deg); }
+.swatch-gauge { position: absolute; right: -13.5%; top: 0; bottom: 0; width: 12%; }
+.swatch-tick { position: absolute; right: 0; width: 100%; border-top: 1.5px solid color-mix(in oklab, var(--accent) 65%, var(--border)); }
+.swatch-tick-1 { top: 14.2%; } .swatch-tick-2 { top: 41.2%; }
+.swatch-rail { position: absolute; right: 46%; width: 1.5px; top: 14.2%; height: 27%; background: color-mix(in oklab, var(--accent) 65%, var(--border)); }
+.swatch-gauge-label { position: absolute; right: -8px; top: 27.5%; transform: translateY(-50%) rotate(90deg); font: 800 9.5px Inter, -apple-system, sans-serif; letter-spacing: 0.07em; color: var(--accent); white-space: nowrap; }
+/* streak: clean vertical band missing toner */
+.swatch-streak-band { position: absolute; top: 0; bottom: 0; left: 45%; width: 10%; background: var(--sw-paper); }
+/* smear: downward toner wash over the lower half */
+.swatch-smear-wash { position: absolute; left: 0; right: 0; top: 45%; bottom: 0; background: linear-gradient(180deg, color-mix(in oklab, var(--sw-toner) 30%, transparent), transparent 85%); }
+/* ghost: a bold source mark + its faint echo lower down */
+.swatch-ghost-src { position: absolute; left: 24%; top: 18%; width: 16%; aspect-ratio: 1; border-radius: 50%; background: color-mix(in oklab, var(--sw-toner) 85%, var(--sw-paper)); }
+.swatch-ghost-echo { position: absolute; left: 24%; top: 58%; width: 16%; aspect-ratio: 1; border-radius: 50%; background: color-mix(in oklab, var(--sw-toner) 22%, var(--sw-paper)); }
+/* skew: rotate the printed content, not the sheet */
+.swatch-skew .swatch-hdr, .swatch-skew .swatch-line { transform: rotate(-7deg); transform-origin: 8% 0; }
+/* caption + note chips (mirrors slot-notes) */
+.swatch-cap { margin-top: 10px; max-width: 320px; font-size: 11.5px; color: var(--text-dim); font-weight: 600; text-align: center; }
+.swatch-notes { display: flex; flex-wrap: wrap; gap: 6px; padding-top: 10px; }
+.swatch-note { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 700; color: var(--text-mid); background: color-mix(in oklab, var(--text) 5%, transparent); border: 1px solid var(--border); border-radius: 999px; padding: 4px 9px; }

--- a/features/sim-lab-seed-aplus-core1.js
+++ b/features/sim-lab-seed-aplus-core1.js
@@ -7896,4 +7896,175 @@ window.SIM_LAB_SEED_APLUS_CORE1 = [
         answer: { slots: { defectPattern: 'p-streak', failedComponent: 'c-scratcheddrum' } } }
     ]
   },
+  {
+    id: 'a1-swatch-05',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Smearing toner — fuser heat lamp failure, maintenance-kit remedy',
+    title: 'Every page out of the warehouse printer smudges at a touch',
+    estMinutes: 5,
+    scenario: 'The warehouse office\'s mono laser prints pages that look right at a glance — until anyone touches them. The toner wipes off with a thumb and smears down the page in the output tray. Pages are coming out cooler than usual. Read the page, name what failed, and close the ticket the right way.',
+    swatch: { damageKind: 'permanent' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · warehouse LaserJet',
+        defect: 'smear',
+        caption: 'Toner wipes off at a touch · smears downward in the tray',
+        notes: ['Pages exit cooler than normal', 'Every page affected, all trays', 'Toner level: fine']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Name the defect pattern, then the component that produces it.',
+        explanation: 'Toner that wipes off was never bonded to the paper. The fuser\'s job is exactly that bond: its heated roller melts the toner into the fibres under pressure. Cool pages plus unfused toner point straight at the fuser assembly — its heat lamp is no longer bringing the roller up to temperature.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' },
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' },
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-fuser', text: 'Fuser assembly · heat lamp no longer bonds toner to the page' },
+            { id: 'c-drum', text: 'Imaging drum · damage on its surface prints every rotation' },
+            { id: 'c-tonerpath', text: 'Blocked toner path · no toner reaches one lane of the page' },
+            { id: 'c-pickup', text: 'Pickup roller worn · pages feed crooked or not at all' } ] } ] },
+        answer: { slots: { defectPattern: 'p-smear', failedComponent: 'c-fuser' } } },
+      { id: 'fix', type: 'configure', points: 1,
+        prompt: 'You confirm the fuser roller never reaches operating temperature — the heat lamp has burned out. Close out the ticket.',
+        explanation: 'A burned-out heat lamp is not cleanable or adjustable: the fuser has failed and the fix is the printer\'s fuser maintenance kit, which replaces the fuser assembly (and usually the pickup/transfer rollers rated for the same service life). Verify with a test page — the print should come out warm and rub-fast.',
+        payload: { slots: [
+          { id: 'remedy', label: 'Remedy', options: [
+            { id: 'r-kit', text: 'Replace the fuser · install the printer\'s fuser maintenance kit' },
+            { id: 'r-clean', text: 'Clean the fuser roller and run a calibration cycle' },
+            { id: 'r-toner', text: 'Replace the toner cartridge with a fresh one' } ] },
+          { id: 'verify', label: 'Before closing the ticket', options: [
+            { id: 'v-none', text: 'Nothing further · a new fuser resolves it by definition' },
+            { id: 'v-test', text: 'Print a test page and check the toner is fused and rub-fast' },
+            { id: 'v-drivers', text: 'Reinstall the printer driver on every workstation' } ] } ] },
+        answer: { slots: { remedy: 'r-kit', verify: 'v-test' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-06',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Smearing toner — unfused output diagnosis',
+    title: 'The clinic\'s discharge summaries are smudging in patients\' hands',
+    estMinutes: 4,
+    scenario: 'Front desk at the clinic reports that printed discharge summaries are smudging before patients reach the car park. The print looks complete and dense, but drags a grey wash down the page wherever a thumb lands. It started suddenly this morning on every page. Read the page and name what failed.',
+    swatch: { damageKind: 'none' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · clinic LaserJet',
+        defect: 'smear',
+        caption: 'Print drags into a grey wash wherever it is touched',
+        notes: ['Started suddenly this morning', 'Print density otherwise normal', 'Same result from every tray and driver']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Name the defect pattern, then the component that produces it.',
+        explanation: 'Dense, complete print that smears at a touch means the image was formed and transferred correctly — it was never fixed to the paper. Fixing is the fuser\'s job: heat and pressure melt the toner in. When output smears on every page from every tray, the fuser assembly has stopped doing that.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' },
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' },
+            { id: 'p-skew', text: 'Crooked print · the whole page is rotated off square' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-blade', text: 'Cleaning blade worn · residual toner echoes an earlier image' },
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not being bonded to the page' },
+            { id: 'c-seppad', text: 'Separation pad worn · pages feed crooked or two at a time' },
+            { id: 'c-toner', text: 'Toner cartridge low · the whole page prints faded' } ] } ] },
+        answer: { slots: { defectPattern: 'p-smear', failedComponent: 'c-fuser' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-07',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Ghosting — worn cleaning blade, replace-class remedy',
+    title: 'Yesterday\'s logo is haunting today\'s letterhead',
+    estMinutes: 5,
+    scenario: 'Marketing\'s mono laser is reprinting a faint copy of the company logo further down every page — even on documents that don\'t contain the logo at all. The echo sits a fixed distance below wherever dense art printed on an earlier page. Read the page, name what failed, and close the ticket the right way.',
+    swatch: { damageKind: 'permanent' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · marketing LaserJet',
+        defect: 'ghost',
+        caption: 'Faint echo of earlier dense art repeats down the page',
+        notes: ['Echo appears even on pages without the logo', 'Offset matches one drum rotation', 'Worsening over the past week']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Name the defect pattern, then the component that produces it.',
+        explanation: 'A faint repeat of an earlier image one rotation later is ghosting: toner from the previous image was never scraped off the drum, so it prints again. The component whose whole job is that scrape is the cleaning blade — worn or nicked, it lets residual toner ride the drum around into the next page.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' },
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-blade', text: 'Cleaning blade worn · residual toner stays on the drum and reprints' },
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not bonding to the page' },
+            { id: 'c-pickup', text: 'Pickup roller worn · pages feed crooked or not at all' },
+            { id: 'c-tonerpath', text: 'Blocked toner path · no toner reaches one lane of the page' } ] } ] },
+        answer: { slots: { defectPattern: 'p-ghost', failedComponent: 'c-blade' } } },
+      { id: 'fix', type: 'configure', points: 1,
+        prompt: 'You inspect the drum unit: the cleaning blade\'s edge is visibly worn and nicked. On this printer the blade is built into the drum unit. Close out the ticket.',
+        explanation: 'A worn blade edge is permanent wear, not debris — and on cartridges that integrate the blade into the drum unit, the serviceable part IS the drum unit. Replacing it installs a fresh blade (and drum) in one step. Verify with a page of dense art followed by a blank-ish page: the echo should be gone.',
+        payload: { slots: [
+          { id: 'remedy', label: 'Remedy', options: [
+            { id: 'r-replace', text: 'Replace the drum unit · a fresh unit includes a new cleaning blade' },
+            { id: 'r-wipe', text: 'Clean the blade edge with a lint-free wipe and reinstall it' },
+            { id: 'r-kit', text: 'Install a fuser maintenance kit' } ] },
+          { id: 'verify', label: 'Before closing the ticket', options: [
+            { id: 'v-none', text: 'Nothing further · the new unit resolves it by definition' },
+            { id: 'v-test', text: 'Print dense art then a light page and check no echo repeats' },
+            { id: 'v-queue', text: 'Clear the print queue on the server' } ] } ] },
+        answer: { slots: { remedy: 'r-replace', verify: 'v-test' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-08',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Ghosting — erase lamp failure diagnosis',
+    title: 'The night-shift reports every page carries a shadow of the last job',
+    estMinutes: 4,
+    scenario: 'The operations printer is stamping a dim shadow of the previous job onto every new page. The tech on the last shift already swapped the drum unit — including its cleaning blade — and the shadow came straight back. The charge across the drum never seems to fully reset between pages. Read the page and name what failed.',
+    swatch: { damageKind: 'none' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · operations LaserJet',
+        defect: 'ghost',
+        caption: 'Dim shadow of the previous job on every new page',
+        notes: ['Drum unit (incl. blade) replaced: no change', 'Shadow tracks the previous job, not this one', 'Consistent from the first page after power-on']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'The drum and its blade are new, and the shadow persists. Name the defect pattern, then the component the evidence points to.',
+        explanation: 'Ghosting has two classic causes: residue the blade failed to scrape, or a latent charge image the erase lamp failed to clear. With a brand-new drum unit and blade, residue is ruled out — the erase lamp, which floods the drum with light to neutralise the previous page\'s charge pattern, is the component left. When it fails, the old electrostatic image survives into the next print.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' },
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' },
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-eraselamp', text: 'Erase lamp failed · the previous page\'s charge image is never cleared' },
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not bonding to the page' },
+            { id: 'c-paperpath', text: 'Paper path misaligned · pages travel crooked' },
+            { id: 'c-toner', text: 'Toner cartridge low · the whole page prints faded' } ] } ] },
+        answer: { slots: { defectPattern: 'p-ghost', failedComponent: 'c-eraselamp' } } }
+    ]
+  },
 ];

--- a/features/sim-lab-seed-aplus-core1.js
+++ b/features/sim-lab-seed-aplus-core1.js
@@ -7716,4 +7716,184 @@ window.SIM_LAB_SEED_APLUS_CORE1 = [
       }
     ]
   },
+
+  // ========================================================================
+  // ===== Wave 4 — Laser Print Defect Clinic (swatch archetype) ============
+  // ===== Objective 5.6 (troubleshoot printer issues; 220-1201 V2.0 —  =====
+  // ===== NOT 3.7, which is printer maintenance). Remedy options are   =====
+  // ===== informed by 3.7's laser maintenance list (replace toner,     =====
+  // ===== maintenance kit, calibrate, clean).                          =====
+  // ========================================================================
+  {
+    id: 'a1-swatch-01',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Repeating marks — drum-circumference interval diagnosis',
+    title: 'The front-desk LaserJet is stamping marks on every page',
+    estMinutes: 5,
+    scenario: 'Reception\'s shared printer started putting dark marks on everything this morning. A fresh ream of paper changed nothing. You pull the last page printed and put it under the light. Read the page, name what failed, and close the ticket the right way.',
+    swatch: { damageKind: 'permanent' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · front-desk LaserJet',
+        defect: 'spots',
+        caption: 'Last page printed · marks land at the same spot across pages',
+        notes: ['Model: mono laser, ~40k pages', 'Fresh paper: no change', 'Every page affected']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Name the defect pattern, then the component that produces it.',
+        explanation: 'Distinct dark marks at a fixed interval and the same horizontal position are a repeating defect. ~76 mm is a common drum circumference: a nick or stuck debris on the drum stamps the page once per rotation.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' },
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' },
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not bonding to the page' },
+            { id: 'c-drum', text: 'Imaging drum · damage or debris on its surface prints every rotation' },
+            { id: 'c-pickup', text: 'Pickup roller feeding pages crooked' },
+            { id: 'c-toner', text: 'Toner cartridge empty or clogged · faded or missing print' } ] } ] },
+        answer: { slots: { defectPattern: 'p-spots', failedComponent: 'c-drum' } } },
+      { id: 'fix', type: 'configure', points: 1,
+        prompt: 'You pull the drum unit and find a deep scratch across its surface. Close out the ticket.',
+        explanation: 'Cleaning handles debris, but a scratch is permanent: the coating is gone, and it stamps every rotation until the drum unit is replaced. Verify with a test page before closing.',
+        payload: { slots: [
+          { id: 'remedy', label: 'Remedy', options: [
+            { id: 'r-clean', text: 'Clean the drum surface and reinstall it' },
+            { id: 'r-replace', text: 'Replace the drum unit · a scratched drum cannot be repaired' },
+            { id: 'r-fuser', text: 'Install a fuser maintenance kit' } ] },
+          { id: 'verify', label: 'Before closing the ticket', options: [
+            { id: 'v-none', text: 'Nothing further · the new drum resolves it by definition' },
+            { id: 'v-test', text: 'Print a test page and check the marks are gone' },
+            { id: 'v-cal', text: 'Recalibrate the printer\'s colour tables' } ] } ] },
+        answer: { slots: { remedy: 'r-replace', verify: 'v-test' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-02',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Repeating marks — new drum, marks persist (fuser roller interval)',
+    title: 'New drum, same marks — the accounts printer will not come clean',
+    estMinutes: 4,
+    scenario: 'The accounts-office laser printer had repeating marks last week, so the on-site tech swapped the drum unit. Today the same glossy mark is back, once per rotation, in the same lane down the page. The drum is brand new and its packaging seal was intact. Read the page and name what is really stamping it.',
+    swatch: { damageKind: 'none' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · accounts LaserJet',
+        defect: 'spots',
+        caption: 'Repeating glossy mark · same interval and lane on every page',
+        notes: ['Drum unit replaced yesterday · seal intact', 'Marks unchanged after the swap', 'Mark looks pressed-in and shiny']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'The drum is new and the marks are unchanged. Name the defect pattern, then the component that matches the evidence.',
+        explanation: 'A repeating mark at a fixed interval is a rotating-part defect, but the interval alone does not name the part: several rollers share circumferences near ~76 mm. A brand-new drum with unchanged marks rules the drum out, and a pressed-in, glossy mark points to the heat-and-pressure stage — a flaw on the fuser roller stamps the page once per rotation.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' },
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-skew', text: 'Crooked print · the whole page is rotated off square' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-drum', text: 'Imaging drum · damage or debris on its surface prints every rotation' },
+            { id: 'c-fuserroller', text: 'Fuser roller · a surface flaw stamps a glossy mark once per rotation' },
+            { id: 'c-blade', text: 'Cleaning blade worn · residual toner echoes an earlier image' },
+            { id: 'c-seppad', text: 'Separation pad worn · pages feed crooked or two at a time' } ] } ] },
+        answer: { slots: { defectPattern: 'p-spots', failedComponent: 'c-fuserroller' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-03',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Vertical white streak — blocked toner path, clean-class remedy',
+    title: 'A white stripe is running down every page in the mailroom',
+    estMinutes: 5,
+    scenario: 'The mailroom\'s mono laser started leaving a clean vertical band down every page this afternoon — same width, same place, top to bottom. The rest of the print is dense and sharp. The toner gauge reads over half full. Read the page, name what failed, and close the ticket the right way.',
+    swatch: { damageKind: 'debris' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · mailroom LaserJet',
+        defect: 'streak',
+        caption: 'Full-height white band · identical position on every page',
+        notes: ['Toner gauge: ~60% remaining', 'Rest of the page prints dense and sharp', 'Started mid-shift, no supplies changed']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Name the defect pattern, then the component that produces it.',
+        explanation: 'A clean, full-height white band means no toner is reaching the page along that lane — the toner is not faded there, it is absent. With plenty of toner in the cartridge, the classic cause is a blocked toner path: clumped or foreign debris obstructing the developer opening so no toner flows in that lane.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' },
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' },
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-tonerpath', text: 'Blocked toner path · debris blocks the developer opening in one lane' },
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not bonding to the page' },
+            { id: 'c-tonerempty', text: 'Toner cartridge empty · the whole page prints faded' },
+            { id: 'c-pickup', text: 'Pickup roller worn · pages feed crooked or not at all' } ] } ] },
+        answer: { slots: { defectPattern: 'p-streak', failedComponent: 'c-tonerpath' } } },
+      { id: 'fix', type: 'configure', points: 1,
+        prompt: 'You pull the cartridge and find clumped toner packed against the developer opening. Close out the ticket.',
+        explanation: 'Debris is not permanent damage: clearing and cleaning the blocked toner path restores flow across the full page width, and the cartridge still has most of its life left. Replacing it would work but wastes a half-full consumable. Verify with a test page before closing.',
+        payload: { slots: [
+          { id: 'remedy', label: 'Remedy', options: [
+            { id: 'r-clean', text: 'Clean the toner path · clear the clumped toner from the developer opening' },
+            { id: 'r-replace', text: 'Replace the toner cartridge with a new one' },
+            { id: 'r-drum', text: 'Replace the drum unit' } ] },
+          { id: 'verify', label: 'Before closing the ticket', options: [
+            { id: 'v-none', text: 'Nothing further · clearing the blockage resolves it by definition' },
+            { id: 'v-test', text: 'Print a test page and check the band is gone' },
+            { id: 'v-reboot', text: 'Power-cycle the printer twice' } ] } ] },
+        answer: { slots: { remedy: 'r-clean', verify: 'v-test' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-04',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Vertical white streak — scratched drum coating diagnosis',
+    title: 'The legal team\'s printer draws a blank line through every contract',
+    estMinutes: 4,
+    scenario: 'Legal\'s mono laser is leaving a narrow white line down every page. A tech already reseated the toner cartridge and ran the printer\'s cleaning cycle — no change. The line is dead straight, always in the same lane, and has been slowly getting wider over two weeks. Read the page and name what failed.',
+    swatch: { damageKind: 'none' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · legal-team LaserJet',
+        defect: 'streak',
+        caption: 'Narrow white line · same lane every page, widening over weeks',
+        notes: ['Cartridge reseated: no change', 'Cleaning cycle run: no change', 'Line has widened gradually over 2 weeks']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Cleaning and reseating changed nothing. Name the defect pattern, then the component the evidence points to.',
+        explanation: 'A white streak that survives a cleaning cycle and a cartridge reseat is not loose debris — something in the image path can no longer hold toner along that lane. A scratched drum fits every clue: a groove worn through the drum\'s coating stops toner transferring along that exact band, it stays perfectly straight because the drum spins in place, and it widens slowly as the coating wears further.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' },
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' },
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-scratcheddrum', text: 'Scratched drum · a groove in the coating stops toner along that band' },
+            { id: 'c-eraselamp', text: 'Erase lamp failing · earlier images faintly reappear' },
+            { id: 'c-paperpath', text: 'Paper path misaligned · pages travel crooked' },
+            { id: 'c-tonerlow', text: 'Toner cartridge nearly empty · the whole page fades evenly' } ] } ] },
+        answer: { slots: { defectPattern: 'p-streak', failedComponent: 'c-scratcheddrum' } } }
+    ]
+  },
 ];

--- a/features/sim-lab-seed-aplus-core1.js
+++ b/features/sim-lab-seed-aplus-core1.js
@@ -8067,4 +8067,185 @@ window.SIM_LAB_SEED_APLUS_CORE1 = [
         answer: { slots: { defectPattern: 'p-ghost', failedComponent: 'c-eraselamp' } } }
     ]
   },
+  {
+    id: 'a1-swatch-09',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Crooked print — glazed pickup roller, clean-class remedy',
+    title: 'The loading-dock printer is feeding every page crooked',
+    estMinutes: 5,
+    scenario: 'The loading dock\'s laser printer sits in the dustiest corner of the building, and this week every page comes out printed at an angle — the text is sharp, but the whole block is rotated a few degrees. Jams are becoming more frequent too. Read the page, name what failed, and close the ticket the right way.',
+    swatch: { damageKind: 'debris' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · loading-dock LaserJet',
+        defect: 'skew',
+        caption: 'Whole print block rotated off square · text itself is sharp',
+        notes: ['Dusty environment · high page volume', 'Occasional feed jams alongside the skew', 'Print quality otherwise normal']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Name the defect pattern, then the component that produces it.',
+        explanation: 'Sharp print rotated off square is not an imaging problem — the image was drawn correctly onto a page that was travelling crooked. The pickup roller sets the page\'s entry angle: when paper dust glazes its surface, one side grips while the other slips, and every page feeds in at a slight rotation.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-skew', text: 'Crooked print · the whole page is rotated off square' },
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' },
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-pickup', text: 'Pickup roller glazed with paper dust · grips unevenly and feeds crooked' },
+            { id: 'c-drum', text: 'Imaging drum · damage on its surface prints every rotation' },
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not bonding to the page' },
+            { id: 'c-toner', text: 'Toner cartridge low · the whole page prints faded' } ] } ] },
+        answer: { slots: { defectPattern: 'p-skew', failedComponent: 'c-pickup' } } },
+      { id: 'fix', type: 'configure', points: 1,
+        prompt: 'You pull the pickup roller: its surface is glazed with packed paper dust, but the rubber is intact with no flat spots. Close out the ticket.',
+        explanation: 'Glaze is debris, not wear: the rubber underneath is sound, so wiping the roller clean with a lint-free cloth restores even grip. Replacement is the answer only when the rubber itself is worn smooth or cracked. Verify by printing and checking the page squares up.',
+        payload: { slots: [
+          { id: 'remedy', label: 'Remedy', options: [
+            { id: 'r-wipe', text: 'Clean the pickup roller with a lint-free cloth to cut the glaze' },
+            { id: 'r-replace', text: 'Replace the pickup roller with a new one' },
+            { id: 'r-tray', text: 'Swap the paper tray for one from another printer' } ] },
+          { id: 'verify', label: 'Before closing the ticket', options: [
+            { id: 'v-none', text: 'Nothing further · a cleaned roller resolves it by definition' },
+            { id: 'v-test', text: 'Print a test page and check the print sits square on the page' },
+            { id: 'v-cal', text: 'Run a full colour calibration' } ] } ] },
+        answer: { slots: { remedy: 'r-wipe', verify: 'v-test' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-10',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Crooked print — worn separation pad diagnosis',
+    title: 'HR\'s printer pulls two pages and prints them both crooked',
+    estMinutes: 4,
+    scenario: 'HR\'s desktop laser has developed a double habit: it often pulls two sheets at once, and whatever it prints lands rotated a few degrees on the page. A tech already cleaned the pickup roller last week — the feed improved for a day, then both symptoms came straight back. Read the page and name what failed.',
+    swatch: { damageKind: 'none' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · HR LaserJet',
+        defect: 'skew',
+        caption: 'Print rotated off square · often two sheets pulled together',
+        notes: ['Pickup roller cleaned last week: brief improvement only', 'Multipage misfeeds alongside the skew', 'Paper is fresh and fanned before loading']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'The pickup roller was cleaned and the symptoms returned. Name the defect pattern, then the component the evidence points to.',
+        explanation: 'Skew plus multipage misfeeds is a feed-separation signature. The separation pad presses against the pickup roller to hold back every sheet but the top one; worn smooth, it lets extra sheets slip through and lets the fed sheet twist as it goes. A cleaned roller helping only briefly says the roller was not the root cause.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-skew', text: 'Crooked print · the whole page is rotated off square' },
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' },
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-seppad', text: 'Separation pad worn smooth · extra sheets slip through and feed crooked' },
+            { id: 'c-scratcheddrum', text: 'Scratched drum · a groove in the coating stops toner along one band' },
+            { id: 'c-blade', text: 'Cleaning blade worn · residual toner echoes an earlier image' },
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not bonding to the page' } ] } ] },
+        answer: { slots: { defectPattern: 'p-skew', failedComponent: 'c-seppad' } } }
+    ]
+  },
+  {
+    id: 'a1-swatch-11',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Multi-symptom — repeating marks with fading print, triage order',
+    title: 'The print room\'s LaserJet is stamping marks AND slowly fading',
+    estMinutes: 6,
+    scenario: 'The print room reports two problems on the same machine: dark marks that repeat down every page at a fixed interval, and print that has been getting gradually fainter for a fortnight. Two symptoms, one ticket. Diagnose the defect the sample page pins down, then sequence the visit so each fix is verified before the next is judged.',
+    swatch: { damageKind: 'none' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · print-room LaserJet',
+        defect: 'spots',
+        caption: 'Repeating marks at a fixed interval · overall density also low',
+        notes: ['Marks: same lane, fixed interval', 'Density fading gradually over 2 weeks', 'Toner gauge: low']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Start with the symptom the sample page can prove. Name the defect pattern, then the component that produces it.',
+        explanation: 'Fading is ambiguous from one page — but repeating marks at a fixed interval are not. The interval fingerprints a rotating part: damage on the imaging drum stamps the page once per rotation. The fading is most simply the low toner gauge, and it gets judged AFTER the drum problem is fixed, not alongside it.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-ghost', text: 'Ghosting · a faint copy of an earlier image repeats' },
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-drum', text: 'Imaging drum · damage on its surface prints every rotation' },
+            { id: 'c-fuser', text: 'Fuser assembly · toner is not bonding to the page' },
+            { id: 'c-seppad', text: 'Separation pad worn · pages feed crooked or two at a time' },
+            { id: 'c-toner', text: 'Toner cartridge low · the whole page prints faded' } ] } ] },
+        answer: { slots: { defectPattern: 'p-spots', failedComponent: 'c-drum' } } },
+      { id: 'triage', type: 'order', points: 1,
+        prompt: 'Sequence the visit: fix what is proven, verify, then judge the second symptom.',
+        explanation: 'Measure first — the interval is the evidence that names the part. Replace the drum on that evidence, then test: the test page both confirms the marks are gone and shows the true remaining density. Only then can the fade be judged on its own, and the toner cartridge assessed as a separate, cheap consumable decision.',
+        payload: { items: [
+          { id: 'o-measure', label: 'Measure the mark-to-mark interval on the sample page' },
+          { id: 'o-drum', label: 'Replace the drum unit' },
+          { id: 'o-test', label: 'Print a test page and confirm the marks are gone' },
+          { id: 'o-toner', label: 'Assess the remaining fade and replace the toner cartridge if needed' } ] },
+        answer: { correctOrder: ['o-measure', 'o-drum', 'o-test', 'o-toner'] } }
+    ]
+  },
+  {
+    id: 'a1-swatch-12',
+    cert: 'aplus-core1',
+    archetype: 'swatch',
+    objective: '5.6',
+    topic: 'Multi-symptom — smearing print with grinding noise, symptom mapping',
+    title: 'The finance printer smears its pages and grinds while doing it',
+    estMinutes: 6,
+    scenario: 'Finance\'s workhorse laser now announces every job with a grinding noise from the output end, and the pages it delivers smudge at a touch. Accordion-style jams are starting at the exit rollers too. Three complaints on one ticket. Read the page, name the failed assembly, then map each symptom to what it tells you.',
+    swatch: { damageKind: 'none' },
+    assets: {
+      reference: {
+        kind: 'swatch',
+        title: 'Sample output · finance LaserJet',
+        defect: 'smear',
+        caption: 'Toner smudges at a touch · grinding noise during every job',
+        notes: ['Grinding from the output end of the printer', 'Accordion jams beginning at the exit', 'Toner level: fine']
+      }
+    },
+    steps: [
+      { id: 'diagnose', type: 'configure', points: 1,
+        prompt: 'Name the defect pattern the sample page shows, then the assembly all three symptoms share.',
+        explanation: 'Unfused toner puts the fault at the fuser. The grinding and the exit-end accordion jams agree: a fuser whose drive gear is wearing out turns roughly, mangles the page as it passes, and no longer holds fusing temperature and pressure. One failing assembly explains all three complaints — that convergence is the diagnosis.',
+        payload: { slots: [
+          { id: 'defectPattern', label: 'Defect pattern', options: [
+            { id: 'p-smear', text: 'Loose toner · print smears at a touch' },
+            { id: 'p-spots', text: 'Repeating marks · same spot at a fixed interval' },
+            { id: 'p-streak', text: 'Vertical white streak · a clean band missing toner' } ] },
+          { id: 'failedComponent', label: 'Failed component', options: [
+            { id: 'c-fuser', text: 'Fuser assembly · failing drive and heat, no longer bonding toner' },
+            { id: 'c-pickup', text: 'Pickup roller worn · pages feed crooked or not at all' },
+            { id: 'c-blade', text: 'Cleaning blade worn · residual toner echoes an earlier image' },
+            { id: 'c-tonerpath', text: 'Blocked toner path · no toner reaches one lane of the page' } ] } ] },
+        answer: { slots: { defectPattern: 'p-smear', failedComponent: 'c-fuser' } } },
+      { id: 'sympmap', type: 'match', points: 1,
+        prompt: 'Map each reported symptom to what it tells you about the failing fuser.',
+        explanation: 'Each complaint is a different window on the same assembly, through a different mechanism: smudging print means the hot roller is not reaching fusing temperature; grinding is the worn drive gear turning roughly; and accordion jams at the exit mean the pressure roller has lost its nip — without that pinch the page is no longer pulled taut through the exit and buckles. Three distinct mechanisms, one assembly: that convergence is what points to the fuser maintenance kit rather than three separate repairs.',
+        payload: {
+          left: [
+            { id: 'm-smear', label: 'Toner smudges at a touch' },
+            { id: 'm-grind', label: 'Grinding noise during printing' },
+            { id: 'm-jam', label: 'Accordion jams at the exit' } ],
+          right: [
+            { id: 'd-heat', label: 'Hot roller not reaching fusing temperature' },
+            { id: 'd-gear', label: 'Fuser drive gear worn and turning roughly' },
+            { id: 'd-nip', label: 'Pressure roller worn · lost nip lets the page buckle at the exit' } ]
+        },
+        answer: { pairs: { 'm-smear': 'd-heat', 'm-grind': 'd-gear', 'm-jam': 'd-nip' } } }
+    ]
+  },
 ];

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -1929,6 +1929,61 @@
     return root;
   }
 
+  // --- swatch reference renderer (Wave 4 Task 2) ---
+  // Laser Print Defect Clinic. DELIBERATELY static/illustrative — like
+  // _slRenderRefSlots above, zero <button>, zero click handler, zero exposed
+  // interaction handle. Task 3's CSS is written against exactly this DOM
+  // shape; do not rename classes without updating that CSS in lockstep.
+  var _SWATCH_ARIA = {
+    spots:  'Printed page with dark toner spots recurring at a fixed vertical interval of roughly 76 millimetres, all at the same horizontal position. The printed text itself is crisp and fully fused.',
+    streak: 'Printed page with a clean vertical white band running the full page height where toner is missing. The remaining print is otherwise normal.',
+    smear:  'Printed page where the toner smudges and streaks downward, as if wiped before it bonded to the paper.',
+    ghost:  'Printed page where a faint copy of an image from higher up the page reappears further down.',
+    skew:   'Printed page whose entire content is rotated several degrees off square, as if the paper fed crooked.'
+  };
+
+  // NOTE: the streak/smear overlay nodes below are named 'swatch-streak-band'
+  // / 'swatch-smear-wash' rather than the bare defect name 'swatch-streak' /
+  // 'swatch-smear' — the sheet itself already carries that exact class as its
+  // defect modifier ('swatch-sheet swatch-' + defect), so a bare-name overlay
+  // class would collide with the sheet's own class list and a CSS rule meant
+  // only for the overlay would also repaint the sheet. spots/ghost/skew don't
+  // collide (their overlay class names differ from the bare defect string).
+  function _slRenderRefSwatch(ref) {
+    var root = _el('div', 'swatch-wrap');
+    var defect = ref.defect;
+    var sheet = _el('div', 'swatch-sheet swatch-' + defect);
+    sheet.setAttribute('role', 'img');
+    sheet.setAttribute('aria-label', _SWATCH_ARIA[defect] || '');
+    sheet.appendChild(_el('div', 'swatch-hdr'));
+    for (var i = 0; i < 14; i++) sheet.appendChild(_el('div', 'swatch-line' + (i % 2 ? ' dim' : '')));
+    if (defect === 'spots') {
+      for (var s = 0; s < 3; s++) sheet.appendChild(_el('div', 'swatch-spot swatch-spot-' + (s + 1)));
+      var gauge = _el('div', 'swatch-gauge');
+      gauge.setAttribute('aria-hidden', 'true');
+      gauge.appendChild(_el('div', 'swatch-tick swatch-tick-1'));
+      gauge.appendChild(_el('div', 'swatch-tick swatch-tick-2'));
+      gauge.appendChild(_el('div', 'swatch-rail'));
+      gauge.appendChild(_el('div', 'swatch-gauge-label', '~76 mm'));
+      sheet.appendChild(gauge);
+    } else if (defect === 'streak') {
+      sheet.appendChild(_el('div', 'swatch-streak-band'));
+    } else if (defect === 'smear') {
+      sheet.appendChild(_el('div', 'swatch-smear-wash'));
+    } else if (defect === 'ghost') {
+      sheet.appendChild(_el('div', 'swatch-ghost-src'));
+      sheet.appendChild(_el('div', 'swatch-ghost-echo'));
+    } // skew: no extra nodes — .swatch-skew on the sheet drives a CSS transform on the lines
+    root.appendChild(sheet);
+    if (_isNonEmptyStr(ref.caption)) root.appendChild(_el('div', 'swatch-cap', _esc(ref.caption)));
+    if (Array.isArray(ref.notes) && ref.notes.length) {
+      var notes = _el('div', 'swatch-notes');
+      ref.notes.forEach(function (n) { notes.appendChild(_el('span', 'swatch-note', _esc(n))); });
+      root.appendChild(notes);
+    }
+    return root;
+  }
+
   function _slRenderReference(ref) {
     if (!ref || !ref.kind) return null;
     var panel = _el('div', 'sl-ref');
@@ -1945,6 +2000,7 @@
     else if (ref.kind === 'faceplate') panel.appendChild(_slRenderRefFaceplate(ref));
     else if (ref.kind === 'wiremap') panel.appendChild(_slRenderRefWiremap(ref));
     else if (ref.kind === 'slots') panel.appendChild(_slRenderRefSlots(ref));
+    else if (ref.kind === 'swatch') panel.appendChild(_slRenderRefSwatch(ref));
     return panel;
   }
 
@@ -3509,6 +3565,7 @@
   window._simLab.pickSeedFresh = _slPickSeedFresh;
   window._simLab.aggregateSession = _slAggregateSession;
   window._simLab.sessionBumpOnce = function () { _slSessionBumpOnce(); };
+  window._simLab.renderRefSwatch = _slRenderRefSwatch;
   window.simLabOpenEntry = simLabOpenEntry;
   window.simLabEntryBack = simLabEntryBack;
   window.simLabSessionStart = _slSessionStartDispatch;

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -4,6 +4,8 @@
 
   var STEP_TYPES = ['order', 'categorize', 'match', 'analyze', 'fillin', 'configure'];
 
+  var _SWATCH_DEFECTS = ['spots', 'streak', 'smear', 'ghost', 'skew'];
+
   var _SL_PBQ_CERTS = ['netplus', 'secplus', 'aplus-core1', 'aplus-core2'];
 
   function _isNonEmptyStr(v) { return typeof v === 'string' && v.trim().length > 0; }
@@ -65,7 +67,7 @@
       });
     }
     if (s.assets && s.assets.reference) {
-      var ref = s.assets.reference, kinds = ['network', 'timeline', 'layered', 'terminal', 'faceplate', 'wiremap', 'slots'];
+      var ref = s.assets.reference, kinds = ['network', 'timeline', 'layered', 'terminal', 'faceplate', 'wiremap', 'slots', 'swatch'];
       if (kinds.indexOf(ref.kind) === -1) errs.push('reference: bad kind');
       else if (ref.kind === 'network' && !Array.isArray(ref.devices)) errs.push('reference network: devices[] required');
       else if (ref.kind === 'timeline' && !Array.isArray(ref.stages)) errs.push('reference timeline: stages[] required');
@@ -80,11 +82,17 @@
         return p && typeof p.pin === 'number' && typeof p.pairId === 'number';
       }))) errs.push('reference wiremap: pins[] must have exactly 8 entries with pin+pairId');
       else if (ref.kind === 'slots' && !Array.isArray(ref.bays)) errs.push('reference slots: bays[] required');
+      else if (ref.kind === 'swatch') {
+        if (_SWATCH_DEFECTS.indexOf(ref.defect) === -1) errs.push('reference swatch: defect must be one of ' + _SWATCH_DEFECTS.join('/'));
+        if (!_isNonEmptyStr(ref.title)) errs.push('reference swatch: title required');
+        if (ref.caption !== undefined && !_isNonEmptyStr(ref.caption)) errs.push('reference swatch: caption must be non-empty when present');
+        if (ref.notes !== undefined && !Array.isArray(ref.notes)) errs.push('reference swatch: notes must be an array when present');
+      }
       if (ref.kind === 'layered' && ref.layout !== undefined && ['nested', 'stacked'].indexOf(ref.layout) === -1) {
         errs.push('reference layered: bad layout');
       }
     }
-    if (s.archetype !== undefined && ['diagram', 'incident', 'defense', 'wireless', 'firewall', 'soho', 'cli', 'discovery', 'triage', 'portmap', 'wiremap', 'pcbuild', 'raid'].indexOf(s.archetype) === -1) {
+    if (s.archetype !== undefined && ['diagram', 'incident', 'defense', 'wireless', 'firewall', 'soho', 'cli', 'discovery', 'triage', 'portmap', 'wiremap', 'pcbuild', 'raid', 'swatch'].indexOf(s.archetype) === -1) {
       errs.push('bad archetype');
     }
     return { ok: errs.length === 0, errors: errs };

--- a/features/sim-lab.js
+++ b/features/sim-lab.js
@@ -810,6 +810,47 @@
     return { ok: errs.length === 0, errors: errs };
   }
 
+  // --- swatch (laser print defect) fidelity validator (Wave 4) ---
+  // Truth table maps each rendered defect to the SET of acceptable failed
+  // components (spec 2026-07-11 §4, pinned set-based). Matching is
+  // case-insensitive substring against the RESOLVED keyed option text.
+  var _SWATCH_CAUSES = {
+    spots:  ['drum', 'roller'],
+    streak: ['toner path', 'blocked toner', 'scratched drum'],
+    smear:  ['fuser'],
+    ghost:  ['cleaning blade', 'erase lamp', 'drum clean'],
+    skew:   ['pickup roller', 'paper path', 'separation pad']
+  };
+
+  function simLabValidateSwatchFidelity(scn) {
+    var errs = [];
+    var ref = scn && scn.assets && scn.assets.reference;
+    if (!ref || ref.kind !== 'swatch') return { ok: false, errors: ['swatch fidelity: assets.reference.kind must be "swatch"'] };
+    var accepts = _SWATCH_CAUSES[ref.defect];
+    if (!accepts) return { ok: false, errors: ['swatch fidelity: unknown defect "' + ref.defect + '"'] };
+    var dx = (scn.steps || []).filter(function (st) { return st.id === 'diagnose'; })[0];
+    if (!dx) return { ok: false, errors: ['swatch fidelity: no configure step with id "diagnose"'] };
+    var comp = _slFidelityResolveSlot(dx, 'failedComponent');
+    if (!comp) {
+      errs.push('swatch fidelity: diagnose step has no keyed failedComponent slot');
+    } else {
+      var compLc = String(comp).toLowerCase();
+      var hit = accepts.some(function (a) { return compLc.indexOf(a) !== -1; });
+      if (!hit) errs.push('swatch fidelity: keyed component "' + comp + '" not in the ' + ref.defect + ' cause set {' + accepts.join(', ') + '}');
+    }
+    var fact = scn.swatch || {};
+    var fix = (scn.steps || []).filter(function (st) { return st.id === 'fix'; })[0];
+    if (fact.damageKind === 'permanent' || fact.damageKind === 'debris') {
+      if (!fix) { errs.push('swatch fidelity: damageKind "' + fact.damageKind + '" declared but no fix step'); }
+      else {
+        var remedy = _slFidelityResolveSlot(fix, 'remedy') || '';
+        if (fact.damageKind === 'permanent' && !/replace/i.test(remedy)) errs.push('swatch fidelity: permanent damage must key a replace-class remedy, got "' + remedy + '"');
+        if (fact.damageKind === 'debris' && !/clean/i.test(remedy)) errs.push('swatch fidelity: debris must key a clean-class remedy, got "' + remedy + '"');
+      }
+    }
+    return { ok: errs.length === 0, errors: errs };
+  }
+
   // --- scoring (Task 2) ---
 
   function _norm(v) {
@@ -3549,6 +3590,7 @@
   // --- exports (more added in later tasks) ---
   window.simLabValidateScenario = simLabValidateScenario;
   window.simLabValidateNetworkFidelity = simLabValidateNetworkFidelity;
+  window.simLabValidateSwatchFidelity = simLabValidateSwatchFidelity;
   window.simLabScoreScenario = simLabScoreScenario;
   window.simLabSubmitScenario = simLabSubmitScenario;
   window._simLab = window._simLab || {};

--- a/index.html
+++ b/index.html
@@ -772,7 +772,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.65.2</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.66.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   html[data-theme="light"] body { color: #1a1a2e; }
 </style>
 <link rel="stylesheet" href="styles.css">
-<link rel="stylesheet" href="dg-system.css?v=7.61.4">
+<link rel="stylesheet" href="dg-system.css?v=7.65.1-w4a">
 <link rel="stylesheet" href="dg-depurple.css?v=7.13.5">
 <!-- v7.36.1: the cert-ios lift is viewport-gated — phone/tablet-portrait
      viewports get the mockup column + tab bar; desktop keeps the classic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certanvil",
-  "version": "7.65.2",
+  "version": "7.66.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/scripts/dev/wave4-fidelity-check.js
+++ b/scripts/dev/wave4-fidelity-check.js
@@ -1,0 +1,18 @@
+// Wave 4 authoring gate: structural + fidelity validation for every a1-swatch-* scenario.
+const fs = require('fs');
+const vm = require('vm');
+const sandbox = { window: {}, console };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync('features/sim-lab.js', 'utf8'), sandbox);
+vm.runInContext(fs.readFileSync('features/sim-lab-seed-aplus-core1.js', 'utf8'), sandbox);
+const bank = sandbox.window.SIM_LAB_SEED_APLUS_CORE1.filter(s => s.archetype === 'swatch');
+let fail = 0;
+for (const scn of bank) {
+  const v = sandbox.window.simLabValidateScenario(scn);
+  const f = sandbox.window.simLabValidateSwatchFidelity(scn);
+  const ok = v.ok && f.ok;
+  console.log((ok ? 'PASS' : 'FAIL') + '  ' + scn.id + (ok ? '' : '  ' + [...v.errors, ...f.errors].join(' | ')));
+  if (!ok) fail++;
+}
+console.log(bank.length + ' swatch scenarios, ' + fail + ' failing');
+process.exit(fail ? 1 : 0);

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.65.2
+   Network+ AI Quiz — styles.css  v7.66.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.65.2 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.65.2';
+// Service Worker v7.66.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.66.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat/190-simlab-configure-reference-assets.js
+++ b/tests/uat/190-simlab-configure-reference-assets.js
@@ -337,6 +337,10 @@ const {
     var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
     var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : "var STEP_TYPES = ['order','categorize','match','analyze','fillin','configure'];";
 
+    // _SWATCH_DEFECTS array (Wave 4 Task 1) — grab from source
+    var swatchDefectsMatch = js.match(/var _SWATCH_DEFECTS\s*=\s*\[[^\]]+\]/);
+    var swatchDefectsDecl = swatchDefectsMatch ? swatchDefectsMatch[0] + ';' : "var _SWATCH_DEFECTS = ['spots','streak','smear','ghost','skew'];";
+
     if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody) {
       test('reference validation: helper extraction succeeded', false);
       results.errors.push('could not extract simLabValidateScenario helpers; check names/indenting');
@@ -346,6 +350,7 @@ const {
     var vCtx = {};
     vm.createContext(vCtx);
     vm.runInContext(stepTypesDecl, vCtx);
+    vm.runInContext(swatchDefectsDecl, vCtx);
     vm.runInContext(isNonEmptyStrBody, vCtx);
     vm.runInContext(validatePayloadBody, vCtx);
     vm.runInContext(validateScenarioBody, vCtx);
@@ -468,6 +473,39 @@ const {
     var _sx3 = _baseScn(); _sx3.archetype = 'diskclinic';
     test('archetype validation: unknown archetype "diskclinic" still rejected',
       simLabValidateScenario(_sx3).ok === false);
+
+    // ── Wave 4 Task 1: 'swatch' reference kind + archetype tag ──
+    // 12. Valid swatch reference passes.
+    var _scnSwatch = _baseScn();
+    _scnSwatch.assets = { reference: { kind: 'swatch', title: 'Sample output', defect: 'spots' } };
+    test('reference validation: valid swatch reference passes',
+      simLabValidateScenario(_scnSwatch).ok === true);
+
+    // 13. swatch reference with bad defect rejected.
+    var _scnSwatchBadDefect = _baseScn();
+    _scnSwatchBadDefect.assets = { reference: { kind: 'swatch', title: 'Sample output', defect: 'banding' } };
+    var _swBadDefectResult = simLabValidateScenario(_scnSwatchBadDefect);
+    test('reference validation: swatch bad defect rejected',
+      _swBadDefectResult.ok === false && _swBadDefectResult.errors.some(function (e) { return /swatch.*defect/i.test(e); }));
+
+    // 14. swatch reference missing title rejected.
+    var _scnSwatchNoTitle = _baseScn();
+    _scnSwatchNoTitle.assets = { reference: { kind: 'swatch', defect: 'spots' } };
+    var _swNoTitleResult = simLabValidateScenario(_scnSwatchNoTitle);
+    test('reference validation: swatch missing title rejected',
+      _swNoTitleResult.ok === false && _swNoTitleResult.errors.some(function (e) { return /swatch.*title/i.test(e); }));
+
+    // 15. swatch reference with empty caption rejected.
+    var _scnSwatchEmptyCaption = _baseScn();
+    _scnSwatchEmptyCaption.assets = { reference: { kind: 'swatch', title: 'Sample output', defect: 'spots', caption: '' } };
+    var _swEmptyCaptionResult = simLabValidateScenario(_scnSwatchEmptyCaption);
+    test('reference validation: swatch empty caption rejected',
+      _swEmptyCaptionResult.ok === false && _swEmptyCaptionResult.errors.some(function (e) { return /swatch.*caption/i.test(e); }));
+
+    // 16. New archetype tag 'swatch' accepted.
+    var _scnSwatchArch = _baseScn(); _scnSwatchArch.archetype = 'swatch';
+    test('archetype validation: archetype swatch accepted',
+      simLabValidateScenario(_scnSwatchArch).ok === true);
 
     // ── Wave 2 Task 3: analyze mode step validates without payload.lines ──
     var _modeStep = { id: 'm', type: 'analyze', prompt: 'p', explanation: 'e', points: 1,

--- a/tests/uat/190-simlab-configure-reference-assets.js
+++ b/tests/uat/190-simlab-configure-reference-assets.js
@@ -998,3 +998,211 @@ const {
   test('slots: renders constraint-note chips', notes.length === 1 && notes[0].innerHTML.indexOf('$700') !== -1);
 })();
 
+// ── Wave 4 Task 2: swatch reference renderer (static/illustrative, zero
+// interaction) — Laser Print Defect Clinic. Mirrors the Wave 3 Task 4 slots
+// block immediately above: same _el/_esc extraction, same makeEl DOM shim
+// (querySelectorAll only supports a single class token, so compound
+// selectors like '.swatch-sheet.swatch-spots' are resolved by a LOCAL
+// helper here, not by extending the shared shim). ──
+(function () {
+  var vm = require('vm');
+  var grab = function (name) { return _fnBody(js, name); };
+  var grabLine = function (name) {
+    var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+    return (js.match(re) || [''])[0];
+  };
+  var elBody = grab('_el'), escBody = grabLine('_esc');
+  var isNonEmptyStrBody = grabLine('_isNonEmptyStr');
+  // _SWATCH_ARIA table (Wave 4 Task 2) — grab from source; flexible whitespace
+  // per the house extraction convention (mirrors swatchDefectsDecl, Task 1).
+  var swatchAriaMatch = js.match(/var _SWATCH_ARIA\s*=\s*\{[\s\S]*?\n\s*\};/);
+  var swatchAriaDecl = swatchAriaMatch ? swatchAriaMatch[0] : "var _SWATCH_ARIA = {};";
+  var swatchBody = grab('_slRenderRefSwatch'), dispBody = grab('_slRenderReference');
+  test('Wave 4: _slRenderRefSwatch extracted', !!swatchBody);
+  test('Wave 4: _SWATCH_ARIA table extracted', !!swatchAriaMatch);
+  test('Wave 4: _slRenderReference dispatches kind === swatch',
+    !!dispBody && /ref\.kind === 'swatch'/.test(dispBody));
+  if (!swatchBody || !dispBody) { results.errors.push('could not extract _slRenderRefSwatch/_slRenderReference'); return; }
+
+  var htmlEsc = function (s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  };
+  var makeEl = function (tag) {
+    var attrs = {}, listeners = {}, children = [], cls = '', inner = '';
+    var clsSet = {};
+    var el = {
+      tagName: tag.toUpperCase(),
+      get className() { return cls; }, set className(v) { cls = v; },
+      get innerHTML() { return inner; }, set innerHTML(v) { inner = v; children = []; },
+      get textContent() { return ''; }, set textContent(v) { inner = htmlEsc(v); },
+      style: {},
+      get _children() { return children; },
+      classList: {
+        add: function (c) { clsSet[c] = true; cls = (cls ? cls + ' ' : '') + c; },
+        remove: function (c) { delete clsSet[c]; },
+        toggle: function (c, on) { if (on) clsSet[c] = true; else delete clsSet[c]; },
+        contains: function (c) { return !!clsSet[c]; }
+      },
+      setAttribute: function (k, v) { attrs[k] = v; },
+      getAttribute: function (k) { return (k in attrs) ? attrs[k] : null; },
+      removeAttribute: function (k) { delete attrs[k]; },
+      appendChild: function (c) { children.push(c); return c; },
+      querySelectorAll: function (sel) {
+        var hits = [], want = sel.replace(/^\./, '');
+        var walk = function (n) { (n._children || []).forEach(function (c) {
+          if (!c || !c.tagName) return;
+          if (want.toUpperCase() === c.tagName || (c.className && c.className.split(' ').indexOf(want) !== -1)) hits.push(c);
+          walk(c);
+        }); };
+        walk(el); return hits;
+      },
+      addEventListener: function (ev, fn) { (listeners[ev] = listeners[ev] || []).push(fn); },
+      _fire: function (ev) { (listeners[ev] || []).forEach(function (fn) { fn({}); }); }
+    };
+    return el;
+  };
+  var mCtx = { document: { createElement: makeEl }, Object: Object, Array: Array, String: String };
+  vm.createContext(mCtx);
+  vm.runInContext(elBody + '\n' + escBody + '\n' + isNonEmptyStrBody + '\n' + swatchAriaDecl + '\n' + swatchBody + '\n' + dispBody, mCtx);
+
+  // LOCAL compound-class query helper (walks the real DOM-shim node objects
+  // directly from Node — no vm involved — so it can support multi-class
+  // selectors the shared shim's querySelectorAll deliberately doesn't).
+  var localQueryAll = function (root, selector) {
+    var classes = selector.split('.').filter(Boolean);
+    var hits = [];
+    var walk = function (n) {
+      (n._children || []).forEach(function (c) {
+        if (!c || !c.tagName) return;
+        var cls = (c.className || '').split(' ');
+        if (classes.every(function (want) { return cls.indexOf(want) !== -1; })) hits.push(c);
+        walk(c);
+      });
+    };
+    walk(root);
+    return hits;
+  };
+  var localQuery = function (root, selector) { return localQueryAll(root, selector)[0] || null; };
+  var hasOnclickAnywhere = function (root) {
+    var found = false;
+    var walk = function (n) {
+      (n._children || []).forEach(function (c) {
+        if (!c) return;
+        if (typeof c.getAttribute === 'function' && c.getAttribute('onclick') != null) found = true;
+        walk(c);
+      });
+    };
+    walk(root);
+    return found;
+  };
+
+  var sandboxRender = function (ref) {
+    mCtx.ref = ref;
+    vm.runInContext('globalThis.__panel = _slRenderReference(ref);', mCtx);
+    return mCtx.__panel;
+  };
+
+  ['spots', 'streak', 'smear', 'ghost', 'skew'].forEach(function (d) {
+    var panel = sandboxRender({ kind: 'swatch', title: 'Sample output', defect: d, caption: 'cap', notes: ['n1'] });
+    var sheet = localQuery(panel, '.swatch-sheet.swatch-' + d);
+    test('Wave 4: swatch ' + d + ' renders sheet', !!sheet);
+    test('Wave 4: swatch ' + d + ' sheet has role=img', !!sheet && sheet.getAttribute('role') === 'img');
+    test('Wave 4: swatch ' + d + ' has a non-empty aria-label',
+      !!sheet && _isNonEmptyStrLocal(sheet.getAttribute('aria-label')));
+    test('Wave 4: swatch ' + d + ' zero interactive elements',
+      panel.querySelectorAll('button').length === 0 && panel.querySelectorAll('select').length === 0 && !hasOnclickAnywhere(panel));
+    var lines = localQueryAll(panel, '.swatch-line');
+    var dimLines = lines.filter(function (l) { return l.className.split(' ').indexOf('dim') !== -1; });
+    test('Wave 4: swatch ' + d + ' renders 14 lines, 7 dim (odd rows)', lines.length === 14 && dimLines.length === 7);
+    test('Wave 4: swatch ' + d + ' has a header', localQueryAll(panel, '.swatch-hdr').length === 1);
+    var wrap = localQuery(panel, '.swatch-wrap');
+    test('Wave 4: swatch ' + d + ' wrapped in .swatch-wrap', !!wrap);
+    var cap = localQuery(panel, '.swatch-cap');
+    test('Wave 4: swatch ' + d + ' caption renders and is ESCAPED',
+      !!cap && cap.innerHTML.indexOf('cap') !== -1);
+    var notes = localQueryAll(panel, '.swatch-note');
+    test('Wave 4: swatch ' + d + ' renders note chips', notes.length === 1 && notes[0].innerHTML.indexOf('n1') !== -1);
+  });
+  function _isNonEmptyStrLocal(v) { return typeof v === 'string' && v.trim().length > 0; }
+
+  // spots: 3 spots + a gauge (2 ticks, 1 rail, 1 label), no other overlay kind
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'spots' });
+    test('Wave 4: spots swatch has exactly 3 .swatch-spot', localQueryAll(panel, '.swatch-spot').length === 3);
+    var gauges = localQueryAll(panel, '.swatch-gauge');
+    test('Wave 4: spots swatch has exactly 1 .swatch-gauge', gauges.length === 1);
+    test('Wave 4: spots gauge is aria-hidden', !!gauges[0] && gauges[0].getAttribute('aria-hidden') === 'true');
+    test('Wave 4: spots gauge has 2 .swatch-tick', localQueryAll(panel, '.swatch-tick').length === 2);
+    test('Wave 4: spots gauge has 1 .swatch-rail', localQueryAll(panel, '.swatch-rail').length === 1);
+    var label = localQuery(panel, '.swatch-gauge-label');
+    test('Wave 4: spots gauge has a .swatch-gauge-label', !!label && label.innerHTML.indexOf('76') !== -1);
+    test('Wave 4: spots swatch has no streak/smear/ghost overlays',
+      localQueryAll(panel, '.swatch-streak-band').length === 0 && localQueryAll(panel, '.swatch-smear-wash').length === 0 &&
+      localQueryAll(panel, '.swatch-ghost-src').length === 0 && localQueryAll(panel, '.swatch-ghost-echo').length === 0);
+  })();
+
+  // streak: exactly 1 .swatch-streak-band (named to avoid colliding with the
+  // sheet's own 'swatch-streak' defect-modifier class), no gauge
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'streak' });
+    test('Wave 4: streak swatch has exactly 1 .swatch-streak-band', localQueryAll(panel, '.swatch-streak-band').length === 1);
+    test('Wave 4: streak swatch sheet still carries the swatch-streak class', !!localQuery(panel, '.swatch-sheet.swatch-streak'));
+    test('Wave 4: streak swatch has no gauge/spot overlays',
+      localQueryAll(panel, '.swatch-gauge').length === 0 && localQueryAll(panel, '.swatch-spot').length === 0);
+  })();
+
+  // smear: exactly 1 .swatch-smear-wash (named to avoid colliding with the
+  // sheet's own 'swatch-smear' defect-modifier class), no gauge
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'smear' });
+    test('Wave 4: smear swatch has exactly 1 .swatch-smear-wash', localQueryAll(panel, '.swatch-smear-wash').length === 1);
+    test('Wave 4: smear swatch sheet still carries the swatch-smear class', !!localQuery(panel, '.swatch-sheet.swatch-smear'));
+    test('Wave 4: smear swatch has no gauge/spot overlays',
+      localQueryAll(panel, '.swatch-gauge').length === 0 && localQueryAll(panel, '.swatch-spot').length === 0);
+  })();
+
+  // ghost: exactly 1 .swatch-ghost-src + 1 .swatch-ghost-echo, no gauge
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'ghost' });
+    test('Wave 4: ghost swatch has exactly 1 .swatch-ghost-src + 1 .swatch-ghost-echo',
+      localQueryAll(panel, '.swatch-ghost-src').length === 1 && localQueryAll(panel, '.swatch-ghost-echo').length === 1);
+    test('Wave 4: ghost swatch has no gauge/spot overlays',
+      localQueryAll(panel, '.swatch-gauge').length === 0 && localQueryAll(panel, '.swatch-spot').length === 0);
+  })();
+
+  // skew: NO extra overlay nodes at all — the CSS transform does the work
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'skew' });
+    test('Wave 4: skew swatch adds zero overlay nodes (spot/streak/smear/ghost/gauge)',
+      localQueryAll(panel, '.swatch-spot').length === 0 && localQueryAll(panel, '.swatch-streak-band').length === 0 &&
+      localQueryAll(panel, '.swatch-smear-wash').length === 0 && localQueryAll(panel, '.swatch-ghost-src').length === 0 &&
+      localQueryAll(panel, '.swatch-ghost-echo').length === 0 && localQueryAll(panel, '.swatch-gauge').length === 0);
+    test('Wave 4: skew swatch sheet still carries the swatch-skew class',
+      !!localQuery(panel, '.swatch-sheet.swatch-skew'));
+  })();
+
+  // caption is XSS-escaped
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'smear', caption: '<img src=x onerror=1>' });
+    var cap = localQuery(panel, '.swatch-cap');
+    test('Wave 4: swatch caption is escaped (no raw <img>, no live onerror handler)',
+      !!cap && cap.innerHTML.indexOf('<img') === -1 && !hasOnclickAnywhere(panel));
+  })();
+
+  // notes are XSS-escaped
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'smear', notes: ['<script>x</script>'] });
+    var note = localQuery(panel, '.swatch-note');
+    test('Wave 4: swatch note text is escaped (no raw <script>)',
+      !!note && note.innerHTML.indexOf('<script>') === -1);
+  })();
+
+  // caption/notes both optional — absent when not provided
+  (function () {
+    var panel = sandboxRender({ kind: 'swatch', title: 't', defect: 'smear' });
+    test('Wave 4: swatch with no caption/notes renders neither .swatch-cap nor .swatch-notes',
+      localQueryAll(panel, '.swatch-cap').length === 0 && localQueryAll(panel, '.swatch-notes').length === 0);
+  })();
+})();
+

--- a/tests/uat/200-simlab-fidelity-validators-renderers.js
+++ b/tests/uat/200-simlab-fidelity-validators-renderers.js
@@ -1221,3 +1221,99 @@ const {
   }
 })();
 
+// ── Wave 4 Task 4: swatch (laser print defect) fidelity validator ──
+// Hand-derived fixture rows (plan Step 1, BEFORE trusting a green run — both
+// Wave 3 fidelity-validator bugs were plausible-looking literal code):
+//   1. spots + drum + permanent + replace remedy -> ok
+//   2. spots + fuser (not in {drum,roller})      -> FAIL
+//   3. spots + roller (set-based, distinct comp)  -> ok
+//   4a. streak + "blocked toner path"            -> ok
+//   4b. streak + bare "toner cartridge" (TRAP: must NOT match 'toner path'/'blocked toner') -> FAIL
+//   5. permanent damage + clean-class remedy      -> FAIL (coherence)
+//   6. debris damage + replace-class remedy        -> FAIL (coherence)
+//   7. damageKind 'none' + no fix step (diagnosis-only) -> ok
+//   8. missing diagnose step                       -> FAIL
+// plus 2 mutation checks proving the validator is load-bearing, not decorative.
+(function () {
+  try {
+    var vm = require('vm');
+    function assert(cond, msg) { test(msg, !!cond); }
+    var grab = function (n) { return _fnBody(js, n); };
+    var causesVar = (js.match(/var _SWATCH_CAUSES = \{[\s\S]*?\n\s*\};/) || [''])[0];
+    var resolveSlotBody = grab('_slFidelityResolveSlot');
+    var swFidelityBody = grab('simLabValidateSwatchFidelity');
+    if (!causesVar || !resolveSlotBody || !swFidelityBody) {
+      test('swatch fidelity: vm extraction succeeded', false);
+      results.errors.push('could not extract simLabValidateSwatchFidelity/_SWATCH_CAUSES');
+      return;
+    }
+    var swCtx = {}; vm.createContext(swCtx);
+    vm.runInContext(resolveSlotBody + '\n' + causesVar + '\n' + swFidelityBody, swCtx);
+    vm.runInContext('globalThis.__swFidelity = simLabValidateSwatchFidelity;', swCtx);
+    var swatchFidelity = swCtx.__swFidelity;
+
+    // minimal scenario fixture builder — mirrors the step-id convention
+    // ('diagnose'/'failedComponent', 'fix'/'remedy') from the Reference contracts.
+    function mkScn(defect, componentText, opts) {
+      opts = opts || {};
+      var scn = {
+        assets: { reference: { kind: 'swatch', title: 't', defect: defect } },
+        swatch: { damageKind: opts.damageKind || 'none' },
+        steps: []
+      };
+      if (!opts.omitDiagnose) {
+        scn.steps.push({ id: 'diagnose', type: 'configure', points: 1,
+          payload: { slots: [{ id: 'failedComponent', label: 'c', options: [
+            { id: 'a', text: componentText }, { id: 'b', text: 'Other component text' } ] }] },
+          answer: { slots: { failedComponent: 'a' } } });
+      }
+      if (opts.remedy !== undefined) {
+        scn.steps.push({ id: 'fix', type: 'configure', points: 1,
+          payload: { slots: [{ id: 'remedy', label: 'r', options: [
+            { id: 'a', text: opts.remedy }, { id: 'b', text: 'Something else' } ] }] },
+          answer: { slots: { remedy: 'a' } } });
+      }
+      return scn;
+    }
+
+    var fixOkSpots = mkScn('spots', 'Imaging drum · damage or debris on its surface prints every rotation',
+      { damageKind: 'permanent', remedy: 'Replace the drum unit · a scratched drum cannot be repaired' });
+    assert(swatchFidelity(fixOkSpots).ok === true, 'Wave 4 fidelity row 1: spots+drum+permanent+replace remedy passes');
+
+    var fix2 = mkScn('spots', 'Fuser assembly · toner is not bonding to the page', { damageKind: 'none' });
+    assert(swatchFidelity(fix2).ok === false, 'Wave 4 fidelity row 2: spots keyed to fuser (out of set) rejected');
+
+    var fix3 = mkScn('spots', 'Pickup roller feeding pages crooked', { damageKind: 'none' });
+    assert(swatchFidelity(fix3).ok === true, 'Wave 4 fidelity row 3: spots keyed to roller (set-based) passes');
+
+    var fix4a = mkScn('streak', 'Blocked toner path · debris jams the transfer', { damageKind: 'none' });
+    assert(swatchFidelity(fix4a).ok === true, 'Wave 4 fidelity row 4a: streak keyed to "blocked toner path" passes');
+    var fix4b = mkScn('streak', 'Toner cartridge empty or clogged · faded or missing print', { damageKind: 'none' });
+    assert(swatchFidelity(fix4b).ok === false, 'Wave 4 fidelity row 4b: streak keyed to bare "toner cartridge" rejected (streak trap)');
+
+    var fix5 = mkScn('spots', 'Imaging drum · damage or debris on its surface prints every rotation',
+      { damageKind: 'permanent', remedy: 'Clean the drum surface and reinstall it' });
+    assert(swatchFidelity(fix5).ok === false, 'Wave 4 fidelity row 5: permanent damage with clean-class remedy rejected');
+
+    var fix6 = mkScn('spots', 'Imaging drum · damage or debris on its surface prints every rotation',
+      { damageKind: 'debris', remedy: 'Replace the drum unit · a scratched drum cannot be repaired' });
+    assert(swatchFidelity(fix6).ok === false, 'Wave 4 fidelity row 6: debris damage with replace-class remedy rejected');
+
+    var fix7 = mkScn('ghost', 'Cleaning blade worn or damaged, streaking a faint echo image', { damageKind: 'none' });
+    assert(swatchFidelity(fix7).ok === true, 'Wave 4 fidelity row 7: diagnosis-only (damageKind none, no fix step) passes');
+
+    var fix8 = mkScn('spots', 'Imaging drum', { damageKind: 'none', omitDiagnose: true });
+    assert(swatchFidelity(fix8).ok === false, 'Wave 4 fidelity row 8: missing diagnose step rejected');
+
+    // mutation checks: prove the validator is load-bearing, not decorative
+    var mutA = JSON.parse(JSON.stringify(fixOkSpots)); mutA.assets.reference.defect = 'smear';
+    assert(swatchFidelity(mutA).ok === false, 'Wave 4 fidelity mutation: flipping defect spots→smear flips verdict');
+    var mutB = JSON.parse(JSON.stringify(fixOkSpots)); mutB.swatch.damageKind = 'debris';
+    assert(swatchFidelity(mutB).ok === false, 'Wave 4 fidelity mutation: flipping damageKind permanent→debris flips verdict');
+
+  } catch (err) {
+    test('swatch fidelity validator: vm smoke test (threw)', false);
+    results.errors.push('swatch fidelity validator smoke test threw: ' + err.message);
+  }
+})();
+

--- a/tests/uat/240-simlab-feedback-portmap-wiremap-raid-final.js
+++ b/tests/uat/240-simlab-feedback-portmap-wiremap-raid-final.js
@@ -1231,3 +1231,309 @@ const {
   }
 })();
 
+// ── Sim Lab: Wave 4 swatch vertical slice ──
+// Proves the swatch archetype works end to end through the REAL Practice
+// path against the REAL a1-swatch-01 bank scenario (not a hand fixture):
+// structural + fidelity validators green, _slRenderReference dispatch,
+// _slMountScenario mount with a static (zero-interaction) swatch panel,
+// per-slot configure scoring incl. the partial-credit path, and the XSS
+// caption round-trip through the real mount path. Scaffolding copied
+// wholesale from the Wave 3 Task 14 block above (same grab() extraction,
+// same stateful DOM shim). NOTE: asserts the REAL committed overlay class
+// names (swatch-streak-band / swatch-smear-wash — renamed in Task 2 to
+// avoid colliding with the sheet's own swatch-<defect> modifier class).
+(function () {
+  console.log('\n\x1b[1m── Sim Lab: Wave 4 swatch vertical slice ──\x1b[0m');
+  try {
+    var vm = require('vm');
+
+    var grab = function (name) {
+      var re = new RegExp('function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n\\}');
+      return (js.match(re) || [''])[0];
+    };
+    var grabLine = function (name) {
+      var re = new RegExp('function ' + name + '\\([^\\n]*\\)\\s*\\{[^\\n]*\\}');
+      return (js.match(re) || [''])[0];
+    };
+
+    // ── (a) validator sandbox: structural + fidelity ──
+    var isNonEmptyStrBody    = _fnBody(js, '_isNonEmptyStr');
+    var validatePayloadBody  = _fnBody(js, '_validateStepPayload');
+    var validateScenarioBody = _fnBody(js, 'simLabValidateScenario');
+    var stepTypesMatch = js.match(/var STEP_TYPES\s*=\s*\[[^\]]+\]/);
+    var stepTypesDecl = stepTypesMatch ? stepTypesMatch[0] + ';' : '';
+    var swatchDefectsMatch = js.match(/var _SWATCH_DEFECTS\s*=\s*\[[^\]]+\]/);
+    var swatchDefectsDecl = swatchDefectsMatch ? swatchDefectsMatch[0] + ';' : '';
+    var resolveSlotBody = _fnBody(js, '_slFidelityResolveSlot');
+    var causesVar = (js.match(/var _SWATCH_CAUSES = \{[\s\S]*?\n\s*\};/) || [''])[0];
+    var swatchFidelityBody = _fnBody(js, 'simLabValidateSwatchFidelity');
+
+    if (!isNonEmptyStrBody || !validatePayloadBody || !validateScenarioBody || !stepTypesDecl ||
+        !swatchDefectsDecl || !resolveSlotBody || !causesVar || !swatchFidelityBody) {
+      test('Wave 4 slice: validator vm extraction succeeded', false);
+      results.errors.push('Wave 4 slice: could not extract validator helpers; check names/indenting');
+      return;
+    }
+    var vCtx = {};
+    vm.createContext(vCtx);
+    vm.runInContext(stepTypesDecl + '\n' + swatchDefectsDecl + '\n' + isNonEmptyStrBody + '\n' +
+      validatePayloadBody + '\n' + validateScenarioBody + '\n' + resolveSlotBody + '\n' +
+      causesVar + '\n' + swatchFidelityBody, vCtx);
+    vm.runInContext('globalThis.__validate = simLabValidateScenario; globalThis.__fidelity = simLabValidateSwatchFidelity;', vCtx);
+    var validateScenario = vCtx.__validate;
+    var swatchFidelity = vCtx.__fidelity;
+
+    // ── (b) the REAL bank scenario ──
+    var seedSrc = read('features/sim-lab-seed-aplus-core1.js');
+    var seedCtx = {};
+    vm.createContext(seedCtx);
+    vm.runInContext('var window = {};\n' + seedSrc + '\nglobalThis.__seed = window.SIM_LAB_SEED_APLUS_CORE1;', seedCtx);
+    var bank = seedCtx.__seed;
+    var swatchScn = (Array.isArray(bank) ? bank : []).filter(function (s) { return s && s.id === 'a1-swatch-01'; })[0];
+    test('Wave 4 slice: a1-swatch-01 resolved from the real bank', !!swatchScn);
+    if (!swatchScn) { results.errors.push('Wave 4 slice: a1-swatch-01 missing from SIM_LAB_SEED_APLUS_CORE1'); return; }
+
+    // (1) belt and suspenders vs. the authoring harness
+    var vr = validateScenario(swatchScn);
+    test('Wave 4 slice: a1-swatch-01 passes simLabValidateScenario', vr && vr.ok === true);
+    var fr = swatchFidelity(swatchScn);
+    test('Wave 4 slice: a1-swatch-01 passes simLabValidateSwatchFidelity', fr && fr.ok === true);
+
+    // ── (c) renderer + mount + score sandbox (Wave 3 Task 14 shim, verbatim) ──
+    var elBody               = grab('_el');
+    var escBody               = grabLine('_esc');
+    var slAttrBody            = grabLine('_slAttr');
+    var renderCfgBody         = grab('_slRenderConfigure');
+    var renderAnalyzeModeBody = grab('_slRenderAnalyzeMode');
+    var renderAnalyzeBody     = grab('_slRenderAnalyze');
+    var renderStepBody        = grab('simLabRenderStep');
+    var refNetBody            = grab('_slRenderRefNetwork');
+    var refTimeBody           = grab('_slRenderRefTimeline');
+    var refLayBody            = grab('_slRenderRefLayered');
+    var refLayStackBody       = grab('_slRenderRefLayeredStacked');
+    var termLineBody          = grab('_termLineHtml');
+    var termPmtBody           = grab('_termPromptHtml');
+    var refTermBody           = grab('_slRenderRefTerminal');
+    var refFaceplateBody      = grab('_slRenderRefFaceplate');
+    var refWiremapBody        = grab('_slRenderRefWiremap');
+    var refSlotsBody          = grab('_slRenderRefSlots');
+    var swatchAriaVar         = (js.match(/var _SWATCH_ARIA = \{[\s\S]*?\n\s*\};/) || [''])[0];
+    var refSwatchBody         = grab('_slRenderRefSwatch');
+    var refDispBody           = grab('_slRenderReference');
+    var mountBody             = grab('_slMountScenario');
+    var scoreSlotsBody          = grab('_scoreConfigureSlots');
+    var scoreAnalyzeLenientBody = grab('_scoreAnalyzeLenient');
+    var scoreStepBody           = grab('_scoreStep');
+    var scoreScenarioBody       = grab('simLabScoreScenario');
+    var normBody           = grab('_norm');
+    var normalizeMatchBody = grab('_simLabNormalizeMatch');
+    var arrEqBody          = grab('_arrEq');
+    var setEqBody          = grab('_setEq');
+
+    if (!elBody || !escBody || !mountBody || !refDispBody || !refSwatchBody || !swatchAriaVar ||
+        !renderCfgBody || !renderStepBody ||
+        !scoreScenarioBody || !scoreSlotsBody || !scoreStepBody) {
+      test('Wave 4 slice: mount/score vm extraction succeeded', false);
+      results.errors.push('Wave 4 slice: could not extract _slMountScenario/_slRenderRefSwatch/_SWATCH_ARIA/score helpers; check names/indenting');
+      return;
+    }
+
+    var htmlEsc = function (s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    };
+    var makeEl = function (tag) {
+      var attrs = {}, listeners = {}, children = [], cls = '', inner = '', val = '';
+      var clsSet = {};
+      var el = {
+        tagName: tag.toUpperCase(),
+        get className() { return cls; }, set className(v) { cls = v; },
+        get innerHTML() { return inner; }, set innerHTML(v) { inner = v; children = []; },
+        get textContent() { return ''; }, set textContent(v) { inner = htmlEsc(v); },
+        get value() { return val; }, set value(v) { val = v; },
+        selected: false,
+        style: {},
+        get _children() { return children; },
+        classList: {
+          add: function (c) { clsSet[c] = true; },
+          remove: function (c) { delete clsSet[c]; },
+          toggle: function (c, on) { if (on) clsSet[c] = true; else delete clsSet[c]; },
+          contains: function (c) { return !!clsSet[c]; }
+        },
+        setAttribute: function (k, v) { attrs[k] = v; },
+        getAttribute: function (k) { return (k in attrs) ? attrs[k] : null; },
+        removeAttribute: function (k) { delete attrs[k]; },
+        appendChild: function (c) { children.push(c); return c; },
+        insertBefore: function (c) { children.unshift(c); return c; },
+        querySelector: function (sel) {
+          var want = sel.replace(/^\./, '');
+          var hit = null;
+          var walk = function (n) {
+            if (hit || !n || !n._children) return;
+            n._children.forEach(function (c) {
+              if (hit || !c || !c.tagName) return;
+              if (want.toUpperCase() === c.tagName || (c.className && c.className.split(' ').indexOf(want) !== -1)) { hit = c; return; }
+              walk(c);
+            });
+          };
+          walk(el);
+          return hit;
+        },
+        querySelectorAll: function (sel) {
+          var hits = [], want = sel.replace(/^\./, '');
+          var walk = function (n) { (n._children || []).forEach(function (c) {
+            if (!c || !c.tagName) return;
+            if (want.toUpperCase() === c.tagName || (c.className && c.className.split(' ').indexOf(want) !== -1)) hits.push(c);
+            walk(c);
+          }); };
+          walk(el); return hits;
+        },
+        addEventListener: function (ev, fn) { (listeners[ev] = listeners[ev] || []).push(fn); },
+        dispatchEvent: function (evObj) { (listeners[evObj.type] || []).forEach(function (fn) { fn(evObj); }); },
+        _fire: function (ev) { (listeners[ev] || []).forEach(function (fn) { fn({}); }); },
+        closest: function () { return null; },
+        remove: function () {}
+      };
+      return el;
+    };
+    var docShim = {
+      createElement: function (tag) { return makeEl(tag); },
+      createTextNode: function (t) { return { textContent: t, tagName: '#text' }; }
+    };
+    var windowShim = { CSS: null, matchMedia: function () { return { matches: false }; } };
+    var mCtx = { document: docShim, window: windowShim, Object: Object, Array: Array, String: String, JSON: JSON };
+    vm.createContext(mCtx);
+    vm.runInContext(elBody, mCtx);
+    vm.runInContext(escBody, mCtx);
+    vm.runInContext(slAttrBody, mCtx);
+    vm.runInContext(isNonEmptyStrBody, mCtx);
+    vm.runInContext(renderCfgBody, mCtx);
+    if (renderAnalyzeModeBody) vm.runInContext(renderAnalyzeModeBody, mCtx);
+    if (renderAnalyzeBody) vm.runInContext(renderAnalyzeBody, mCtx);
+    vm.runInContext(renderStepBody, mCtx);
+    if (refNetBody) vm.runInContext(refNetBody, mCtx);
+    if (refTimeBody) vm.runInContext(refTimeBody, mCtx);
+    if (refLayBody) vm.runInContext(refLayBody, mCtx);
+    if (refLayStackBody) vm.runInContext(refLayStackBody, mCtx);
+    if (termLineBody) vm.runInContext(termLineBody, mCtx);
+    if (termPmtBody) vm.runInContext(termPmtBody, mCtx);
+    if (refTermBody) vm.runInContext(refTermBody, mCtx);
+    if (refFaceplateBody) vm.runInContext(refFaceplateBody, mCtx);
+    if (refWiremapBody) vm.runInContext(refWiremapBody, mCtx);
+    if (refSlotsBody) vm.runInContext(refSlotsBody, mCtx);
+    vm.runInContext(swatchAriaVar, mCtx);
+    vm.runInContext(refSwatchBody, mCtx);
+    vm.runInContext(refDispBody, mCtx);
+    vm.runInContext(mountBody, mCtx);
+    if (normBody) vm.runInContext(normBody, mCtx);
+    if (normalizeMatchBody) vm.runInContext(normalizeMatchBody, mCtx);
+    if (arrEqBody) vm.runInContext(arrEqBody, mCtx);
+    if (setEqBody) vm.runInContext(setEqBody, mCtx);
+    vm.runInContext(scoreSlotsBody, mCtx);
+    if (scoreAnalyzeLenientBody) vm.runInContext(scoreAnalyzeLenientBody, mCtx);
+    vm.runInContext(scoreStepBody, mCtx);
+    vm.runInContext(scoreScenarioBody, mCtx);
+
+    // local compound-class query (the shim's querySelector is single-token)
+    var queryCompound = function (root, selector) {
+      var classes = selector.split('.').filter(Boolean);
+      var hit = null;
+      var walk = function (n) {
+        if (hit) return;
+        (n._children || []).forEach(function (c) {
+          if (hit || !c || !c.tagName) return;
+          var cls = (c.className || '').split(' ');
+          if (classes.every(function (w) { return cls.indexOf(w) !== -1; })) { hit = c; return; }
+          walk(c);
+        });
+      };
+      walk(root);
+      return hit;
+    };
+
+    function expectedSelectCount(scn) {
+      return scn.steps.filter(function (s) { return s.type === 'configure'; })
+        .reduce(function (sum, s) { return sum + s.payload.slots.length; }, 0);
+    }
+    function mountOnly(scn) {
+      var host = makeEl('div');
+      mCtx.__host = host;
+      mCtx.__scn = scn;
+      var result = null;
+      mCtx.__onSubmit = function (r) { result = r; };
+      vm.runInContext('globalThis.__opts = { onSubmit: __onSubmit }; _slMountScenario(__host, __scn, __opts);', mCtx);
+      return { wrap: host._children[0], getResult: function () { return result; } };
+    }
+    function submitActive() { vm.runInContext('window.__slActiveSubmit();', mCtx); }
+    function driveConfigureCorrectly(wrap, scn, wrongSlot) {
+      var stepWraps = wrap._children.filter(function (c) { return c && c.className === 'sl-step'; });
+      scn.steps.forEach(function (st, i) {
+        if (st.type !== 'configure') return;
+        var selects = stepWraps[i].querySelectorAll('select');
+        selects.forEach(function (sel) {
+          var slotId = sel.getAttribute('data-slot');
+          var correctVal = st.answer.slots[slotId];
+          var v = correctVal;
+          if (wrongSlot && wrongSlot.stepId === st.id && wrongSlot.slotId === slotId) {
+            var slotDef = st.payload.slots.filter(function (s) { return s.id === slotId; })[0];
+            var wrongOpt = slotDef.options.filter(function (o) { return o.id !== correctVal; })[0];
+            v = wrongOpt.id;
+          }
+          sel.value = v;
+          sel.dispatchEvent({ type: 'change' });
+        });
+      });
+    }
+
+    // (2) dispatch: _slRenderReference routes kind 'swatch' to the swatch renderer
+    mCtx.__swRef = swatchScn.assets.reference;
+    var dispPanel = vm.runInContext('_slRenderReference(__swRef);', mCtx);
+    test('Wave 4 slice: _slRenderReference returns a .sl-ref panel for kind swatch',
+      dispPanel && dispPanel.className === 'sl-ref');
+    test('Wave 4 slice: dispatched panel contains .swatch-sheet.swatch-spots (a1-swatch-01 primary defect)',
+      !!queryCompound(dispPanel, '.swatch-sheet.swatch-spots'));
+
+    // (3) full mount through _slMountScenario: reference panel + steps render;
+    // the swatch sheet itself carries ZERO interactive elements (static by spec)
+    var swMount = mountOnly(swatchScn);
+    var swWrap = swMount.wrap;
+    var mountedSheet = swWrap.querySelector('.swatch-sheet');
+    test('Wave 4 slice: mounted DOM contains the swatch sheet and every configure <select>',
+      !!mountedSheet && swWrap.querySelectorAll('select').length === expectedSelectCount(swatchScn));
+    test('Wave 4 slice: zero interactive elements inside the swatch sheet (static reference)',
+      !!mountedSheet && mountedSheet.querySelectorAll('button').length === 0 &&
+      mountedSheet.querySelectorAll('select').length === 0);
+
+    // (4) fully-correct submission scores full points through the real path
+    driveConfigureCorrectly(swWrap, swatchScn);
+    submitActive();
+    var swResult = swMount.getResult();
+    test('Wave 4 slice: fully-correct diagnose+fix answers score correct === total',
+      swResult && swResult.total > 0 && swResult.correct === swResult.total);
+
+    // (5) wrong failedComponent → partial credit; the defectPattern point is retained
+    var swatchClone = JSON.parse(JSON.stringify(swatchScn));
+    var swMount2 = mountOnly(swatchClone);
+    driveConfigureCorrectly(swMount2.wrap, swatchClone, { stepId: 'diagnose', slotId: 'failedComponent' });
+    submitActive();
+    var swResult2 = swMount2.getResult();
+    test('Wave 4 slice: wrong failedComponent scores partial credit (correct < total, correct > 0)',
+      swResult2 && swResult2.correct < swResult2.total && swResult2.correct > 0);
+    var swDiagTally = swResult2 && swResult2.perStep && swResult2.perStep.diagnose;
+    test('Wave 4 slice: per-step diagnose tally retains the defectPattern point (correct === total - 1)',
+      swDiagTally && swDiagTally.total > 1 && swDiagTally.correct === swDiagTally.total - 1);
+
+    // (6) XSS caption round-trips ESCAPED through the real mount path
+    var xssClone = JSON.parse(JSON.stringify(swatchScn));
+    xssClone.assets.reference.caption = '<img src=x onerror=1>';
+    var xssMount = mountOnly(xssClone);
+    var xssCap = xssMount.wrap.querySelector('.swatch-cap');
+    test('Wave 4 slice: XSS caption round-trips escaped through the real mount path (no raw <img>)',
+      !!xssCap && xssCap.innerHTML.indexOf('<img') === -1 && xssCap.innerHTML.indexOf('&lt;img') !== -1);
+
+  } catch (err) {
+    test('Wave 4 slice: vertical-slice smoke test (threw)', false);
+    results.errors.push('Wave 4 slice vertical-slice smoke test threw: ' + err.message);
+  }
+})();
+


### PR DESCRIPTION
## Summary

Final archetype of the 4-wave / 11-archetype PBQ program: **Laser Print Defect Clinic** (A+ Core 1). One new reference kind (`swatch`, the 8th) with a static pure-CSS renderer, one set-based fidelity validator, and a 12-scenario two-agent-gated seed bank. No new step types, no new analyze modes, no new binding infrastructure — everything rides the proven Wave 1-3 engine.

- **Task 1-2:** `swatch` kind validation + archetype tag; `_slRenderRefSwatch` static renderer (role=img, per-defect `_SWATCH_ARIA`, zero interactive elements) + dispatch + test hook.
- **Task 3:** `--sw-paper/--sw-paper-edge/--sw-toner` tokens + `.swatch*` component CSS in `dg-system.css`; hand-bumped `?v=` only; ratchet guard green (zero new undefined `var()`).
- **Task 4:** `simLabValidateSwatchFidelity` — set-based defect→component truth table (`_SWATCH_CAUSES`), remediation coherence (permanent→replace / debris→clean), 8 hand-derived fixture rows + 2 mutation checks.
- **Tasks 5-7:** 12 scenarios `a1-swatch-01..12` (spots/streak/smear/ghost/skew ×2 each + 2 multi-symptom with order/match triage steps), all through `scripts/dev/wave4-fidelity-check.js` (12/12 PASS).
- **Task 8:** Wave 4 vertical slice through the real Practice mount/score path (11 checks incl. partial-credit and XSS caption round-trip).
- **Task 9:** live-local drive — dark+light × desktop+375px × 5 defects, real submit → 4/4 · 100% result screen; screenshots in `.superpowers/sdd/wave4-screens/`.

## Two-agent gate records (printer-hardware engineer + CompTIA 220-1201 examiner)

- **Batch A (01-04, spots+streak):** BOTH APPROVE ALL, round 1.
- **Batch B (05-08, smear+ghost):** BOTH APPROVE ALL, round 1.
- **Batch C (09-12, skew+multi):** engineer APPROVE ALL round 1; examiner rejected 12's match step (grind/jam mechanisms defensibly swappable) → revised to orthogonal mechanisms (heat / worn drive gear / lost nip at the pressure roller) → BOTH APPROVE round 2.

## Objective correction

Verified against the official 220-1201 V2.0 objectives: printer troubleshooting is **5.6** (the spec's 3.6/3.7 belief was stale — 3.6 = deploy/configure MFDs, 3.7 = printer maintenance). All 12 scenarios carry `objective: '5.6'`; remedy options informed by 3.7's laser maintenance list. Pre-wave coverage: 3.6 ×1, 3.7 ×2, 5.6 ×1.

## Engine-wins deviations from the plan's literal code

1. **Overlay class rename:** `swatch-streak`/`swatch-smear` overlay divs → `swatch-streak-band`/`swatch-smear-wash` — the bare names collide with the sheet's own `swatch-<defect>` modifier class, so the plan's CSS would have repainted the sheet itself (Wave 3 dead-selector class of bug, caught before Task 3).
2. **4 theme token blocks, not 2:** `dg-system.css` defines tokens in 4 cascade blocks (`html:root`, media-query light, `[data-theme=dark]`, `[data-theme=light]`); the swatch tokens were added to all 4 for consistency.

## Verification

- UAT: **4729 → 4824, ALL PASS** (+95 checks)
- tech-debt.js: all thresholds within limits
- Playwright: 431 passed; 15 failed = the pre-existing `[mobile-safari]` flaky set (app.spec.js nav/export/monitor/quiz — zero sim-lab references, no wave-modified file involved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)