### PR TITLE
perf(v7.95.0): defer Supabase auth/cloud chain to post-load — Lighthouse-90 mobile LCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,10 @@
 |---|---|---|
 | app.js | 8260 | 428 KB |
 | styles.css | 14906 | 551 KB |
-| index.html | 2187 | 142 KB |
+| index.html | 2216 | 143 KB |
 | dg-system.css | 4642 | 451 KB |
-| tests/uat.js + tests/uat/ (27 modules) | 27700 | — |
-UAT checks: 4853 · E2E `test(` count: 160 · APP_VERSION: 7.94.0 · stamped-at: worktree
+| tests/uat.js + tests/uat/ (27 modules) | 27746 | — |
+UAT checks: 4856 · E2E `test(` count: 160 · APP_VERSION: 7.95.0 · stamped-at: worktree
 <!-- FACTS:AUTO:END -->
 
 | File | Purpose | Size |
@@ -131,6 +131,7 @@ npx playwright test              # E2E (tests/e2e/app.spec.js)
 
 | Version | Features Added |
 |---|---|
+| v7.95.0 | Lighthouse-90 mobile: Supabase chain (+ diagnostic-claim/web-vitals-collector) deferred past window.load — real bytes+CPU off the eager render-delay chain Lantern penalizes |
 | v7.94.0 | Lighthouse-90 mobile: Fraunces font-display swap to optional — Lantern-simulated LCP no longer waits on webfont fetch |
 | v7.93.0 | Lighthouse-90 mobile LCP render-delay root-cause fix: synchronous data-theme set eliminates late CSS re-application |
 | v7.92.0 | Lighthouse-90 mobile: real second CLS root-cause fix — topbar-time/version-pill hide rules to critical path |

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 // ══════════════════════════════════════════
-// Network+ AI Quiz — app.js  v7.94.0
+// Network+ AI Quiz — app.js  v7.95.0
 // ══════════════════════════════════════════
 
 // ── CONSTANTS ──
-const APP_VERSION = '7.94.0';
+const APP_VERSION = '7.95.0';
 // v4.99.45 (Phase 6b): expose APP_VERSION on window so the web-vitals
 // collector (lib/web-vitals-collector.js, loaded BEFORE app.js so its
 // PerformanceObservers attach earlier) can stamp this version onto every

--- a/index.html
+++ b/index.html
@@ -943,7 +943,7 @@
     <span class="hero-icon">&#9889;</span>
     <h1>Network+ AI Quiz</h1>
     <p>AI-generated MCQs every session. Never the same quiz twice.</p>
-    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.94.0</span>
+    <span id="version-badge" style="display:inline-block;margin-top:10px;font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--accent-light);background:color-mix(in oklab,var(--accent) 12%,transparent);border:1px solid color-mix(in oklab,var(--accent) 30%,transparent);padding:3px 10px;border-radius:99px;cursor:default;user-select:none">v7.95.0</span>
     <div id="streak-badge" class="streak-badge"></div>
     <div id="stats-card" class="hero-stats-strip is-hidden">
       <div class="stats-grid" id="stats-grid"></div>
@@ -2065,45 +2065,74 @@
      pack <script> tags back here. -->
 
 <!-- Phase C′ (cloud-first): Supabase UMD bundle + cert-app cloud modules.
-     Order matters:
-       1. supabase-js (window.supabase factory)
-       2. lib/supabase.js (creates window.certanvilSupabase)
-       3. cloud-store.js (reads window.certanvilSupabase)
-       4. auth-state.js (reads cloud-store + Supabase)
-       5. migration.js (called from auth-state.js on SIGNED_IN)
-     app.js loads last so its DOMContentLoaded handlers see the account pill
-     mount + cloud-store API already in place. -->
-<!-- v4.89.1: vendored locally instead of cdn.jsdelivr.net (CDN 503'd
-     intermittently for users — broke auth.js bailing out → Sign-in button
-     did nothing). Local copy is identical to v2.105.3 UMD bundle. -->
-<!-- v4.99.35 (MOBILE_OPTIMIZATION_PLAN.md Phase 11a): all 6 scripts now
-     `defer`-attributed. Browser downloads them in parallel during HTML
+     v7.95.0: moved off this eager position — see the window.load loader
+     below (after app.js/features). Order is preserved WITHIN the loader
+     (umd -> lib/supabase.js -> cloud-store.js -> auth-state.js ->
+     migration.js), it just no longer runs before app.js. app.js's
+     DOMContentLoaded handlers no longer assume the account-pill mount /
+     cloud-store API are in place synchronously — every consumer null-guards
+     and either polls or listens for the auth event (confirmed by audit). -->
+<!-- v4.99.35 (MOBILE_OPTIMIZATION_PLAN.md Phase 11a): remaining eager scripts
+     stay `defer`-attributed. Browser downloads them in parallel during HTML
      parsing instead of blocking each one serially. Execution order is
      PRESERVED (defer scripts run in document order before DOMContentLoaded
      fires). Lighthouse mobile baseline showed app.js alone causes 3,150ms
      of render-blocking time; defer cuts that to near-zero on the FCP
      critical path. The bigger feature-extraction work lands in Phase 11b. -->
 <!-- Preload hint for app.js — biggest payload (~614 KB), highest priority.
-     Other 5 scripts are small enough that the browser's preload scanner
+     Other eager scripts are small enough that the browser's preload scanner
      picks them up via the <script defer> tag itself. -->
 <link rel="preload" as="script" href="app.js">
-<script defer src="lib/supabase-umd.min.js"></script>
-<script defer src="lib/supabase.js"></script>
-<script defer src="cloud-store.js"></script>
-<script defer src="auth-state.js"></script>
-<script defer src="migration.js"></script>
-<!-- v4.99.56 (D.5): Diagnostic claim hook. Reads ?action=claim-diagnostic&token=…
-     from the URL (set by the landing magic-link emailRedirectTo), waits for
-     SIGNED_IN, calls claim_diagnostic_results(token) RPC to merge the anon
-     diagnostic into profiles.metadata, then toasts + strips URL params.
-     Self-contained · no app.js mutation. Fires no-op unless URL has the
-     action+token combo. -->
-<script defer src="diagnostic-claim.js"></script>
-<!-- v4.99.45 (Phase 6b): Web Vitals collector. Sets up PerformanceObservers
-     immediately on load (buffered:true picks up pre-script events too),
-     then POSTs LCP/FCP/CLS/TTFB once per session on tab hide. Prod-host
-     gated + signed-in only — localhost and preview deploys never fire. -->
-<script defer src="lib/web-vitals-collector.js"></script>
+<!-- v7.95.0 (Lighthouse-90 TASK — mobile LCP render-delay root cause #2):
+     the Supabase chain (umd -> lib/supabase.js -> cloud-store.js ->
+     auth-state.js -> migration.js) plus the closely-related
+     diagnostic-claim.js + lib/web-vitals-collector.js are NOT paint-critical
+     — the signin pill is already static HTML (auth-state.js only mutates its
+     href/signed-in state once it runs), cloud sync is background work, and
+     the other two are event-driven / analytics. But Lantern's mobile
+     simulation chains modeled LCP behind every eager defer-chain script
+     regardless of what it actually paints, so removing real bytes+CPU from
+     the eager chain is the fix. Injected as classic <script> tags AFTER
+     window.load instead of `defer` in the head, preserving execution order
+     via sequential onload chaining (defer's document-order guarantee doesn't
+     apply to dynamically-injected scripts, so this loader re-implements it).
+     Every consumer (app.js, features/*.js) already null-guards
+     window.certanvilSupabase / window.cloudStore / window._certanvilSignedIn
+     and either polls, listens for the SIGNED_IN/onAuthStateChange event, or
+     optimistic-allows — confirmed by audit, no consumer assumes these
+     globals exist at DOMContentLoaded. auth-state.js / migration.js /
+     diagnostic-claim.js each already guard their own init with
+     `document.readyState === 'loading' ? addEventListener(DOMContentLoaded) :
+     init()`, so running after window.load (readyState already 'complete')
+     calls init() immediately — no change needed there. Do NOT move these
+     back to eager `defer` tags without re-adding the preload-scanner
+     rationale that justified them being eager in the first place (none —
+     they were never paint-critical, just historically eager). Keep in sw.js
+     SHELL_ASSETS for offline precache (unrelated to load timing). -->
+<script>
+(function () {
+  'use strict';
+  var CHAIN = [
+    'lib/supabase-umd.min.js',
+    'lib/supabase.js',
+    'cloud-store.js',
+    'auth-state.js',
+    'migration.js',
+    'diagnostic-claim.js',
+    'lib/web-vitals-collector.js'
+  ];
+  function loadNext(i) {
+    if (i >= CHAIN.length) return;
+    var s = document.createElement('script');
+    s.src = CHAIN[i];
+    s.onload = s.onerror = function () { loadNext(i + 1); };
+    document.body.appendChild(s);
+  }
+  function start() { loadNext(0); }
+  if (document.readyState === 'complete') start();
+  else window.addEventListener('load', start);
+})();
+</script>
 <!-- Sec-P4/M6: vendored DOMPurify (no build step). Must load before app.js,
      which calls window.DOMPurify in sanitizeHTML() for XSS defence-in-depth. -->
 <script defer src="lib/dompurify.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certanvil",
-  "version": "7.94.0",
+  "version": "7.95.0",
   "private": true,
   "scripts": {
     "test:uat": "node tests/uat.js",

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /* ══════════════════════════════════════════
-   Network+ AI Quiz — styles.css  v7.94.0
+   Network+ AI Quiz — styles.css  v7.95.0
    ══════════════════════════════════════════ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// Service Worker v7.94.0 — Network+ Quiz App (Phase C′ cloud-first)
-const CACHE_NAME = 'netplus-v7.94.0';
+// Service Worker v7.95.0 — Network+ Quiz App (Phase C′ cloud-first)
+const CACHE_NAME = 'netplus-v7.95.0';
 const SHELL_ASSETS = [
   './',
   './index.html',

--- a/tests/uat/130-cert-aware-ios-branding-cloud-store.js
+++ b/tests/uat/130-cert-aware-ios-branding-cloud-store.js
@@ -359,18 +359,30 @@ test('v4.88.2 Security+: exam-domain-breakdown render uses cert-aware order',
 //   4. SHELL_ASSETS in sw.js missing one of the 4 new modules (broken offline).
 // ══════════════════════════════════════════════════════════════════════════
 
-// 1. Script-tag order — index.html must load Supabase UMD → lib/supabase.js
-//    → cloud-store.js → auth-state.js → migration.js → app.js, in that order.
+// 1. Script order — the chain (Supabase UMD → lib/supabase.js → cloud-store.js
+//    → auth-state.js → migration.js) must stay internally ordered.
 //    v4.89.1: switched from cdn.jsdelivr.net to vendored lib/supabase-umd.min.js
 //    after the CDN 503'd intermittently for some users and broke the auth flow
 //    (auth.js bails out when window.supabase is missing → Sign-in button does
 //    nothing → migration banner never appears).
-test('v4.89.0 Phase C′: index.html loads Supabase UMD before cloud modules',
-  html.indexOf('src="lib/supabase-umd.min.js"') < html.indexOf('src="lib/supabase.js"') &&
-  html.indexOf('src="lib/supabase.js"') < html.indexOf('src="cloud-store.js"') &&
-  html.indexOf('src="cloud-store.js"') < html.indexOf('src="auth-state.js"') &&
-  html.indexOf('src="auth-state.js"') < html.indexOf('src="migration.js"') &&
-  html.indexOf('src="migration.js"') < html.indexOf('src="app.js"'));
+//    v7.95.0 (Lighthouse-90 TASK): the chain no longer runs before app.js —
+//    it moved into the window.load CHAIN loader (see 140-*.js for the full
+//    7-module order test), which by definition runs after every defer
+//    script including app.js. This test now only asserts the chain's
+//    internal order + that it's no longer a static pre-app.js defer tag.
+test('v4.89.0/v7.95.0 Phase C′: Supabase chain internally ordered in the CHAIN loader',
+  (() => {
+    const m = html.match(/var CHAIN = \[([\s\S]{0,600}?)\];/);
+    if (!m) return false;
+    const idx = (f) => m[1].indexOf("'" + f + "'");
+    return idx('lib/supabase-umd.min.js') >= 0 &&
+      idx('lib/supabase-umd.min.js') < idx('lib/supabase.js') &&
+      idx('lib/supabase.js') < idx('cloud-store.js') &&
+      idx('cloud-store.js') < idx('auth-state.js') &&
+      idx('auth-state.js') < idx('migration.js');
+  })());
+test('v7.95.0 Phase C′: Supabase chain is no longer a static pre-app.js defer tag',
+  html.indexOf('<script defer src="lib/supabase-umd.min.js"') === -1);
 
 // v4.89.1: zero-tolerance regression guard — no third-party CDN script tags
 // for Supabase. Vendored locally because cdn.jsdelivr.net 503'd for users.

--- a/tests/uat/140-cross-cert-analytics-playwright-triage.js
+++ b/tests/uat/140-cross-cert-analytics-playwright-triage.js
@@ -771,16 +771,40 @@ test('v4.99.34 SignedInFlag behavioral: handleSignedOut() flips the flag from tr
 
 // ── v4.99.35 — Phase 11a: defer all 6 scripts (FCP/LCP unblock) ──
 console.log('\n\x1b[1m── v4.99.35 — PHASE 11a SCRIPT DEFER ──\x1b[0m');
-test('v4.99.35 Phase11a: lib/supabase-umd.min.js has defer attribute',
-  /<script\s+defer\s+src=["']lib\/supabase-umd\.min\.js["']/.test(html));
-test('v4.99.35 Phase11a: lib/supabase.js has defer attribute',
-  /<script\s+defer\s+src=["']lib\/supabase\.js["']/.test(html));
-test('v4.99.35 Phase11a: cloud-store.js has defer attribute',
-  /<script\s+defer\s+src=["']cloud-store\.js["']/.test(html));
-test('v4.99.35 Phase11a: auth-state.js has defer attribute',
-  /<script\s+defer\s+src=["']auth-state\.js["']/.test(html));
-test('v4.99.35 Phase11a: migration.js has defer attribute',
-  /<script\s+defer\s+src=["']migration\.js["']/.test(html));
+// v7.95.0 (Lighthouse-90 TASK): the Supabase chain moved OFF eager `defer`
+// tags entirely — it now loads via the window.load CHAIN loader (see the
+// v7.95.0 tests below). These 5 defer-attribute checks are superseded by
+// "must NOT be a static defer/eager script tag" guards so the chain can
+// never silently regress back onto the eager path.
+test('v7.95.0 Lighthouse-90: lib/supabase-umd.min.js is NOT a static eager script tag',
+  !/<script[^>]*\ssrc=["']lib\/supabase-umd\.min\.js["']/.test(html));
+test('v7.95.0 Lighthouse-90: lib/supabase.js is NOT a static eager script tag',
+  !/<script[^>]*\ssrc=["']lib\/supabase\.js["']/.test(html));
+test('v7.95.0 Lighthouse-90: cloud-store.js is NOT a static eager script tag',
+  !/<script[^>]*\ssrc=["']cloud-store\.js["']/.test(html));
+test('v7.95.0 Lighthouse-90: auth-state.js is NOT a static eager script tag',
+  !/<script[^>]*\ssrc=["']auth-state\.js["']/.test(html));
+test('v7.95.0 Lighthouse-90: migration.js is NOT a static eager script tag',
+  !/<script[^>]*\ssrc=["']migration\.js["']/.test(html));
+// v7.95.0: window.load CHAIN loader — order preserved WITHIN the chain via
+// the CHAIN array + sequential onload chaining (loadNext), just moved off
+// the eager pre-paint path.
+test('v7.95.0 Lighthouse-90: window.load CHAIN loader present with all 7 modules in order',
+  (() => {
+    const m = html.match(/var CHAIN = \[([\s\S]{0,600}?)\];/);
+    if (!m) return false;
+    const order = ['lib/supabase-umd.min.js', 'lib/supabase.js', 'cloud-store.js',
+      'auth-state.js', 'migration.js', 'diagnostic-claim.js', 'lib/web-vitals-collector.js'];
+    let last = -1;
+    for (const f of order) {
+      const idx = m[1].indexOf("'" + f + "'");
+      if (idx === -1 || idx < last) return false;
+      last = idx;
+    }
+    return true;
+  })());
+test('v7.95.0 Lighthouse-90: CHAIN loader waits for window.load (or already-complete readyState)',
+  /document\.readyState === ['"]complete['"][\s\S]{0,50}start\(\)[\s\S]{0,80}addEventListener\(['"]load['"],\s*start\)/.test(html));
 test('v4.99.35 Phase11a: app.js has defer attribute',
   /<script\s+defer\s+src=["']app\.js["']/.test(html));
 test('v4.99.35 Phase11a: app.js has preload hint (largest payload, highest priority)',

--- a/tests/uat/150-webvitals-landing-diagnostic.js
+++ b/tests/uat/150-webvitals-landing-diagnostic.js
@@ -94,16 +94,18 @@ test('v4.99.45 Phase6b: collector strips auth tokens from page_path (anti-PII)',
   && /replace\(/.test(_collectorRaw));
 
 // — Wiring —
-test('v4.99.45 Phase6b: index.html loads collector after Supabase but before app.js',
+// v7.95.0 (Lighthouse-90 TASK): collector moved off the eager defer chain
+// into the window.load CHAIN loader (see 140-*.js CHAIN-order test), running
+// AFTER app.js now instead of before it — app.js no longer needs it present
+// at DOMContentLoaded (window.APP_VERSION is a static assignment, unrelated
+// to load timing). Verify it's still last in the CHAIN array, after Supabase.
+test('v4.99.45/v7.95.0 Phase6b: web-vitals-collector.js is last in the CHAIN loader, after Supabase',
   (() => {
-    // Verify the script tag order: supabase modules → web-vitals-collector → app.js
-    // v4.99.50: anchor on `<script ... src="lib/web-vitals-collector.js">` not just the
-    // literal string, since the v4.99.50 admin-dashboard description mentions the
-    // path in body copy too.
-    const wvIdx = html.indexOf('<script defer src="lib/web-vitals-collector.js"');
-    const appIdx = html.indexOf('src="app.js"');
-    const supaIdx = html.indexOf('<script defer src="lib/supabase.js"');
-    return wvIdx > 0 && wvIdx > supaIdx && wvIdx < appIdx;
+    const m = html.match(/var CHAIN = \[([\s\S]{0,600}?)\];/);
+    if (!m) return false;
+    const wvIdx = m[1].indexOf("'lib/web-vitals-collector.js'");
+    const supaIdx = m[1].indexOf("'lib/supabase.js'");
+    return wvIdx > 0 && wvIdx > supaIdx;
   })());
 test('v4.99.45 Phase6b: app.js exposes APP_VERSION on window for collector consumption',
   /window\.APP_VERSION\s*=\s*APP_VERSION/.test(js));
@@ -961,8 +963,16 @@ test('v4.99.56 D.5: claim hook handles all 4 RPC outcomes (claimed/already_claim
   /expired/.test(_claimRaw) && /not_found/.test(_claimRaw));
 
 // ── Wiring on cert app ──
-test('v4.99.56 D.5: index.html loads diagnostic-claim.js after auth-state.js',
-  /<script defer src="auth-state\.js"[\s\S]{0,500}<script defer src="diagnostic-claim\.js"/.test(html));
+// v7.95.0: diagnostic-claim.js moved into the window.load CHAIN loader,
+// still after auth-state.js (order preserved within the array).
+test('v4.99.56/v7.95.0 D.5: diagnostic-claim.js runs after auth-state.js in the CHAIN loader',
+  (() => {
+    const m = html.match(/var CHAIN = \[([\s\S]{0,600}?)\];/);
+    if (!m) return false;
+    const authIdx = m[1].indexOf("'auth-state.js'");
+    const claimIdx = m[1].indexOf("'diagnostic-claim.js'");
+    return authIdx > 0 && claimIdx > authIdx;
+  })());
 test('v4.99.56 D.5: sw.js precaches diagnostic-claim.js in SHELL_ASSETS',
   /SHELL_ASSETS[\s\S]{0,2000}'\.\/diagnostic-claim\.js'/.test(sw));
 


### PR DESCRIPTION
## Summary
Gated-lane ship (touches auth-state.js/cloud-store.js/lib/supabase.js load timing). Moves the 7-file Supabase chain (~78KB gzip: supabase-umd → supabase.js → cloud-store → auth-state → migration → diagnostic-claim → web-vitals-collector) from eager `<script defer>` to a `window.load`-gated ordered injector. Cuts the Lantern-modeled mobile LCP dependency chain — the last blocker for Lighthouse mobile ≥90 (currently 84–87 warm; desktop 100).

## Why safe
- Consumer audit: every read site of `window.certanvilSupabase` / `cloudStore` / `_certanvilSignedIn` already null-guards, polls, or listens to `onAuthStateChange`; the chain modules self-init correctly when loaded post-DOMContentLoaded.
- Signin pill is static HTML since v7.84 — auth-state only mutates href/state whenever it loads.
- SHELL_ASSETS unchanged (offline caching intact); sw.js diff is version-bump only.

## Verification
- UAT 4853/4856 (3 known-unrelated), tech-debt clean, Playwright chromium 82/82
- Live signed-out flow verified on localhost (pill + href correct after chain settles)
- Devtools-throttled mobile: real LCP unchanged 2.76s (never actually delayed); SI 4.79→4.50s
- Script-order UAT guards updated to assert the new CHAIN array (tests/uat/130,140,150)

🤖 Generated with [Claude Code](https://claude.com/claude-code)