### PR TITLE
feat(T9): diagnostic endpoint telemetry + cloud-store flush timeout

### DIFF
--- a/cloud-store.js
+++ b/cloud-store.js
@@ -497,7 +497,11 @@
       }
     }
 
-    inflightFlush = Promise.all(ops).then(function (results) {
+    var flushPromise = (typeof withTimeout === 'function')
+      ? withTimeout(Promise.all(ops), 20000, 'cloud-flush')
+      : Promise.all(ops);
+
+    inflightFlush = flushPromise.then(function (results) {
       inflightFlush = null;
       var hadError = results.some(function (r) { return r && r.error; });
       lastSyncAt = Date.now();
@@ -510,7 +514,7 @@
       return results;
     }).catch(function (err) {
       inflightFlush = null;
-      // Network error or other — re-queue + report
+      // Network error, timeout, or other — re-queue + report
       keysSnapshot.forEach(function (k) { pendingFlush.add(k); });
       setStatus(navigator.onLine === false ? 'offline' : 'error');
       console.error('[cloud-store] flush threw', err);

--- a/landing/api/diagnostic/signup-magic-link.js
+++ b/landing/api/diagnostic/signup-magic-link.js
@@ -30,6 +30,8 @@
 //   503 service_unconfigured (any env var missing → graceful pre-config)
 // ══════════════════════════════════════════════════════════════════════════
 
+import { logServerError } from '../_lib/log-server-error.js';
+
 export const config = { runtime: 'edge' };
 
 const SUPABASE_URL = process.env.SUPABASE_URL || '';
@@ -105,6 +107,8 @@ function generateToken() {
 
 async function verifyTurnstile(token, ip) {
   if (!TURNSTILE_SECRET_KEY) return true;  // not configured = skip check
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 10000);
   try {
     const body = new URLSearchParams();
     body.set('secret', TURNSTILE_SECRET_KEY);
@@ -114,12 +118,20 @@ async function verifyTurnstile(token, ip) {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body,
+      signal: ctrl.signal,
     });
-    if (!res.ok) return false;
+    if (!res.ok) {
+      logServerError({ endpoint: 'landing/api/diagnostic/signup-magic-link', message: 'turnstile_http_failed ' + res.status, status: res.status });
+      return false;
+    }
     const data = await res.json().catch(() => null);
     return Boolean(data && data.success);
-  } catch (_) {
+  } catch (e) {
+    const isTimeout = e && e.name === 'AbortError';
+    logServerError({ endpoint: 'landing/api/diagnostic/signup-magic-link', error: e, message: isTimeout ? 'turnstile_timeout' : 'turnstile_threw', status: isTimeout ? 504 : 502 });
     return false;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -138,6 +150,7 @@ async function checkRateLimit(ipHash) {
   if (!res.ok) {
     // Supabase RPC failure — fail closed (block the request) rather than
     // letting unlimited magic-link sends through.
+    logServerError({ endpoint: 'landing/api/diagnostic/signup-magic-link', message: 'rate_limit_rpc_failed ' + res.status, status: res.status });
     return { allowed: false, error: 'rate_limit_rpc_failed', currentCount: null, hourlyLimit: 5, resetsAt: null };
   }
   const data = await res.json().catch(() => null);
@@ -217,6 +230,7 @@ export default async function handler(req) {
     const ip = getClientIp(req);
     const tsOk = await verifyTurnstile(turnstileToken, ip);
     if (!tsOk) {
+      logServerError({ endpoint: 'landing/api/diagnostic/signup-magic-link', message: 'turnstile_failed', status: 403 });
       return json({ ok: false, error: 'turnstile_failed' }, 403);
     }
   }
@@ -239,6 +253,7 @@ export default async function handler(req) {
   const token = generateToken();
   const writeOk = await writePendingRow({ token, email, cert, results: diagnosticResults });
   if (!writeOk) {
+    logServerError({ endpoint: 'landing/api/diagnostic/signup-magic-link', message: 'write_failed diagnostic_pending', status: 500 });
     return json({ ok: false, error: 'write_failed' }, 500);
   }
 


### PR DESCRIPTION
## Summary

- **`landing/api/diagnostic/signup-magic-link.js`**: Wire `logServerError` into all error branches (turnstile timeout/failure, rate-limit RPC failure, write failure). Add `AbortController` 10s timeout to the Turnstile `fetch` — timeout returns the existing failure shape (`turnstile_failed → 403`) so the caller is unaffected.
- **`cloud-store.js`**: Wrap `Promise.all(ops)` in `doFlush` with `withTimeout(20000, 'cloud-flush')`. A timeout re-queues the pending keys via the existing `.catch` path — exactly the same retry behaviour as a network error.

Depends on: `landing/api/_lib/log-server-error.js` (ESM) created in T5 on `main` (already merged).

## Gated lane

This PR touches `landing/api/diagnostic/*` (gated trigger) and `cloud-store.js` (gated trigger). Per ENVIRONMENT_STRATEGY.md: PR auto-spins a Supabase branch DB + Vercel preview. Smoke the preview before squash-merging.

## Test plan

- [ ] Vercel preview deploys successfully (CI green)
- [ ] Smoke the magic-link flow on the preview URL: submit the diagnostic form → confirm `ok: true` response
- [ ] To verify telemetry path: set `TURNSTILE_SECRET_KEY` to a bad value in preview env → re-submit → confirm a `type='server'` row appears in the **branch** Supabase `client_errors` table
- [ ] UAT: `node tests/uat.js` — stays at 4846/4849 (3 pre-existing failures unchanged)
- [ ] Squash-merge → post-deploy smoke on prod landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)